### PR TITLE
Added live_preview option to filebrowser.

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -700,6 +700,8 @@ Use `type: "filepath"` in `capabilities.chain_params` to let Shadow UI open a re
 - `start_path` (optional): Absolute folder or file path used as the initial location when current value is empty.
 - `filter` (optional): File extension filter as a string or array, for example `".wav"` or `[".wav", ".aif"]`.
 - `live_preview` (optional): When true, moving the file-browser cursor over files temporarily sets the parameter to that file until the user confirms or cancels.
+- `browser_hooks` (optional): Event hooks to run additional parameter writes at browser lifecycle points. Supported keys: `on_open`, `on_preview`, `on_cancel`, `on_commit`.
+- `suspend_auto_select` (optional): When true, Shadow temporarily sets `<component>:ui_auto_select_pad` to `"off"` while the browser is open, then restores it on close.
 - `default` or `value` (optional): Initial absolute path. If the path exists and is inside `root`, the browser opens to the parent folder and highlights the file.
 
 Behavior notes:
@@ -708,6 +710,9 @@ Behavior notes:
 - Initial browser location priority is: current/default value, then `start_path`, then `root`.
 - If the chosen start location is missing, invalid, or outside `root`, the browser falls back to `root`.
 - With `live_preview: true`, preview changes are temporary: Back cancels and restores the original value, Click commits the highlighted file.
+- `browser_hooks` action format is `{ "key": "<param>", "value": "<string>", "restore": true|false }`. Non-prefixed keys are resolved against the active component prefix.
+- `browser_hooks` supports value placeholders: `$path`/`$selected_path` and `$filename`/`$selected_filename`.
+- `suspend_auto_select: true` is useful for pad samplers so pad-hit selection changes do not retarget the edited filepath while browsing.
 - Example user sample file path: `/data/UserData/UserLibrary/Samples/Drums/Kick01.wav`.
 
 These map to knobs 1-8 in the Shadow UI for quick access.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -699,6 +699,7 @@ Use `type: "filepath"` in `capabilities.chain_params` to let Shadow UI open a re
 - `root` (optional, recommended): Absolute folder where browsing starts and is constrained.
 - `start_path` (optional): Absolute folder or file path used as the initial location when current value is empty.
 - `filter` (optional): File extension filter as a string or array, for example `".wav"` or `[".wav", ".aif"]`.
+- `live_preview` (optional): When true, moving the file-browser cursor over files temporarily sets the parameter to that file until the user confirms or cancels.
 - `default` or `value` (optional): Initial absolute path. If the path exists and is inside `root`, the browser opens to the parent folder and highlights the file.
 
 Behavior notes:
@@ -706,6 +707,7 @@ Behavior notes:
 - Selected files are stored as absolute paths.
 - Initial browser location priority is: current/default value, then `start_path`, then `root`.
 - If the chosen start location is missing, invalid, or outside `root`, the browser falls back to `root`.
+- With `live_preview: true`, preview changes are temporary: Back cancels and restores the original value, Click commits the highlighted file.
 - Example user sample file path: `/data/UserData/UserLibrary/Samples/Drums/Kick01.wav`.
 
 These map to knobs 1-8 in the Shadow UI for quick access.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -701,7 +701,6 @@ Use `type: "filepath"` in `capabilities.chain_params` to let Shadow UI open a re
 - `filter` (optional): File extension filter as a string or array, for example `".wav"` or `[".wav", ".aif"]`.
 - `live_preview` (optional): When true, moving the file-browser cursor over files temporarily sets the parameter to that file until the user confirms or cancels.
 - `browser_hooks` (optional): Event hooks to run additional parameter writes at browser lifecycle points. Supported keys: `on_open`, `on_preview`, `on_cancel`, `on_commit`.
-- `suspend_auto_select` (optional): When true, Shadow temporarily sets `<component>:ui_auto_select_pad` to `"off"` while the browser is open, then restores it on close.
 - `default` or `value` (optional): Initial absolute path. If the path exists and is inside `root`, the browser opens to the parent folder and highlights the file.
 
 Behavior notes:
@@ -712,7 +711,7 @@ Behavior notes:
 - With `live_preview: true`, preview changes are temporary: Back cancels and restores the original value, Click commits the highlighted file.
 - `browser_hooks` action format is `{ "key": "<param>", "value": "<string>", "restore": true|false }`. Non-prefixed keys are resolved against the active component prefix.
 - `browser_hooks` supports value placeholders: `$path`/`$selected_path` and `$filename`/`$selected_filename`.
-- `suspend_auto_select: true` is useful for pad samplers so pad-hit selection changes do not retarget the edited filepath while browsing.
+- For pad samplers, you can suspend auto-pad switching while browsing by adding `{"key":"ui_auto_select_pad","value":"off","restore":true}` to `browser_hooks.on_open`.
 - Example user sample file path: `/data/UserData/UserLibrary/Samples/Drums/Kick01.wav`.
 
 These map to knobs 1-8 in the Shadow UI for quick access.

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1298,23 +1298,12 @@ function buildFilepathBrowserHooks(meta, prefix) {
     const hooksRaw = (meta && meta.browser_hooks && typeof meta.browser_hooks === "object")
         ? meta.browser_hooks
         : {};
-    const hooks = {
+    return {
         onOpen: normalizeFilepathHookActions(hooksRaw.on_open, prefix),
         onPreview: normalizeFilepathHookActions(hooksRaw.on_preview, prefix),
         onCancel: normalizeFilepathHookActions(hooksRaw.on_cancel, prefix),
         onCommit: normalizeFilepathHookActions(hooksRaw.on_commit, prefix)
     };
-
-    /* Backward-compatible alias: suspend_auto_select => on_open restore action */
-    if (parseMetaBool(meta && meta.suspend_auto_select) && prefix) {
-        hooks.onOpen.push({
-            key: `${prefix}:ui_auto_select_pad`,
-            value: "off",
-            restore: true
-        });
-    }
-
-    return hooks;
 }
 
 function resolveFilepathHookValue(rawValue, context) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1258,8 +1258,6 @@ let hierEditorNavigateTo = "";        // level to navigate to after item selecti
 /* Filepath browser state (for chain_params type: filepath) */
 let filepathBrowserState = null;
 let filepathBrowserParamKey = "";
-let filepathBrowserSuspendParamKey = "";
-let filepathBrowserSuspendPrevValue = "";
 const FILEPATH_BROWSER_FS = {
     readdir(path) {
         const entries = os.readdir(path) || [];
@@ -1276,6 +1274,96 @@ function parseMetaBool(value) {
     if (value === false || value === 0 || value === null || value === undefined) return false;
     const v = String(value).trim().toLowerCase();
     return v === "1" || v === "true" || v === "on" || v === "yes";
+}
+
+function normalizeFilepathHookActions(rawActions, prefix) {
+    if (!Array.isArray(rawActions)) return [];
+    const out = [];
+    for (const action of rawActions) {
+        if (!action || typeof action !== "object") continue;
+        const rawKey = typeof action.key === "string" ? action.key.trim() : "";
+        if (!rawKey) continue;
+        const fullKey = rawKey.includes(":") ? rawKey : (prefix ? `${prefix}:${rawKey}` : rawKey);
+        const value = action.value === undefined || action.value === null ? "" : String(action.value);
+        out.push({
+            key: fullKey,
+            value,
+            restore: parseMetaBool(action.restore)
+        });
+    }
+    return out;
+}
+
+function buildFilepathBrowserHooks(meta, prefix) {
+    const hooksRaw = (meta && meta.browser_hooks && typeof meta.browser_hooks === "object")
+        ? meta.browser_hooks
+        : {};
+    const hooks = {
+        onOpen: normalizeFilepathHookActions(hooksRaw.on_open, prefix),
+        onPreview: normalizeFilepathHookActions(hooksRaw.on_preview, prefix),
+        onCancel: normalizeFilepathHookActions(hooksRaw.on_cancel, prefix),
+        onCommit: normalizeFilepathHookActions(hooksRaw.on_commit, prefix)
+    };
+
+    /* Backward-compatible alias: suspend_auto_select => on_open restore action */
+    if (parseMetaBool(meta && meta.suspend_auto_select) && prefix) {
+        hooks.onOpen.push({
+            key: `${prefix}:ui_auto_select_pad`,
+            value: "off",
+            restore: true
+        });
+    }
+
+    return hooks;
+}
+
+function resolveFilepathHookValue(rawValue, context) {
+    const value = rawValue === undefined || rawValue === null ? "" : String(rawValue);
+    if (value === "$path" || value === "$selected_path") {
+        return context && context.path ? String(context.path) : "";
+    }
+    if (value === "$filename" || value === "$selected_filename") {
+        if (context && context.path) {
+            const path = String(context.path);
+            const idx = path.lastIndexOf("/");
+            return idx >= 0 ? path.slice(idx + 1) : path;
+        }
+        return "";
+    }
+    return value;
+}
+
+function applyFilepathHookActions(state, actions, context) {
+    if (!state || !Array.isArray(actions) || actions.length === 0) return;
+    for (const action of actions) {
+        if (!action || !action.key) continue;
+
+        if (action.restore && state.hookRestoreValues && !Object.prototype.hasOwnProperty.call(state.hookRestoreValues, action.key)) {
+            const prev = getSlotParam(hierEditorSlot, action.key);
+            if (prev !== null && prev !== undefined) {
+                state.hookRestoreValues[action.key] = String(prev);
+            }
+        }
+
+        const nextVal = resolveFilepathHookValue(action.value, context);
+        setSlotParam(hierEditorSlot, action.key, nextVal);
+    }
+}
+
+function restoreFilepathHookActions(state) {
+    if (!state || !state.hookRestoreValues) return;
+    for (const [key, prevValue] of Object.entries(state.hookRestoreValues)) {
+        setSlotParam(hierEditorSlot, key, prevValue);
+    }
+}
+
+function applyLivePreview(state, selected) {
+    if (!state || !state.livePreviewEnabled || !selected || selected.kind !== "file" || !selected.path) return;
+    if (selected.path === state.previewCurrentValue || !state.previewParamFullKey) return;
+    if (setSlotParam(hierEditorSlot, state.previewParamFullKey, selected.path)) {
+        state.previewCurrentValue = selected.path;
+        applyFilepathHookActions(state, state.hooksOnPreview, { path: selected.path });
+    }
 }
 
 /* Loaded module UI state */
@@ -5423,19 +5511,6 @@ function openHierarchyFilepathBrowser(key, meta) {
     const currentVal = getSlotParam(hierEditorSlot, fullKey) || "";
     const prefix = getComponentParamPrefix(hierEditorComponent);
 
-    filepathBrowserSuspendParamKey = "";
-    filepathBrowserSuspendPrevValue = "";
-    if (prefix) {
-        const maybeSuspendKey = `${prefix}:ui_auto_select_pad`;
-        const prevVal = getSlotParam(hierEditorSlot, maybeSuspendKey);
-        if (prevVal !== null && prevVal !== undefined && String(prevVal).length > 0) {
-            if (setSlotParam(hierEditorSlot, maybeSuspendKey, "off")) {
-                filepathBrowserSuspendParamKey = maybeSuspendKey;
-                filepathBrowserSuspendPrevValue = String(prevVal);
-            }
-        }
-    }
-
     filepathBrowserParamKey = key;
     filepathBrowserState = buildFilepathBrowserState(effectiveMeta, currentVal);
     filepathBrowserState.livePreviewEnabled = parseMetaBool(effectiveMeta.live_preview);
@@ -5443,15 +5518,22 @@ function openHierarchyFilepathBrowser(key, meta) {
     filepathBrowserState.previewCurrentValue = currentVal;
     filepathBrowserState.previewCommitted = false;
     filepathBrowserState.previewParamFullKey = fullKey;
+    filepathBrowserState.previewPendingPath = "";
+    filepathBrowserState.previewPendingTime = 0;
+    filepathBrowserState.previewSelectedPath = "";
+    const hooks = buildFilepathBrowserHooks(effectiveMeta, prefix);
+    filepathBrowserState.hooksOnOpen = hooks.onOpen;
+    filepathBrowserState.hooksOnPreview = hooks.onPreview;
+    filepathBrowserState.hooksOnCancel = hooks.onCancel;
+    filepathBrowserState.hooksOnCommit = hooks.onCommit;
+    filepathBrowserState.hookRestoreValues = {};
+    applyFilepathHookActions(filepathBrowserState, filepathBrowserState.hooksOnOpen, { path: currentVal });
+
     refreshFilepathBrowser(filepathBrowserState, FILEPATH_BROWSER_FS);
 
     if (filepathBrowserState.livePreviewEnabled) {
         const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
-        if (selected && selected.kind === "file" && selected.path && selected.path !== filepathBrowserState.previewCurrentValue) {
-            if (setSlotParam(hierEditorSlot, fullKey, selected.path)) {
-                filepathBrowserState.previewCurrentValue = selected.path;
-            }
-        }
+        applyLivePreview(filepathBrowserState, selected);
     }
 
     setView(VIEWS.FILEPATH_BROWSER);
@@ -5467,26 +5549,31 @@ function openHierarchyFilepathBrowser(key, meta) {
 }
 
 function closeHierarchyFilepathBrowser() {
-    if (filepathBrowserState &&
-        filepathBrowserState.livePreviewEnabled &&
-        !filepathBrowserState.previewCommitted &&
-        filepathBrowserState.previewParamFullKey &&
-        filepathBrowserState.previewCurrentValue !== filepathBrowserState.previewOriginalValue) {
-        setSlotParam(
-            hierEditorSlot,
-            filepathBrowserState.previewParamFullKey,
-            filepathBrowserState.previewOriginalValue || ""
-        );
-    }
+    const state = filepathBrowserState;
+    if (state) {
+        const committed = !!state.previewCommitted;
+        if (state.livePreviewEnabled &&
+            !committed &&
+            state.previewParamFullKey &&
+            state.previewCurrentValue !== state.previewOriginalValue) {
+            setSlotParam(
+                hierEditorSlot,
+                state.previewParamFullKey,
+                state.previewOriginalValue || ""
+            );
+        }
 
-    if (filepathBrowserSuspendParamKey) {
-        setSlotParam(hierEditorSlot, filepathBrowserSuspendParamKey, filepathBrowserSuspendPrevValue);
+        if (committed) {
+            applyFilepathHookActions(state, state.hooksOnCommit, { path: state.previewSelectedPath || state.previewCurrentValue || "" });
+        } else {
+            applyFilepathHookActions(state, state.hooksOnCancel, { path: state.previewOriginalValue || "" });
+        }
+
+        restoreFilepathHookActions(state);
     }
 
     filepathBrowserState = null;
     filepathBrowserParamKey = "";
-    filepathBrowserSuspendParamKey = "";
-    filepathBrowserSuspendPrevValue = "";
     setView(VIEWS.HIERARCHY_EDITOR);
 }
 
@@ -6696,15 +6783,12 @@ function handleJog(delta) {
             if (filepathBrowserState) {
                 moveFilepathBrowserSelection(filepathBrowserState, delta);
                 const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
-                if (filepathBrowserState.livePreviewEnabled &&
-                    selected &&
-                    selected.kind === "file" &&
-                    selected.path &&
-                    selected.path !== filepathBrowserState.previewCurrentValue &&
-                    filepathBrowserState.previewParamFullKey) {
-                    if (setSlotParam(hierEditorSlot, filepathBrowserState.previewParamFullKey, selected.path)) {
-                        filepathBrowserState.previewCurrentValue = selected.path;
-                    }
+                if (filepathBrowserState.livePreviewEnabled && selected && selected.kind === "file" && selected.path) {
+                    filepathBrowserState.previewPendingPath = selected.path;
+                    filepathBrowserState.previewPendingTime = Date.now();
+                } else if (filepathBrowserState.livePreviewEnabled) {
+                    filepathBrowserState.previewPendingPath = "";
+                    filepathBrowserState.previewPendingTime = 0;
                 }
                 if (selected) announceMenuItem(selected.label || "File", "");
             }
@@ -7359,15 +7443,9 @@ function handleSelect() {
                     refreshFilepathBrowser(filepathBrowserState, FILEPATH_BROWSER_FS);
                     if (filepathBrowserState.livePreviewEnabled) {
                         const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
-                        if (selected &&
-                            selected.kind === "file" &&
-                            selected.path &&
-                            selected.path !== filepathBrowserState.previewCurrentValue &&
-                            filepathBrowserState.previewParamFullKey) {
-                            if (setSlotParam(hierEditorSlot, filepathBrowserState.previewParamFullKey, selected.path)) {
-                                filepathBrowserState.previewCurrentValue = selected.path;
-                            }
-                        }
+                        filepathBrowserState.previewPendingPath = "";
+                        filepathBrowserState.previewPendingTime = 0;
+                        applyLivePreview(filepathBrowserState, selected);
                     }
                 } else if (result.action === "select") {
                     const key = filepathBrowserParamKey || result.key;
@@ -7375,7 +7453,10 @@ function handleSelect() {
                     if (filepathBrowserState.livePreviewEnabled) {
                         filepathBrowserState.previewCommitted = true;
                         filepathBrowserState.previewCurrentValue = result.value || "";
+                        filepathBrowserState.previewPendingPath = "";
+                        filepathBrowserState.previewPendingTime = 0;
                     }
+                    filepathBrowserState.previewSelectedPath = result.value || "";
                     setSlotParam(hierEditorSlot, fullKey, result.value || "");
                     announceParameter(filepathBrowserState.title || key, result.filename || result.value || "");
                     closeHierarchyFilepathBrowser();
@@ -9246,6 +9327,15 @@ globalThis.tick = function() {
             debugLog("SET_CHANGED: reload complete");
         }
         /* SETTINGS and SCREENREADER flags are handled earlier with SLOT/MFX/OVERTAKE */
+    }
+
+    if (filepathBrowserState &&
+        filepathBrowserState.livePreviewEnabled &&
+        filepathBrowserState.previewPendingPath &&
+        Date.now() - filepathBrowserState.previewPendingTime >= 150) {
+        applyLivePreview(filepathBrowserState, { kind: "file", path: filepathBrowserState.previewPendingPath });
+        filepathBrowserState.previewPendingPath = "";
+        filepathBrowserState.previewPendingTime = 0;
     }
 
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1258,6 +1258,8 @@ let hierEditorNavigateTo = "";        // level to navigate to after item selecti
 /* Filepath browser state (for chain_params type: filepath) */
 let filepathBrowserState = null;
 let filepathBrowserParamKey = "";
+let filepathBrowserSuspendParamKey = "";
+let filepathBrowserSuspendPrevValue = "";
 const FILEPATH_BROWSER_FS = {
     readdir(path) {
         const entries = os.readdir(path) || [];
@@ -1268,6 +1270,13 @@ const FILEPATH_BROWSER_FS = {
         return os.stat(path);
     }
 };
+
+function parseMetaBool(value) {
+    if (value === true || value === 1) return true;
+    if (value === false || value === 0 || value === null || value === undefined) return false;
+    const v = String(value).trim().toLowerCase();
+    return v === "1" || v === "true" || v === "on" || v === "yes";
+}
 
 /* Loaded module UI state */
 let loadedModuleUi = null;       // The chain_ui object from loaded module
@@ -5412,10 +5421,39 @@ function openHierarchyFilepathBrowser(key, meta) {
 
     const fullKey = buildHierarchyParamKey(key);
     const currentVal = getSlotParam(hierEditorSlot, fullKey) || "";
+    const prefix = getComponentParamPrefix(hierEditorComponent);
+
+    filepathBrowserSuspendParamKey = "";
+    filepathBrowserSuspendPrevValue = "";
+    if (prefix) {
+        const maybeSuspendKey = `${prefix}:ui_auto_select_pad`;
+        const prevVal = getSlotParam(hierEditorSlot, maybeSuspendKey);
+        if (prevVal !== null && prevVal !== undefined && String(prevVal).length > 0) {
+            if (setSlotParam(hierEditorSlot, maybeSuspendKey, "off")) {
+                filepathBrowserSuspendParamKey = maybeSuspendKey;
+                filepathBrowserSuspendPrevValue = String(prevVal);
+            }
+        }
+    }
 
     filepathBrowserParamKey = key;
     filepathBrowserState = buildFilepathBrowserState(effectiveMeta, currentVal);
+    filepathBrowserState.livePreviewEnabled = parseMetaBool(effectiveMeta.live_preview);
+    filepathBrowserState.previewOriginalValue = currentVal;
+    filepathBrowserState.previewCurrentValue = currentVal;
+    filepathBrowserState.previewCommitted = false;
+    filepathBrowserState.previewParamFullKey = fullKey;
     refreshFilepathBrowser(filepathBrowserState, FILEPATH_BROWSER_FS);
+
+    if (filepathBrowserState.livePreviewEnabled) {
+        const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
+        if (selected && selected.kind === "file" && selected.path && selected.path !== filepathBrowserState.previewCurrentValue) {
+            if (setSlotParam(hierEditorSlot, fullKey, selected.path)) {
+                filepathBrowserState.previewCurrentValue = selected.path;
+            }
+        }
+    }
+
     setView(VIEWS.FILEPATH_BROWSER);
 
     if (filepathBrowserState.items.length > 0) {
@@ -5429,8 +5467,26 @@ function openHierarchyFilepathBrowser(key, meta) {
 }
 
 function closeHierarchyFilepathBrowser() {
+    if (filepathBrowserState &&
+        filepathBrowserState.livePreviewEnabled &&
+        !filepathBrowserState.previewCommitted &&
+        filepathBrowserState.previewParamFullKey &&
+        filepathBrowserState.previewCurrentValue !== filepathBrowserState.previewOriginalValue) {
+        setSlotParam(
+            hierEditorSlot,
+            filepathBrowserState.previewParamFullKey,
+            filepathBrowserState.previewOriginalValue || ""
+        );
+    }
+
+    if (filepathBrowserSuspendParamKey) {
+        setSlotParam(hierEditorSlot, filepathBrowserSuspendParamKey, filepathBrowserSuspendPrevValue);
+    }
+
     filepathBrowserState = null;
     filepathBrowserParamKey = "";
+    filepathBrowserSuspendParamKey = "";
+    filepathBrowserSuspendPrevValue = "";
     setView(VIEWS.HIERARCHY_EDITOR);
 }
 
@@ -6640,6 +6696,16 @@ function handleJog(delta) {
             if (filepathBrowserState) {
                 moveFilepathBrowserSelection(filepathBrowserState, delta);
                 const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
+                if (filepathBrowserState.livePreviewEnabled &&
+                    selected &&
+                    selected.kind === "file" &&
+                    selected.path &&
+                    selected.path !== filepathBrowserState.previewCurrentValue &&
+                    filepathBrowserState.previewParamFullKey) {
+                    if (setSlotParam(hierEditorSlot, filepathBrowserState.previewParamFullKey, selected.path)) {
+                        filepathBrowserState.previewCurrentValue = selected.path;
+                    }
+                }
                 if (selected) announceMenuItem(selected.label || "File", "");
             }
             break;
@@ -7291,9 +7357,25 @@ function handleSelect() {
                 const result = activateFilepathBrowserItem(filepathBrowserState);
                 if (result.action === "open") {
                     refreshFilepathBrowser(filepathBrowserState, FILEPATH_BROWSER_FS);
+                    if (filepathBrowserState.livePreviewEnabled) {
+                        const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
+                        if (selected &&
+                            selected.kind === "file" &&
+                            selected.path &&
+                            selected.path !== filepathBrowserState.previewCurrentValue &&
+                            filepathBrowserState.previewParamFullKey) {
+                            if (setSlotParam(hierEditorSlot, filepathBrowserState.previewParamFullKey, selected.path)) {
+                                filepathBrowserState.previewCurrentValue = selected.path;
+                            }
+                        }
+                    }
                 } else if (result.action === "select") {
                     const key = filepathBrowserParamKey || result.key;
                     const fullKey = buildHierarchyParamKey(key);
+                    if (filepathBrowserState.livePreviewEnabled) {
+                        filepathBrowserState.previewCommitted = true;
+                        filepathBrowserState.previewCurrentValue = result.value || "";
+                    }
                     setSlotParam(hierEditorSlot, fullKey, result.value || "");
                     announceParameter(filepathBrowserState.title || key, result.filename || result.value || "");
                     closeHierarchyFilepathBrowser();

--- a/tests/shadow/test_shadow_filepath_browser_hooks.sh
+++ b/tests/shadow/test_shadow_filepath_browser_hooks.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shadow_file="src/shadow/shadow_ui.js"
+docs_file="docs/MODULES.md"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required to run this test" >&2
+  exit 1
+fi
+
+if ! rg -F -q "function buildFilepathBrowserHooks(meta, prefix) {" "$shadow_file"; then
+  echo "FAIL: filepath browser hooks builder is missing" >&2
+  exit 1
+fi
+
+if ! rg -F -q "onOpen: normalizeFilepathHookActions(hooksRaw.on_open, prefix)" "$shadow_file"; then
+  echo "FAIL: filepath browser does not wire on_open hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "onPreview: normalizeFilepathHookActions(hooksRaw.on_preview, prefix)" "$shadow_file"; then
+  echo "FAIL: filepath browser does not wire on_preview hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "onCancel: normalizeFilepathHookActions(hooksRaw.on_cancel, prefix)" "$shadow_file"; then
+  echo "FAIL: filepath browser does not wire on_cancel hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "onCommit: normalizeFilepathHookActions(hooksRaw.on_commit, prefix)" "$shadow_file"; then
+  echo "FAIL: filepath browser does not wire on_commit hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "applyFilepathHookActions(filepathBrowserState, filepathBrowserState.hooksOnOpen" "$shadow_file"; then
+  echo "FAIL: filepath browser does not execute on_open hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "applyFilepathHookActions(state, state.hooksOnCommit" "$shadow_file"; then
+  echo "FAIL: filepath browser does not execute on_commit hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q "applyFilepathHookActions(state, state.hooksOnCancel" "$shadow_file"; then
+  echo "FAIL: filepath browser does not execute on_cancel hooks" >&2
+  exit 1
+fi
+
+if ! rg -F -q -- '- `browser_hooks` (optional): Event hooks to run additional parameter writes at browser lifecycle points. Supported keys: `on_open`, `on_preview`, `on_cancel`, `on_commit`.' "$docs_file"; then
+  echo "FAIL: docs/MODULES.md does not document browser_hooks field" >&2
+  exit 1
+fi
+
+echo "PASS: filepath browser hooks wiring present"
+exit 0

--- a/tests/shadow/test_shadow_filepath_live_preview.sh
+++ b/tests/shadow/test_shadow_filepath_live_preview.sh
@@ -14,13 +14,28 @@ if ! rg -F -q "filepathBrowserState.livePreviewEnabled = parseMetaBool(effective
   exit 1
 fi
 
+if ! rg -F -q "function applyLivePreview(state, selected) {" "$shadow_file"; then
+  echo "FAIL: live preview helper function is missing" >&2
+  exit 1
+fi
+
 if ! rg -F -q "filepathBrowserState.previewOriginalValue = currentVal;" "$shadow_file"; then
   echo "FAIL: filepath browser does not snapshot original value for live preview cancel" >&2
   exit 1
 fi
 
-if ! rg -F -q "selected.kind === \"file\"" "$shadow_file"; then
-  echo "FAIL: filepath browser live preview is not gated to file items" >&2
+if ! rg -F -q "filepathBrowserState.previewPendingPath = selected.path;" "$shadow_file"; then
+  echo "FAIL: filepath browser does not queue pending live preview path on jog" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.previewPendingTime = Date.now();" "$shadow_file"; then
+  echo "FAIL: filepath browser does not timestamp pending live preview updates" >&2
+  exit 1
+fi
+
+if ! rg -F -q "Date.now() - filepathBrowserState.previewPendingTime >= 150" "$shadow_file"; then
+  echo "FAIL: filepath browser missing debounce threshold check for pending live preview" >&2
   exit 1
 fi
 
@@ -29,12 +44,12 @@ if ! rg -F -q "filepathBrowserState.previewCommitted = true;" "$shadow_file"; th
   exit 1
 fi
 
-if ! rg -F -q "filepathBrowserState.previewCurrentValue !== filepathBrowserState.previewOriginalValue" "$shadow_file"; then
+if ! rg -F -q "state.previewCurrentValue !== state.previewOriginalValue" "$shadow_file"; then
   echo "FAIL: filepath browser cancel path does not compare preview value against original" >&2
   exit 1
 fi
 
-if ! rg -F -q "filepathBrowserState.previewOriginalValue || \"\"" "$shadow_file"; then
+if ! rg -F -q "state.previewOriginalValue || \"\"" "$shadow_file"; then
   echo "FAIL: filepath browser cancel path does not restore original value" >&2
   exit 1
 fi

--- a/tests/shadow/test_shadow_filepath_live_preview.sh
+++ b/tests/shadow/test_shadow_filepath_live_preview.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shadow_file="src/shadow/shadow_ui.js"
+docs_file="docs/MODULES.md"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required to run this test" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.livePreviewEnabled = parseMetaBool(effectiveMeta.live_preview);" "$shadow_file"; then
+  echo "FAIL: live_preview metadata is not read when opening filepath browser" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.previewOriginalValue = currentVal;" "$shadow_file"; then
+  echo "FAIL: filepath browser does not snapshot original value for live preview cancel" >&2
+  exit 1
+fi
+
+if ! rg -F -q "selected.kind === \"file\"" "$shadow_file"; then
+  echo "FAIL: filepath browser live preview is not gated to file items" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.previewCommitted = true;" "$shadow_file"; then
+  echo "FAIL: filepath browser does not mark preview as committed on select" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.previewCurrentValue !== filepathBrowserState.previewOriginalValue" "$shadow_file"; then
+  echo "FAIL: filepath browser cancel path does not compare preview value against original" >&2
+  exit 1
+fi
+
+if ! rg -F -q "filepathBrowserState.previewOriginalValue || \"\"" "$shadow_file"; then
+  echo "FAIL: filepath browser cancel path does not restore original value" >&2
+  exit 1
+fi
+
+if ! rg -F -q -- "- \`live_preview\` (optional): When true, moving the file-browser cursor over files temporarily sets the parameter to that file until the user confirms or cancels." "$docs_file"; then
+  echo "FAIL: docs/MODULES.md does not document filepath live_preview field" >&2
+  exit 1
+fi
+
+echo "PASS: filepath browser live preview wiring present"
+exit 0

--- a/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
+++ b/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shadow_file="src/shadow/shadow_ui.js"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required to run this test" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'let filepathBrowserSuspendParamKey = "";' "$shadow_file"; then
+  echo "FAIL: filepath browser missing suspend param key state" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'let filepathBrowserSuspendPrevValue = "";' "$shadow_file"; then
+  echo "FAIL: filepath browser missing suspend previous value state" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'const maybeSuspendKey = `${prefix}:ui_auto_select_pad`;' "$shadow_file"; then
+  echo "FAIL: filepath browser does not target ui_auto_select_pad for temporary suspend" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'if (setSlotParam(hierEditorSlot, maybeSuspendKey, "off")) {' "$shadow_file"; then
+  echo "FAIL: filepath browser does not disable ui_auto_select_pad on open" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'setSlotParam(hierEditorSlot, filepathBrowserSuspendParamKey, filepathBrowserSuspendPrevValue);' "$shadow_file"; then
+  echo "FAIL: filepath browser does not restore ui_auto_select_pad on close" >&2
+  exit 1
+fi
+
+echo "PASS: filepath browser temporarily suspends ui_auto_select_pad"
+exit 0

--- a/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
+++ b/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
@@ -2,34 +2,45 @@
 set -euo pipefail
 
 shadow_file="src/shadow/shadow_ui.js"
+docs_file="docs/MODULES.md"
 
 if ! command -v rg >/dev/null 2>&1; then
   echo "rg is required to run this test" >&2
   exit 1
 fi
 
-if ! rg -F -q 'let filepathBrowserSuspendParamKey = "";' "$shadow_file"; then
-  echo "FAIL: filepath browser missing suspend param key state" >&2
+if ! rg -F -q "parseMetaBool(meta && meta.suspend_auto_select)" "$shadow_file"; then
+  echo "FAIL: filepath browser missing suspend_auto_select backward-compatible alias" >&2
   exit 1
 fi
 
-if ! rg -F -q 'let filepathBrowserSuspendPrevValue = "";' "$shadow_file"; then
-  echo "FAIL: filepath browser missing suspend previous value state" >&2
+if ! rg -F -q 'key: `${prefix}:ui_auto_select_pad`' "$shadow_file"; then
+  echo "FAIL: filepath browser suspend alias does not target ui_auto_select_pad" >&2
   exit 1
 fi
 
-if ! rg -F -q 'const maybeSuspendKey = `${prefix}:ui_auto_select_pad`;' "$shadow_file"; then
-  echo "FAIL: filepath browser does not target ui_auto_select_pad for temporary suspend" >&2
+if ! rg -F -q "value: \"off\"" "$shadow_file"; then
+  echo "FAIL: filepath browser suspend alias does not force off value" >&2
   exit 1
 fi
 
-if ! rg -F -q 'if (setSlotParam(hierEditorSlot, maybeSuspendKey, "off")) {' "$shadow_file"; then
-  echo "FAIL: filepath browser does not disable ui_auto_select_pad on open" >&2
+if ! rg -F -q "restore: true" "$shadow_file"; then
+  echo "FAIL: filepath browser suspend alias does not request restoration" >&2
   exit 1
 fi
 
-if ! rg -F -q 'setSlotParam(hierEditorSlot, filepathBrowserSuspendParamKey, filepathBrowserSuspendPrevValue);' "$shadow_file"; then
-  echo "FAIL: filepath browser does not restore ui_auto_select_pad on close" >&2
+if ! rg -F -q "applyFilepathHookActions(filepathBrowserState, filepathBrowserState.hooksOnOpen" "$shadow_file"; then
+  echo "FAIL: filepath browser does not apply open hooks (including suspend alias)" >&2
+  exit 1
+fi
+
+if ! rg -F -q "restoreFilepathHookActions(state);" "$shadow_file"; then
+  echo "FAIL: filepath browser does not restore hook-managed params on close" >&2
+  exit 1
+fi
+
+if ! rg -F -q -- '- `suspend_auto_select` (optional): When true, Shadow temporarily sets `<component>:ui_auto_select_pad` to `"off"` while the browser is open, then restores it on close.' "$docs_file"; then
+  echo "FAIL: docs/MODULES.md does not document filepath suspend_auto_select field" >&2
   exit 1
 fi
 

--- a/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
+++ b/tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh
@@ -9,28 +9,23 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! rg -F -q "parseMetaBool(meta && meta.suspend_auto_select)" "$shadow_file"; then
-  echo "FAIL: filepath browser missing suspend_auto_select backward-compatible alias" >&2
+if rg -F -q "suspend_auto_select" "$shadow_file"; then
+  echo "FAIL: filepath browser still contains suspend_auto_select alias behavior" >&2
   exit 1
 fi
 
-if ! rg -F -q 'key: `${prefix}:ui_auto_select_pad`' "$shadow_file"; then
-  echo "FAIL: filepath browser suspend alias does not target ui_auto_select_pad" >&2
+if rg -F -q -- '- `suspend_auto_select` (optional):' "$docs_file"; then
+  echo "FAIL: docs/MODULES.md still documents suspend_auto_select alias field" >&2
   exit 1
 fi
 
-if ! rg -F -q "value: \"off\"" "$shadow_file"; then
-  echo "FAIL: filepath browser suspend alias does not force off value" >&2
-  exit 1
-fi
-
-if ! rg -F -q "restore: true" "$shadow_file"; then
-  echo "FAIL: filepath browser suspend alias does not request restoration" >&2
+if ! rg -F -q "normalizeFilepathHookActions(hooksRaw.on_open, prefix)" "$shadow_file"; then
+  echo "FAIL: filepath browser missing on_open hook wiring" >&2
   exit 1
 fi
 
 if ! rg -F -q "applyFilepathHookActions(filepathBrowserState, filepathBrowserState.hooksOnOpen" "$shadow_file"; then
-  echo "FAIL: filepath browser does not apply open hooks (including suspend alias)" >&2
+  echo "FAIL: filepath browser does not apply on_open hook actions" >&2
   exit 1
 fi
 
@@ -39,10 +34,10 @@ if ! rg -F -q "restoreFilepathHookActions(state);" "$shadow_file"; then
   exit 1
 fi
 
-if ! rg -F -q -- '- `suspend_auto_select` (optional): When true, Shadow temporarily sets `<component>:ui_auto_select_pad` to `"off"` while the browser is open, then restores it on close.' "$docs_file"; then
-  echo "FAIL: docs/MODULES.md does not document filepath suspend_auto_select field" >&2
+if ! rg -F -q -- '- For pad samplers, you can suspend auto-pad switching while browsing by adding `{"key":"ui_auto_select_pad","value":"off","restore":true}` to `browser_hooks.on_open`.' "$docs_file"; then
+  echo "FAIL: docs/MODULES.md missing browser_hooks-based pad auto-select suspend guidance" >&2
   exit 1
 fi
 
-echo "PASS: filepath browser temporarily suspends ui_auto_select_pad"
+echo "PASS: filepath browser uses browser_hooks for pad auto-select suspension"
 exit 0


### PR DESCRIPTION
Adds `live_preview` support to the filepath browser.

If enabled, the browser temporarily swaps the target filepath while browsing so pads can be auditioned live. The original value is preserved and restored on cancel; confirm commits the currently selected file.

## Follow-up updates from review feedback

Implemented updates requested in review:

- Refactored duplicated live-preview param-write logic into a shared helper in `shadow_ui.js`.
- Added debounced live-preview application while scrolling/jogging (150ms settle) to reduce UI/engine churn.
- Added optional generic filepath `browser_hooks` callbacks for module-specific behavior:
  - `on_open`, `on_preview`, `on_cancel`, `on_commit`
  - hook actions can set params with optional restore (`restore: true`)
  - placeholders supported in hook values: `$path` / `$selected_path`, `$filename` / `$selected_filename`
- Removed the temporary `suspend_auto_select` alias support and documentation (not needed before public release); pad auto-select suspension remains available via `browser_hooks.on_open`.

## Validation

Added/updated tests and verified passing:

- `tests/shadow/test_shadow_filepath_browser_hooks.sh` (new)
- `tests/shadow/test_shadow_filepath_live_preview.sh`
- `tests/shadow/test_shadow_filepath_pad_autoselect_suspend.sh`
- `tests/shadow/test_shadow_filepath_start_path_priority.sh`
- `tests/shadow/test_shadow_filepath_chain_params_refresh.sh`
