### PR TITLE
Add modulation runtime API and standardized target picker types

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -363,6 +363,27 @@ int16_t *audio_in = (int16_t *)(host->mapped_memory + host->audio_in_offset);
 
 Note: Audio input routing depends on the last selected input in the stock Move interface before launching Move Anything.
 
+### Chain Runtime Modulation Callbacks (DSP)
+
+When a DSP plugin runs inside Signal Chain, `host_api_v1_t` may expose optional modulation callbacks:
+
+```c
+int (*mod_emit_value)(void *ctx,
+                      const char *source_id,
+                      const char *target,
+                      const char *param,
+                      float signal,
+                      float depth,
+                      float offset,
+                      int bipolar,
+                      int enabled);
+void (*mod_clear_source)(void *ctx, const char *source_id);
+void *mod_host_ctx;
+```
+
+Use these to publish temporary modulation contributions without overwriting saved base parameter values.
+If callbacks are unavailable, plugins should fail silently and keep operating normally.
+
 ## LED Colors
 
 Common color values for pad LEDs (from `constants.mjs`):

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -473,6 +473,33 @@ plugin_api_v2_t* move_plugin_init_v2(const host_api_v1_t* host) {
 }
 ```
 
+### Runtime Modulation Callbacks (Chain Host)
+
+When a plugin runs inside Signal Chain, `host_api_v1_t` may provide optional modulation callbacks:
+
+```c
+int (*mod_emit_value)(void *ctx,
+                      const char *source_id,
+                      const char *target,
+                      const char *param,
+                      float signal,
+                      float depth,
+                      float offset,
+                      int bipolar,
+                      int enabled);
+void (*mod_clear_source)(void *ctx, const char *source_id);
+void *mod_host_ctx;
+```
+
+Use these to publish temporary modulation overlays without overwriting a target parameter's saved base value.
+
+Guidelines:
+- `source_id`: stable ID for the modulation source instance/lane.
+- `target`: `"synth"`, `"fx1"`, `"fx2"`, `"midi_fx1"`, or `"midi_fx2"`.
+- `enabled=0` or `mod_clear_source(...)`: clears that source's contribution.
+- Missing/stale targets should fail silently (do not crash or spam logs).
+- Multiple sources can target the same parameter; the host sums contributions and clamps to target range.
+
 ### Plugin API v1 (Deprecated)
 
 V1 is a singleton API - only one instance can exist. **Do not use for new modules:**
@@ -696,6 +723,8 @@ int get_param(void *instance, const char *key, char *buf, int buf_len) {
 | `float` | `min`, `max`, `default`/`value` | Float value |
 | `enum` | `options`, `default`/`value` | List of string options |
 | `filepath` | `root`, `start_path`, `filter`, `default`/`value` | Opens Shadow UI file browser and stores selected path |
+| `module_picker` | `allow_none`, `allow_self`, `allowed_targets`, `param_key` | Dynamic enum from loaded chain components |
+| `parameter_picker` | `target_key`, `numeric_only`, `allow_none` | Dynamic enum from selected target's exposed params |
 
 #### `filepath` in module.json
 
@@ -741,6 +770,19 @@ Behavior notes:
 - `browser_hooks` supports value placeholders: `$path`/`$selected_path` and `$filename`/`$selected_filename`.
 - For pad samplers, you can suspend auto-pad switching while browsing by adding `{"key":"ui_auto_select_pad","value":"off","restore":true}` to `browser_hooks.on_open`.
 - Example user sample file path: `/data/UserData/UserLibrary/Samples/Drums/Kick01.wav`.
+
+#### Dynamic Target Pickers
+
+Use `module_picker` and `parameter_picker` for chain-aware target routing without custom UI code.
+
+- `module_picker`: Renders as a normal enum editor whose options are refreshed from currently loaded chain components.
+- `parameter_picker`: Renders as a normal enum editor whose options are refreshed from the component selected by `target_key`.
+- `allow_none` (optional, default true): Includes an empty option for clearing assignment.
+- `allow_self` (module_picker only, optional, default false): Allows selecting the hosting component itself.
+- `allowed_targets` (module_picker only, optional): Comma-separated string or array of target IDs to whitelist.
+- `param_key` (module_picker, optional): Companion parameter key to clear when target changes (for example `lfo1_target_param`).
+- `target_key` (parameter_picker, recommended): Companion key holding selected module target.
+- `numeric_only` (parameter_picker, optional, default true): Restricts options to float/int parameters.
 
 These map to knobs 1-8 in the Shadow UI for quick access.
 

--- a/src/host/plugin_api_v1.h
+++ b/src/host/plugin_api_v1.h
@@ -30,6 +30,21 @@
 #define MOVE_CLOCK_STATUS_STOPPED 1      /* Clock available, transport stopped */
 #define MOVE_CLOCK_STATUS_RUNNING 2      /* Clock available, transport running */
 
+/* Optional modulation callbacks for chain-owned runtime modulation buses.
+ * Sub-plugins can publish temporary modulation contributions without writing
+ * target base values directly.
+ */
+typedef int (*move_mod_emit_value_fn)(void *ctx,
+                                      const char *source_id,
+                                      const char *target,
+                                      const char *param,
+                                      float signal,
+                                      float depth,
+                                      float offset,
+                                      int bipolar,
+                                      int enabled);
+typedef void (*move_mod_clear_source_fn)(void *ctx, const char *source_id);
+
 /*
  * Host API - provided by host to plugin during initialization
  */
@@ -60,6 +75,11 @@ typedef struct host_api_v1 {
      * Returns one of MOVE_CLOCK_STATUS_*.
      */
     int (*get_clock_status)(void);
+
+    /* Optional runtime modulation callbacks (NULL if unsupported). */
+    move_mod_emit_value_fn mod_emit_value;
+    move_mod_clear_source_fn mod_clear_source;
+    void *mod_host_ctx;
 
 } host_api_v1_t;
 

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <ctype.h>
 #include <dlfcn.h>
 #include <dirent.h>
 #include <time.h>
@@ -148,6 +149,35 @@ typedef struct {
     char options[MAX_ENUM_OPTIONS][32];  /* Enum options (if type is ENUM) */
     int option_count;       /* Number of enum options */
 } chain_param_info_t;
+
+#define MAX_MOD_TARGETS 32
+#define MAX_MOD_SOURCES_PER_TARGET 8
+#define MOD_PARAM_CACHE_REFRESH_MS 250
+#define MOD_FLOAT_CHANGE_EPSILON 0.000001f
+#define MOD_INT_ENUM_MIN_INTERVAL_MS 50
+
+typedef struct mod_source_contribution {
+    int active;
+    char source_id[32];
+    float contribution;
+} mod_source_contribution_t;
+
+/* Runtime modulation target state (non-destructive overlay). */
+typedef struct mod_target_state {
+    int active;
+    int enabled;
+    char target[16];
+    char param[32];
+    float base_value;
+    mod_source_contribution_t sources[MAX_MOD_SOURCES_PER_TARGET];
+    float effective_value;
+    float last_applied_value;
+    uint64_t last_applied_ms;
+    int has_last_applied;
+    float min_val;
+    float max_val;
+    knob_type_t type;
+} mod_target_state_t;
 
 #define MOVE_PAD_NOTE_MAX 99
 
@@ -400,6 +430,7 @@ typedef struct chain_instance {
     int synth_param_count;
     chain_param_info_t fx_params[MAX_AUDIO_FX][MAX_CHAIN_PARAMS];
     int fx_param_counts[MAX_AUDIO_FX];
+    char fx_ui_hierarchy[MAX_AUDIO_FX][8192];  /* Cached ui_hierarchy JSON */
 
     /* Patch state */
     patch_info_t patches[MAX_PATCHES];
@@ -420,6 +451,13 @@ typedef struct chain_instance {
     knob_mapping_t knob_mappings[MAX_KNOB_MAPPINGS];
     int knob_mapping_count;
     uint64_t knob_last_time_ms[MAX_KNOB_MAPPINGS];  /* For acceleration */
+
+    /* Runtime modulation bus state */
+    mod_target_state_t mod_targets[MAX_MOD_TARGETS];
+    int mod_target_count;
+    uint64_t mod_param_refresh_ms_synth;
+    uint64_t mod_param_refresh_ms_fx[MAX_AUDIO_FX];
+    uint64_t mod_param_refresh_ms_midi_fx[MAX_MIDI_FX];
 
     /* Mute countdown after patch switch */
     int mute_countdown;
@@ -625,12 +663,38 @@ static int chain_get_clock_status(void);
 static int scan_patches(const char *module_dir);
 static void unload_patch(void);
 static int parse_chain_params(const char *module_path, chain_param_info_t *params, int *count);
+static int parse_ui_hierarchy_cache(const char *module_path, char *out, int out_len);
+static int parse_chain_params_array_json(const char *json_array, chain_param_info_t *params, int max_params);
 static chain_param_info_t *find_param_info(chain_param_info_t *params, int count, const char *key);
 static chain_param_info_t *find_param_by_key(chain_instance_t *inst, const char *target, const char *key);
+static int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target);
 static float dsp_value_to_float(const char *val_str, chain_param_info_t *pinfo, float fallback);
 static void v2_chain_log(chain_instance_t *inst, const char *msg);  /* Forward declaration */
 static void parse_debug_log(const char *msg);  /* Forward declaration */
 static void chain_update_clock_runtime(const uint8_t *msg, int len);
+static int chain_mod_emit_value(void *ctx,
+                                const char *source_id,
+                                const char *target,
+                                const char *param,
+                                float signal,
+                                float depth,
+                                float offset,
+                                int bipolar,
+                                int enabled);
+static void chain_mod_clear_source(void *ctx, const char *source_id);
+static int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param);
+static void chain_mod_update_base_from_set_param(chain_instance_t *inst,
+                                                 const char *target,
+                                                 const char *param,
+                                                 const char *val);
+static void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry, int force_write);
+static void chain_mod_clear_target_entry(chain_instance_t *inst, mod_target_state_t *entry, int restore_base);
+static void chain_mod_clear_target_entries(chain_instance_t *inst, const char *target, int restore_base);
+static int chain_mod_get_base_for_subkey(chain_instance_t *inst,
+                                         const char *target,
+                                         const char *subkey,
+                                         char *buf,
+                                         int buf_len);
 
 /* Plugin API we return to host */
 static plugin_api_v1_t g_plugin_api;
@@ -1454,6 +1518,7 @@ static int v2_load_midi_fx(chain_instance_t *inst, const char *fx_name) {
     inst->midi_fx_handles[slot] = handle;
     inst->midi_fx_plugins[slot] = api;
     inst->midi_fx_instances[slot] = instance;
+    inst->mod_param_refresh_ms_midi_fx[slot] = 0;
     strncpy(inst->current_midi_fx_modules[slot], fx_name, MAX_NAME_LEN - 1);
     inst->current_midi_fx_modules[slot][MAX_NAME_LEN - 1] = '\0';
 
@@ -1469,45 +1534,7 @@ static int v2_load_midi_fx(chain_instance_t *inst, const char *fx_name) {
         return -1;
     }
 
-    /* Parse ui_hierarchy from module.json */
-    {
-        char json_path[MAX_PATH_LEN];
-        snprintf(json_path, sizeof(json_path), "%s/module.json", fx_dir);
-        FILE *f = fopen(json_path, "r");
-        if (f) {
-            fseek(f, 0, SEEK_END);
-            long size = ftell(f);
-            fseek(f, 0, SEEK_SET);
-            if (size > 0 && size < 32768) {
-                char *json = malloc(size + 1);
-                if (json) {
-                    { size_t nr = fread(json, 1, size, f); json[nr] = '\0'; }
-                    /* Find ui_hierarchy object */
-                    const char *hier_start = strstr(json, "\"ui_hierarchy\"");
-                    if (hier_start) {
-                        const char *obj_start = strchr(hier_start, '{');
-                        if (obj_start) {
-                            /* Find matching } by counting braces */
-                            int depth = 1;
-                            const char *obj_end = obj_start + 1;
-                            while (*obj_end && depth > 0) {
-                                if (*obj_end == '{') depth++;
-                                else if (*obj_end == '}') depth--;
-                                obj_end++;
-                            }
-                            int len = (int)(obj_end - obj_start);
-                            if (len > 0 && len < 8191) {
-                                strncpy(inst->midi_fx_ui_hierarchy[slot], obj_start, len);
-                                inst->midi_fx_ui_hierarchy[slot][len] = '\0';
-                            }
-                        }
-                    }
-                    free(json);
-                }
-            }
-            fclose(f);
-        }
-    }
+    parse_ui_hierarchy_cache(fx_dir, inst->midi_fx_ui_hierarchy[slot], sizeof(inst->midi_fx_ui_hierarchy[slot]));
 
     inst->midi_fx_count++;
 
@@ -1521,6 +1548,10 @@ static void v2_unload_all_midi_fx(chain_instance_t *inst) {
     if (!inst) return;
 
     for (int i = 0; i < inst->midi_fx_count; i++) {
+        char target[16];
+        snprintf(target, sizeof(target), "midi_fx%d", i + 1);
+        chain_mod_clear_target_entries(inst, target, 0);
+
         if (inst->midi_fx_plugins[i] && inst->midi_fx_instances[i] &&
             inst->midi_fx_plugins[i]->destroy_instance) {
             inst->midi_fx_plugins[i]->destroy_instance(inst->midi_fx_instances[i]);
@@ -1533,6 +1564,7 @@ static void v2_unload_all_midi_fx(chain_instance_t *inst) {
         inst->midi_fx_instances[i] = NULL;
         inst->current_midi_fx_modules[i][0] = '\0';
         inst->midi_fx_param_counts[i] = 0;
+        inst->mod_param_refresh_ms_midi_fx[i] = 0;
         inst->midi_fx_ui_hierarchy[i][0] = '\0';
     }
     inst->midi_fx_count = 0;
@@ -2382,6 +2414,105 @@ static int parse_chain_params(const char *module_path, chain_param_info_t *param
 
     free(json);
     return 0;
+}
+
+/* Parse ui_hierarchy object from module.json and cache it as raw JSON. */
+static int parse_ui_hierarchy_cache(const char *module_path, char *out, int out_len) {
+    char json_path[MAX_PATH_LEN];
+    if (!module_path || !out || out_len < 2) return -1;
+
+    out[0] = '\0';
+    snprintf(json_path, sizeof(json_path), "%s/module.json", module_path);
+
+    FILE *f = fopen(json_path, "r");
+    if (!f) return -1;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0 || size >= 32768) {
+        fclose(f);
+        return -1;
+    }
+
+    char *json = malloc(size + 1);
+    if (!json) {
+        fclose(f);
+        return -1;
+    }
+
+    { size_t nr = fread(json, 1, size, f); json[nr] = '\0'; }
+    fclose(f);
+
+    int rc = -1;
+    const char *hier_start = strstr(json, "\"ui_hierarchy\"");
+    if (hier_start) {
+        const char *obj_start = strchr(hier_start, '{');
+        if (obj_start) {
+            int depth = 1;
+            const char *obj_end = obj_start + 1;
+            while (*obj_end && depth > 0) {
+                if (*obj_end == '{') depth++;
+                else if (*obj_end == '}') depth--;
+                obj_end++;
+            }
+            int len = (int)(obj_end - obj_start);
+            if (depth == 0 && len > 0 && len < out_len) {
+                memcpy(out, obj_start, (size_t)len);
+                out[len] = '\0';
+                rc = len;
+            }
+        }
+    }
+
+    free(json);
+    return rc;
+}
+
+/*
+ * Parse a runtime chain_params JSON array (as returned by plugin get_param).
+ * Returns parsed count on success (including 0), or -1 on malformed input.
+ */
+static int parse_chain_params_array_json(const char *json_array, chain_param_info_t *params, int max_params) {
+    if (!json_array || !params || max_params <= 0) return -1;
+
+    const char *arr_start = strchr(json_array, '[');
+    if (!arr_start) return -1;
+
+    int depth = 1;
+    const char *arr_end = arr_start + 1;
+    while (*arr_end && depth > 0) {
+        if (*arr_end == '[') depth++;
+        else if (*arr_end == ']') depth--;
+        arr_end++;
+    }
+    if (depth != 0) return -1;
+
+    int count = 0;
+    const char *pos = arr_start + 1;
+    while (pos < arr_end && count < max_params) {
+        const char *obj_start = strchr(pos, '{');
+        if (!obj_start || obj_start >= arr_end) break;
+
+        int obj_depth = 0;
+        const char *obj_end = obj_start;
+        do {
+            if (*obj_end == '{') obj_depth++;
+            else if (*obj_end == '}') obj_depth--;
+            obj_end++;
+        } while (obj_end < arr_end && obj_depth > 0);
+
+        if (obj_depth != 0) break;
+
+        chain_param_info_t parsed;
+        if (parse_param_object(obj_start, &parsed) == 0) {
+            params[count++] = parsed;
+        }
+
+        pos = obj_end;
+    }
+
+    return count;
 }
 
 /* Look up parameter info by key in a param list */
@@ -3913,6 +4044,12 @@ plugin_api_v1_t* move_plugin_init_v1(const host_api_v1_t *host) {
     g_source_host_api.midi_send_external = midi_source_send;
     g_subplugin_host_api.get_clock_status = chain_get_clock_status;
     g_source_host_api.get_clock_status = chain_get_clock_status;
+    g_subplugin_host_api.mod_emit_value = chain_mod_emit_value;
+    g_subplugin_host_api.mod_clear_source = chain_mod_clear_source;
+    g_subplugin_host_api.mod_host_ctx = NULL;
+    g_source_host_api.mod_emit_value = chain_mod_emit_value;
+    g_source_host_api.mod_clear_source = chain_mod_clear_source;
+    g_source_host_api.mod_host_ctx = NULL;
 
     /* Initialize our plugin API struct */
     memset(&g_plugin_api, 0, sizeof(g_plugin_api));
@@ -3941,6 +4078,469 @@ static void v2_chain_log(chain_instance_t *inst, const char *msg) {
         char buf[256];
         snprintf(buf, sizeof(buf), "[chain-v2] %s", msg);
         inst->host->log(buf);
+    }
+}
+
+static float chain_mod_clampf(float value, float min_val, float max_val) {
+    if (value < min_val) return min_val;
+    if (value > max_val) return max_val;
+    return value;
+}
+
+static int chain_mod_get_param_string(chain_instance_t *inst,
+                                      const char *target,
+                                      const char *param,
+                                      char *buf,
+                                      int buf_len) {
+    if (!inst || !target || !param || !buf || buf_len < 2) return -1;
+
+    if (strcmp(target, "synth") == 0) {
+        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_param) {
+            return inst->synth_plugin_v2->get_param(inst->synth_instance, param, buf, buf_len);
+        }
+        if (inst->synth_plugin && inst->synth_plugin->get_param) {
+            return inst->synth_plugin->get_param(param, buf, buf_len);
+        }
+        return -1;
+    }
+
+    if (strncmp(target, "fx", 2) == 0) {
+        int fx_slot = atoi(target + 2) - 1;
+        if (fx_slot < 0 || fx_slot >= MAX_AUDIO_FX || fx_slot >= inst->fx_count) return -1;
+
+        if (inst->fx_is_v2[fx_slot] && inst->fx_plugins_v2[fx_slot] && inst->fx_instances[fx_slot]) {
+            return inst->fx_plugins_v2[fx_slot]->get_param(inst->fx_instances[fx_slot], param, buf, buf_len);
+        }
+        if (inst->fx_plugins[fx_slot] && inst->fx_plugins[fx_slot]->get_param) {
+            return inst->fx_plugins[fx_slot]->get_param(param, buf, buf_len);
+        }
+        return -1;
+    }
+
+    if (strncmp(target, "midi_fx", 7) == 0) {
+        int midi_fx_slot = 0;
+        if (target[7] != '\0') {
+            midi_fx_slot = atoi(target + 7) - 1;
+        }
+        if (midi_fx_slot < 0 || midi_fx_slot >= MAX_MIDI_FX || midi_fx_slot >= inst->midi_fx_count) return -1;
+        if (inst->midi_fx_plugins[midi_fx_slot] && inst->midi_fx_instances[midi_fx_slot]) {
+            return inst->midi_fx_plugins[midi_fx_slot]->get_param(inst->midi_fx_instances[midi_fx_slot],
+                                                                  param,
+                                                                  buf,
+                                                                  buf_len);
+        }
+        return -1;
+    }
+
+    return -1;
+}
+
+static int chain_mod_set_param_string(chain_instance_t *inst,
+                                      const char *target,
+                                      const char *param,
+                                      const char *val) {
+    if (!inst || !target || !param || !val) return -1;
+
+    if (strcmp(target, "synth") == 0) {
+        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->set_param) {
+            inst->synth_plugin_v2->set_param(inst->synth_instance, param, val);
+            return 0;
+        }
+        if (inst->synth_plugin && inst->synth_plugin->set_param) {
+            inst->synth_plugin->set_param(param, val);
+            return 0;
+        }
+        return -1;
+    }
+
+    if (strncmp(target, "fx", 2) == 0) {
+        int fx_slot = atoi(target + 2) - 1;
+        if (fx_slot < 0 || fx_slot >= MAX_AUDIO_FX || fx_slot >= inst->fx_count) return -1;
+
+        if (inst->fx_is_v2[fx_slot] && inst->fx_plugins_v2[fx_slot] && inst->fx_instances[fx_slot]) {
+            inst->fx_plugins_v2[fx_slot]->set_param(inst->fx_instances[fx_slot], param, val);
+            return 0;
+        }
+        if (inst->fx_plugins[fx_slot] && inst->fx_plugins[fx_slot]->set_param) {
+            inst->fx_plugins[fx_slot]->set_param(param, val);
+            return 0;
+        }
+        return -1;
+    }
+
+    if (strncmp(target, "midi_fx", 7) == 0) {
+        int midi_fx_slot = 0;
+        if (target[7] != '\0') {
+            midi_fx_slot = atoi(target + 7) - 1;
+        }
+        if (midi_fx_slot < 0 || midi_fx_slot >= MAX_MIDI_FX || midi_fx_slot >= inst->midi_fx_count) return -1;
+        if (inst->midi_fx_plugins[midi_fx_slot] && inst->midi_fx_instances[midi_fx_slot]) {
+            inst->midi_fx_plugins[midi_fx_slot]->set_param(inst->midi_fx_instances[midi_fx_slot], param, val);
+            return 0;
+        }
+        return -1;
+    }
+
+    return -1;
+}
+
+static int chain_mod_has_active_sources(const mod_target_state_t *entry) {
+    if (!entry) return 0;
+
+    for (int i = 0; i < MAX_MOD_SOURCES_PER_TARGET; i++) {
+        if (entry->sources[i].active) return 1;
+    }
+    return 0;
+}
+
+static float chain_mod_sum_contributions(const mod_target_state_t *entry) {
+    float sum = 0.0f;
+    if (!entry) return sum;
+
+    for (int i = 0; i < MAX_MOD_SOURCES_PER_TARGET; i++) {
+        if (!entry->sources[i].active) continue;
+        sum += entry->sources[i].contribution;
+    }
+    return sum;
+}
+
+static mod_source_contribution_t *chain_mod_find_source_contribution(mod_target_state_t *entry,
+                                                                     const char *source_id) {
+    if (!entry || !source_id || !source_id[0]) return NULL;
+
+    for (int i = 0; i < MAX_MOD_SOURCES_PER_TARGET; i++) {
+        mod_source_contribution_t *source_entry = &entry->sources[i];
+        if (!source_entry->active) continue;
+        if (strcmp(source_entry->source_id, source_id) == 0) return source_entry;
+    }
+
+    return NULL;
+}
+
+static mod_source_contribution_t *chain_mod_find_or_alloc_source_contribution(mod_target_state_t *entry,
+                                                                               const char *source_id) {
+    if (!entry || !source_id || !source_id[0]) return NULL;
+
+    mod_source_contribution_t *source_entry = chain_mod_find_source_contribution(entry, source_id);
+    if (source_entry) return source_entry;
+
+    for (int i = 0; i < MAX_MOD_SOURCES_PER_TARGET; i++) {
+        source_entry = &entry->sources[i];
+        if (source_entry->active) continue;
+        memset(source_entry, 0, sizeof(*source_entry));
+        source_entry->active = 1;
+        strncpy(source_entry->source_id, source_id, sizeof(source_entry->source_id) - 1);
+        return source_entry;
+    }
+
+    return NULL;
+}
+
+static void chain_mod_remove_source_contribution(mod_target_state_t *entry, const char *source_id) {
+    mod_source_contribution_t *source_entry = chain_mod_find_source_contribution(entry, source_id);
+    if (!source_entry) return;
+    memset(source_entry, 0, sizeof(*source_entry));
+}
+
+static void chain_mod_recompute_effective(mod_target_state_t *entry) {
+    if (!entry) return;
+
+    float effective = chain_mod_clampf(entry->base_value + chain_mod_sum_contributions(entry),
+                                       entry->min_val,
+                                       entry->max_val);
+    if (entry->type == KNOB_TYPE_INT || entry->type == KNOB_TYPE_ENUM) {
+        effective = (float)((int)effective);
+    }
+    entry->effective_value = chain_mod_clampf(effective, entry->min_val, entry->max_val);
+}
+
+static mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst,
+                                                        const char *target,
+                                                        const char *param) {
+    if (!inst || !target || !param) return NULL;
+
+    for (int i = 0; i < inst->mod_target_count && i < MAX_MOD_TARGETS; i++) {
+        mod_target_state_t *entry = &inst->mod_targets[i];
+        if (!entry->active) continue;
+        if (strcmp(entry->target, target) == 0 && strcmp(entry->param, param) == 0) {
+            return entry;
+        }
+    }
+    return NULL;
+}
+
+static mod_target_state_t *chain_mod_alloc_target_entry(chain_instance_t *inst,
+                                                         const char *target,
+                                                         const char *param) {
+    mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+    if (entry) return entry;
+    if (!inst || !target || !param) return NULL;
+
+    for (int i = 0; i < MAX_MOD_TARGETS; i++) {
+        entry = &inst->mod_targets[i];
+        if (entry->active) continue;
+
+        memset(entry, 0, sizeof(*entry));
+        entry->active = 1;
+        strncpy(entry->target, target, sizeof(entry->target) - 1);
+        strncpy(entry->param, param, sizeof(entry->param) - 1);
+        entry->min_val = 0.0f;
+        entry->max_val = 1.0f;
+        entry->type = KNOB_TYPE_FLOAT;
+
+        if (i >= inst->mod_target_count) {
+            inst->mod_target_count = i + 1;
+        }
+        return entry;
+    }
+
+    return NULL;
+}
+
+static int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param) {
+    mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+    return (entry && entry->active && entry->enabled);
+}
+
+static void chain_mod_update_base_from_set_param(chain_instance_t *inst,
+                                                 const char *target,
+                                                 const char *param,
+                                                 const char *val) {
+    if (!inst || !target || !param || !val) return;
+
+    mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+    if (!entry || !entry->active) return;
+
+    chain_param_info_t *pinfo = find_param_by_key(inst, target, param);
+    if (pinfo) {
+        entry->type = pinfo->type;
+        entry->min_val = pinfo->min_val;
+        entry->max_val = pinfo->max_val;
+    }
+
+    float base = entry->base_value;
+    if (pinfo) {
+        base = dsp_value_to_float(val, pinfo, base);
+    } else {
+        char *endptr = NULL;
+        float parsed = strtof(val, &endptr);
+        if (endptr != val) {
+            base = parsed;
+        }
+    }
+
+    entry->base_value = chain_mod_clampf(base, entry->min_val, entry->max_val);
+}
+
+static void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry, int force_write) {
+    if (!inst || !entry || !entry->active) return;
+
+    chain_mod_recompute_effective(entry);
+
+    uint64_t now_ms = 0;
+    uint32_t min_interval_ms = 0;
+    if (entry->type == KNOB_TYPE_INT || entry->type == KNOB_TYPE_ENUM) {
+        min_interval_ms = MOD_INT_ENUM_MIN_INTERVAL_MS;
+    }
+
+    if (!force_write) {
+        if (entry->has_last_applied) {
+            if (entry->type == KNOB_TYPE_INT || entry->type == KNOB_TYPE_ENUM) {
+                if ((int)entry->effective_value == (int)entry->last_applied_value) {
+                    return;
+                }
+            } else if (fabsf(entry->effective_value - entry->last_applied_value) < MOD_FLOAT_CHANGE_EPSILON) {
+                return;
+            }
+        }
+
+        if (min_interval_ms > 0) {
+            now_ms = get_time_ms();
+            if (entry->last_applied_ms > 0 && (now_ms - entry->last_applied_ms) < min_interval_ms) {
+                return;
+            }
+        }
+    }
+
+    char val_str[32];
+    if (entry->type == KNOB_TYPE_INT || entry->type == KNOB_TYPE_ENUM) {
+        snprintf(val_str, sizeof(val_str), "%d", (int)entry->effective_value);
+    } else {
+        snprintf(val_str, sizeof(val_str), "%.6f", entry->effective_value);
+    }
+
+    int rc = chain_mod_set_param_string(inst, entry->target, entry->param, val_str);
+    if (rc == 0) {
+        entry->last_applied_value = entry->effective_value;
+        if (now_ms == 0) now_ms = get_time_ms();
+        entry->last_applied_ms = now_ms;
+        entry->has_last_applied = 1;
+    }
+}
+
+static void chain_mod_clear_target_entry(chain_instance_t *inst, mod_target_state_t *entry, int restore_base) {
+    if (!inst || !entry || !entry->active) return;
+
+    entry->enabled = 0;
+    if (restore_base) {
+        entry->effective_value = entry->base_value;
+        chain_mod_apply_effective_value(inst, entry, 1);
+    }
+    memset(entry, 0, sizeof(*entry));
+
+    while (inst->mod_target_count > 0 &&
+           !inst->mod_targets[inst->mod_target_count - 1].active) {
+        inst->mod_target_count--;
+    }
+}
+
+static void chain_mod_clear_target_entries(chain_instance_t *inst, const char *target, int restore_base) {
+    if (!inst || !target || !target[0]) return;
+
+    for (int i = 0; i < inst->mod_target_count && i < MAX_MOD_TARGETS; i++) {
+        mod_target_state_t *entry = &inst->mod_targets[i];
+        if (!entry->active) continue;
+        if (strcmp(entry->target, target) != 0) continue;
+        chain_mod_clear_target_entry(inst, entry, restore_base);
+    }
+}
+
+/* Optional getter helper: key suffix ':base' returns non-modulated base value.
+ * Example: 'synth:cutoff:base' -> base cutoff while modulation is active. */
+static int chain_mod_get_base_for_subkey(chain_instance_t *inst,
+                                         const char *target,
+                                         const char *subkey,
+                                         char *buf,
+                                         int buf_len) {
+    if (!inst || !target || !subkey || !buf || buf_len < 2) return -1;
+
+    const size_t suffix_len = 5; /* ":base" */
+    const size_t subkey_len = strlen(subkey);
+    if (subkey_len <= suffix_len || strcmp(subkey + subkey_len - suffix_len, ":base") != 0) {
+        return -1;
+    }
+
+    char param[64];
+    const size_t param_len = subkey_len - suffix_len;
+    if (param_len == 0 || param_len >= sizeof(param)) return -1;
+    memcpy(param, subkey, param_len);
+    param[param_len] = '\0';
+
+    mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+    if (entry && entry->active) {
+        if (entry->type == KNOB_TYPE_INT || entry->type == KNOB_TYPE_ENUM) {
+            return snprintf(buf, buf_len, "%d", (int)entry->base_value);
+        }
+        return snprintf(buf, buf_len, "%.6f", entry->base_value);
+    }
+
+    /* If not modulated, return current plugin value for compatibility. */
+    return chain_mod_get_param_string(inst, target, param, buf, buf_len);
+}
+
+/* Runtime modulation callback (initial stateful implementation).
+ * Applies non-destructive contribution math and stores effective values. */
+static int chain_mod_emit_value(void *ctx,
+                                const char *source_id,
+                                const char *target,
+                                const char *param,
+                                float signal,
+                                float depth,
+                                float offset,
+                                int bipolar,
+                                int enabled) {
+    chain_instance_t *inst = (chain_instance_t *)ctx;
+    if (!inst) inst = g_v1_instance;
+    if (!inst || !source_id || !target || !param) return -1;
+
+    if (!enabled) {
+        chain_mod_clear_source(inst, source_id);
+        return 0;
+    }
+
+    chain_param_info_t *pinfo = find_param_by_key(inst, target, param);
+    if (!pinfo) {
+        mod_target_state_t *stale = chain_mod_find_target_entry(inst, target, param);
+        if (stale && stale->active) {
+            chain_mod_remove_source_contribution(stale, source_id);
+            if (!chain_mod_has_active_sources(stale)) {
+                chain_mod_clear_target_entry(inst, stale, 0);
+            }
+        }
+        return -1;
+    }
+    if (pinfo->type == KNOB_TYPE_ENUM) {
+        mod_target_state_t *stale = chain_mod_find_target_entry(inst, target, param);
+        if (stale && stale->active) {
+            chain_mod_remove_source_contribution(stale, source_id);
+            if (!chain_mod_has_active_sources(stale)) {
+                chain_mod_clear_target_entry(inst, stale, 1);
+            }
+        }
+        return -1;  /* v1 numeric only */
+    }
+
+    mod_target_state_t *entry = chain_mod_alloc_target_entry(inst, target, param);
+    if (!entry) return -1;
+
+    mod_source_contribution_t *source_entry = chain_mod_find_or_alloc_source_contribution(entry, source_id);
+    if (!source_entry) return -1;
+
+    if (!entry->enabled) {
+        float base = pinfo->default_val;
+        char val_buf[64];
+        if (chain_mod_get_param_string(inst, target, param, val_buf, sizeof(val_buf)) > 0) {
+            base = dsp_value_to_float(val_buf, pinfo, base);
+        }
+        entry->base_value = chain_mod_clampf(base, pinfo->min_val, pinfo->max_val);
+    }
+
+    entry->type = pinfo->type;
+    entry->min_val = pinfo->min_val;
+    entry->max_val = pinfo->max_val;
+
+    /* For unipolar sources, map [-1,1] into [0,1] before depth scaling. */
+    float mod_signal = signal;
+    if (!bipolar) {
+        mod_signal = (signal + 1.0f) * 0.5f;
+    }
+
+    /* Scale source depth/offset by target parameter range so a depth of 1.0
+     * has meaningful effect on large-range params (e.g. 0..127). */
+    float range_span = entry->max_val - entry->min_val;
+    if (range_span <= 0.0f) {
+        range_span = 1.0f;
+    }
+    float range_scale = bipolar ? (0.5f * range_span) : range_span;
+    source_entry->contribution = ((mod_signal * depth) + offset) * range_scale;
+    entry->enabled = chain_mod_has_active_sources(entry);
+    chain_mod_apply_effective_value(inst, entry, 0);
+    return 0;
+}
+
+static void chain_mod_clear_source(void *ctx, const char *source_id) {
+    chain_instance_t *inst = (chain_instance_t *)ctx;
+    if (!inst) inst = g_v1_instance;
+    if (!inst) return;
+
+    const int clear_all = (!source_id || source_id[0] == '\0');
+    for (int i = 0; i < inst->mod_target_count && i < MAX_MOD_TARGETS; i++) {
+        mod_target_state_t *entry = &inst->mod_targets[i];
+        if (!entry->active) continue;
+
+        if (clear_all) {
+            chain_mod_clear_target_entry(inst, entry, 1);
+            continue;
+        }
+
+        chain_mod_remove_source_contribution(entry, source_id);
+        if (!chain_mod_has_active_sources(entry)) {
+            chain_mod_clear_target_entry(inst, entry, 1);
+            continue;
+        }
+
+        entry->enabled = 1;
+        chain_mod_apply_effective_value(inst, entry, 0);
     }
 }
 
@@ -3976,6 +4576,12 @@ static void* v2_create_instance(const char *module_dir, const char *config_json)
         memcpy(&inst->source_host_api, g_host, sizeof(host_api_v1_t));
         inst->subplugin_host_api.get_clock_status = chain_get_clock_status;
         inst->source_host_api.get_clock_status = chain_get_clock_status;
+        inst->subplugin_host_api.mod_emit_value = chain_mod_emit_value;
+        inst->subplugin_host_api.mod_clear_source = chain_mod_clear_source;
+        inst->subplugin_host_api.mod_host_ctx = inst;
+        inst->source_host_api.mod_emit_value = chain_mod_emit_value;
+        inst->source_host_api.mod_clear_source = chain_mod_clear_source;
+        inst->source_host_api.mod_host_ctx = inst;
         /* Note: MIDI source routing would need instance-specific handling for full v2 */
     }
 
@@ -4061,6 +4667,7 @@ static int v2_synth_get_error(chain_instance_t *inst, char *buf, int buf_len) {
 /* V2 unload synth */
 static void v2_unload_synth(chain_instance_t *inst) {
     if (!inst) return;
+    chain_mod_clear_target_entries(inst, "synth", 0);
 
     if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->destroy_instance) {
         inst->synth_plugin_v2->destroy_instance(inst->synth_instance);
@@ -4078,6 +4685,7 @@ static void v2_unload_synth(chain_instance_t *inst) {
     inst->synth_instance = NULL;
     inst->current_synth_module[0] = '\0';
     inst->synth_param_count = 0;
+    inst->mod_param_refresh_ms_synth = 0;
     inst->synth_default_forward_channel = -1;
 }
 
@@ -4086,6 +4694,10 @@ static void v2_unload_all_audio_fx(chain_instance_t *inst) {
     if (!inst) return;
 
     for (int i = 0; i < inst->fx_count; i++) {
+        char target_name[16];
+        snprintf(target_name, sizeof(target_name), "fx%d", i + 1);
+        chain_mod_clear_target_entries(inst, target_name, 0);
+
         if (inst->fx_is_v2[i]) {
             if (inst->fx_plugins_v2[i] && inst->fx_instances[i] && inst->fx_plugins_v2[i]->destroy_instance) {
                 inst->fx_plugins_v2[i]->destroy_instance(inst->fx_instances[i]);
@@ -4107,7 +4719,9 @@ static void v2_unload_all_audio_fx(chain_instance_t *inst) {
         inst->fx_is_v2[i] = 0;
         inst->fx_on_midi[i] = NULL;
         inst->fx_param_counts[i] = 0;
+        inst->mod_param_refresh_ms_fx[i] = 0;
         inst->current_fx_modules[i][0] = '\0';
+        inst->fx_ui_hierarchy[i][0] = '\0';
     }
     inst->fx_count = 0;
 }
@@ -4115,6 +4729,9 @@ static void v2_unload_all_audio_fx(chain_instance_t *inst) {
 /* V2 unload a single audio FX slot */
 static void v2_unload_audio_fx_slot(chain_instance_t *inst, int slot) {
     if (!inst || slot < 0 || slot >= MAX_AUDIO_FX) return;
+    char target_name[16];
+    snprintf(target_name, sizeof(target_name), "fx%d", slot + 1);
+    chain_mod_clear_target_entries(inst, target_name, 0);
 
     if (inst->fx_is_v2[slot]) {
         if (inst->fx_plugins_v2[slot] && inst->fx_instances[slot] && inst->fx_plugins_v2[slot]->destroy_instance) {
@@ -4137,7 +4754,9 @@ static void v2_unload_audio_fx_slot(chain_instance_t *inst, int slot) {
     inst->fx_is_v2[slot] = 0;
     inst->fx_on_midi[slot] = NULL;
     inst->fx_param_counts[slot] = 0;
+    inst->mod_param_refresh_ms_fx[slot] = 0;
     inst->current_fx_modules[slot][0] = '\0';
+    inst->fx_ui_hierarchy[slot][0] = '\0';
 }
 
 /* V2 load audio FX into a specific slot */
@@ -4230,8 +4849,11 @@ static int v2_load_audio_fx_slot(chain_instance_t *inst, int slot, const char *f
         inst->fx_is_v2[slot] = 0;
         inst->fx_on_midi[slot] = NULL;
         inst->current_fx_modules[slot][0] = '\0';
+        inst->fx_ui_hierarchy[slot][0] = '\0';
         return -1;
     }
+    parse_ui_hierarchy_cache(fx_dir, inst->fx_ui_hierarchy[slot], sizeof(inst->fx_ui_hierarchy[slot]));
+    inst->mod_param_refresh_ms_fx[slot] = 0;
 
     /* Update fx_count to include this slot */
     if (slot >= inst->fx_count) {
@@ -4339,6 +4961,7 @@ static int v2_load_synth(chain_instance_t *inst, const char *module_name) {
         inst->current_synth_module[0] = '\0';
         return -1;
     }
+    inst->mod_param_refresh_ms_synth = 0;
 
     /* Parse default_forward_channel from capabilities in module.json */
     inst->synth_default_forward_channel = -1;  /* Default: no forwarding preference */
@@ -4356,10 +4979,7 @@ static int v2_load_synth(chain_instance_t *inst, const char *module_name) {
                     { size_t nr = fread(json, 1, size, f); json[nr] = '\0'; }
                     int fwd_ch = -1;
                     if (json_get_int_in_section(json, "capabilities", "default_forward_channel", &fwd_ch) == 0) {
-                        if (fwd_ch == -2) {
-                            inst->synth_default_forward_channel = -2;  /* Passthrough (for MPE) */
-                            v2_chain_log(inst, "Synth default_forward_channel: passthrough");
-                        } else if (fwd_ch >= 1 && fwd_ch <= 16) {
+                        if (fwd_ch >= 1 && fwd_ch <= 16) {
                             inst->synth_default_forward_channel = fwd_ch - 1;  /* Store as 0-15 */
                             snprintf(msg, sizeof(msg), "Synth default_forward_channel: %d", fwd_ch);
                             v2_chain_log(inst, msg);
@@ -4451,8 +5071,11 @@ static int v2_load_audio_fx(chain_instance_t *inst, const char *fx_name) {
         inst->fx_is_v2[slot] = 0;
         inst->fx_on_midi[slot] = NULL;
         inst->current_fx_modules[slot][0] = '\0';
+        inst->fx_ui_hierarchy[slot][0] = '\0';
         return -1;
     }
+    parse_ui_hierarchy_cache(fx_dir, inst->fx_ui_hierarchy[slot], sizeof(inst->fx_ui_hierarchy[slot]));
+    inst->mod_param_refresh_ms_fx[slot] = 0;
 
     inst->fx_count++;
 
@@ -6097,6 +6720,16 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             }
             inst->dirty = 1;
         } else {
+            if (chain_mod_is_target_active(inst, "synth", subkey)) {
+                chain_mod_update_base_from_set_param(inst, "synth", subkey, val);
+                mod_target_state_t *entry = chain_mod_find_target_entry(inst, "synth", subkey);
+                if (entry) {
+                    chain_mod_apply_effective_value(inst, entry, 0);
+                    inst->dirty = 1;
+                    return;
+                }
+            }
+
             /* Only smooth float params — int/enum values must not be interpolated */
             float fval;
             if (is_smoothable_float(val, &fval)) {
@@ -6123,6 +6756,16 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             smoother_reset(&inst->fx_smoothers[0]);  /* Reset smoother on module change */
             inst->dirty = 1;
         } else if (inst->fx_count > 0) {
+            if (chain_mod_is_target_active(inst, "fx1", subkey)) {
+                chain_mod_update_base_from_set_param(inst, "fx1", subkey, val);
+                mod_target_state_t *entry = chain_mod_find_target_entry(inst, "fx1", subkey);
+                if (entry) {
+                    chain_mod_apply_effective_value(inst, entry, 0);
+                    inst->dirty = 1;
+                    return;
+                }
+            }
+
             float fval;
             if (is_smoothable_float(val, &fval)) {
                 chain_param_info_t *pinfo = find_param_info(inst->fx_params[0], inst->fx_param_counts[0], subkey);
@@ -6134,6 +6777,10 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                 inst->fx_plugins_v2[0]->set_param(inst->fx_instances[0], subkey, val);
             } else if (inst->fx_plugins[0] && inst->fx_plugins[0]->set_param) {
                 inst->fx_plugins[0]->set_param(subkey, val);
+            }
+            if (strcmp(subkey, "plugin_id") == 0) {
+                inst->fx_param_counts[0] = 0;
+                inst->mod_param_refresh_ms_fx[0] = 0;
             }
             inst->dirty = 1;
         }
@@ -6147,6 +6794,16 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             smoother_reset(&inst->fx_smoothers[1]);  /* Reset smoother on module change */
             inst->dirty = 1;
         } else if (inst->fx_count > 1) {
+            if (chain_mod_is_target_active(inst, "fx2", subkey)) {
+                chain_mod_update_base_from_set_param(inst, "fx2", subkey, val);
+                mod_target_state_t *entry = chain_mod_find_target_entry(inst, "fx2", subkey);
+                if (entry) {
+                    chain_mod_apply_effective_value(inst, entry, 0);
+                    inst->dirty = 1;
+                    return;
+                }
+            }
+
             float fval;
             if (is_smoothable_float(val, &fval)) {
                 chain_param_info_t *pinfo = find_param_info(inst->fx_params[1], inst->fx_param_counts[1], subkey);
@@ -6158,6 +6815,10 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                 inst->fx_plugins_v2[1]->set_param(inst->fx_instances[1], subkey, val);
             } else if (inst->fx_plugins[1] && inst->fx_plugins[1]->set_param) {
                 inst->fx_plugins[1]->set_param(subkey, val);
+            }
+            if (strcmp(subkey, "plugin_id") == 0) {
+                inst->fx_param_counts[1] = 0;
+                inst->mod_param_refresh_ms_fx[1] = 0;
             }
             inst->dirty = 1;
         }
@@ -6175,6 +6836,15 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             }
             inst->dirty = 1;
         } else if (inst->midi_fx_count > 0 && inst->midi_fx_plugins[0] && inst->midi_fx_instances[0]) {
+            if (chain_mod_is_target_active(inst, "midi_fx1", subkey)) {
+                chain_mod_update_base_from_set_param(inst, "midi_fx1", subkey, val);
+                mod_target_state_t *entry = chain_mod_find_target_entry(inst, "midi_fx1", subkey);
+                if (entry) {
+                    chain_mod_apply_effective_value(inst, entry, 0);
+                    inst->dirty = 1;
+                    return;
+                }
+            }
             inst->midi_fx_plugins[0]->set_param(inst->midi_fx_instances[0], subkey, val);
             inst->dirty = 1;
         }
@@ -6189,6 +6859,15 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             }
             inst->dirty = 1;
         } else if (inst->midi_fx_count > 1 && inst->midi_fx_plugins[1] && inst->midi_fx_instances[1]) {
+            if (chain_mod_is_target_active(inst, "midi_fx2", subkey)) {
+                chain_mod_update_base_from_set_param(inst, "midi_fx2", subkey, val);
+                mod_target_state_t *entry = chain_mod_find_target_entry(inst, "midi_fx2", subkey);
+                if (entry) {
+                    chain_mod_apply_effective_value(inst, entry, 0);
+                    inst->dirty = 1;
+                    return;
+                }
+            }
             inst->midi_fx_plugins[1]->set_param(inst->midi_fx_instances[1], subkey, val);
             inst->dirty = 1;
         }
@@ -6410,12 +7089,117 @@ static float dsp_value_to_float(const char *val_str, chain_param_info_t *pinfo, 
 }
 
 /*
+ * Refresh target parameter metadata from runtime plugin chain_params.
+ * This allows modulation to resolve dynamic params that are not declared in
+ * static module.json metadata.
+ */
+static int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target) {
+    if (!inst || !target) return -1;
+
+    char buf[8192];
+    int result = -1;
+    chain_param_info_t parsed[MAX_CHAIN_PARAMS];
+    int parsed_count = -1;
+
+    if (strcmp(target, "synth") == 0) {
+        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_param) {
+            result = inst->synth_plugin_v2->get_param(inst->synth_instance, "chain_params", buf, sizeof(buf));
+        } else if (inst->synth_plugin && inst->synth_plugin->get_param) {
+            result = inst->synth_plugin->get_param("chain_params", buf, sizeof(buf));
+        }
+        if (result <= 0) return -1;
+        parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
+        if (parsed_count < 0) return -1;
+        memcpy(inst->synth_params, parsed, sizeof(chain_param_info_t) * (size_t)parsed_count);
+        inst->synth_param_count = parsed_count;
+        return parsed_count;
+    }
+
+    if (strncmp(target, "fx", 2) == 0) {
+        int fx_slot = atoi(target + 2) - 1;
+        if (fx_slot < 0 || fx_slot >= MAX_AUDIO_FX || fx_slot >= inst->fx_count) return -1;
+
+        if (inst->fx_is_v2[fx_slot] && inst->fx_plugins_v2[fx_slot] &&
+            inst->fx_instances[fx_slot] && inst->fx_plugins_v2[fx_slot]->get_param) {
+            result = inst->fx_plugins_v2[fx_slot]->get_param(inst->fx_instances[fx_slot], "chain_params", buf, sizeof(buf));
+        } else if (inst->fx_plugins[fx_slot] && inst->fx_plugins[fx_slot]->get_param) {
+            result = inst->fx_plugins[fx_slot]->get_param("chain_params", buf, sizeof(buf));
+        }
+        if (result <= 0) return -1;
+        parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
+        if (parsed_count < 0) return -1;
+        memcpy(inst->fx_params[fx_slot], parsed, sizeof(chain_param_info_t) * (size_t)parsed_count);
+        inst->fx_param_counts[fx_slot] = parsed_count;
+        return parsed_count;
+    }
+
+    if (strncmp(target, "midi_fx", 7) == 0) {
+        int midi_fx_slot = 0;
+        if (target[7] != '\0') {
+            midi_fx_slot = atoi(target + 7) - 1;
+        }
+        if (midi_fx_slot < 0 || midi_fx_slot >= MAX_MIDI_FX || midi_fx_slot >= inst->midi_fx_count) return -1;
+        if (!inst->midi_fx_plugins[midi_fx_slot] || !inst->midi_fx_instances[midi_fx_slot]) return -1;
+
+        result = inst->midi_fx_plugins[midi_fx_slot]->get_param(inst->midi_fx_instances[midi_fx_slot],
+                                                                "chain_params",
+                                                                buf,
+                                                                sizeof(buf));
+        if (result <= 0) return -1;
+        parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
+        if (parsed_count < 0) return -1;
+        memcpy(inst->midi_fx_params[midi_fx_slot], parsed, sizeof(chain_param_info_t) * (size_t)parsed_count);
+        inst->midi_fx_param_counts[midi_fx_slot] = parsed_count;
+        return parsed_count;
+    }
+
+    return -1;
+}
+
+/*
+ * Match a modulation key against chain_params metadata.
+ * Supports exact matches and child-prefixed keys (e.g. nvram_tone_0_cutofffrequency)
+ * where metadata may only expose the suffix key (e.g. cutofffrequency).
+ */
+static int chain_param_key_matches(const char *requested_key, const char *meta_key) {
+    if (!requested_key || !meta_key) return 0;
+    if (strcmp(requested_key, meta_key) == 0) return 1;
+
+    size_t req_len = strlen(requested_key);
+    size_t meta_len = strlen(meta_key);
+    if (req_len <= meta_len + 1) return 0;
+
+    const char *suffix = requested_key + (req_len - meta_len);
+    if (strcmp(suffix, meta_key) != 0) return 0;
+    if (*(suffix - 1) != '_') return 0;
+
+    /* Require strict "..._<index>_<meta_key>" shape for suffix fallback. */
+    const char *idx_end = suffix - 1;  /* underscore before suffix */
+    const char *idx_start = idx_end;
+    while (idx_start > requested_key && *(idx_start - 1) != '_') {
+        idx_start--;
+    }
+    if (idx_start <= requested_key || *(idx_start - 1) != '_') return 0;
+    if (idx_start >= idx_end) return 0;
+
+    for (const char *p = idx_start; p < idx_end; p++) {
+        if (!isdigit((unsigned char)*p)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/*
  * Find parameter metadata by target and key.
  */
 static chain_param_info_t* find_param_by_key(chain_instance_t *inst, const char *target, const char *key) {
+    if (!inst || !target || !key || !key[0]) return NULL;
+
     if (strcmp(target, "synth") == 0) {
         for (int i = 0; i < inst->synth_param_count; i++) {
-            if (strcmp(inst->synth_params[i].key, key) == 0) {
+            if (chain_param_key_matches(key, inst->synth_params[i].key)) {
                 return &inst->synth_params[i];
             }
         }
@@ -6423,7 +7207,7 @@ static chain_param_info_t* find_param_by_key(chain_instance_t *inst, const char 
         int fx_slot = atoi(target + 2) - 1;
         if (fx_slot >= 0 && fx_slot < MAX_AUDIO_FX) {
             for (int i = 0; i < inst->fx_param_counts[fx_slot]; i++) {
-                if (strcmp(inst->fx_params[fx_slot][i].key, key) == 0) {
+                if (chain_param_key_matches(key, inst->fx_params[fx_slot][i].key)) {
                     return &inst->fx_params[fx_slot][i];
                 }
             }
@@ -6436,12 +7220,73 @@ static chain_param_info_t* find_param_by_key(chain_instance_t *inst, const char 
         }
         if (midi_fx_slot >= 0 && midi_fx_slot < MAX_MIDI_FX) {
             for (int i = 0; i < inst->midi_fx_param_counts[midi_fx_slot]; i++) {
-                if (strcmp(inst->midi_fx_params[midi_fx_slot][i].key, key) == 0) {
+                if (chain_param_key_matches(key, inst->midi_fx_params[midi_fx_slot][i].key)) {
                     return &inst->midi_fx_params[midi_fx_slot][i];
                 }
             }
         }
     }
+
+    /* Static metadata missed. Retry with runtime chain_params refresh, throttled
+     * to avoid re-parsing dynamic params every tick when a mapping is stale. */
+    uint64_t now_ms = get_time_ms();
+    uint64_t *last_refresh_ms = NULL;
+    if (strcmp(target, "synth") == 0) {
+        last_refresh_ms = &inst->mod_param_refresh_ms_synth;
+    } else if (strncmp(target, "fx", 2) == 0) {
+        int fx_slot = atoi(target + 2) - 1;
+        if (fx_slot >= 0 && fx_slot < MAX_AUDIO_FX) {
+            last_refresh_ms = &inst->mod_param_refresh_ms_fx[fx_slot];
+        }
+    } else if (strncmp(target, "midi_fx", 7) == 0) {
+        int midi_fx_slot = 0;
+        if (target[7] != '\0') {
+            midi_fx_slot = atoi(target + 7) - 1;
+        }
+        if (midi_fx_slot >= 0 && midi_fx_slot < MAX_MIDI_FX) {
+            last_refresh_ms = &inst->mod_param_refresh_ms_midi_fx[midi_fx_slot];
+        }
+    }
+
+    if (!last_refresh_ms) return NULL;
+    if (*last_refresh_ms > 0 && (now_ms - *last_refresh_ms) < MOD_PARAM_CACHE_REFRESH_MS) {
+        return NULL;
+    }
+    *last_refresh_ms = now_ms;
+
+    if (chain_mod_refresh_target_param_cache(inst, target) <= 0) {
+        return NULL;
+    }
+
+    if (strcmp(target, "synth") == 0) {
+        for (int i = 0; i < inst->synth_param_count; i++) {
+            if (chain_param_key_matches(key, inst->synth_params[i].key)) {
+                return &inst->synth_params[i];
+            }
+        }
+    } else if (strncmp(target, "fx", 2) == 0) {
+        int fx_slot = atoi(target + 2) - 1;
+        if (fx_slot >= 0 && fx_slot < MAX_AUDIO_FX) {
+            for (int i = 0; i < inst->fx_param_counts[fx_slot]; i++) {
+                if (chain_param_key_matches(key, inst->fx_params[fx_slot][i].key)) {
+                    return &inst->fx_params[fx_slot][i];
+                }
+            }
+        }
+    } else if (strncmp(target, "midi_fx", 7) == 0) {
+        int midi_fx_slot = 0;
+        if (target[7] != '\0') {
+            midi_fx_slot = atoi(target + 7) - 1;
+        }
+        if (midi_fx_slot >= 0 && midi_fx_slot < MAX_MIDI_FX) {
+            for (int i = 0; i < inst->midi_fx_param_counts[midi_fx_slot]; i++) {
+                if (chain_param_key_matches(key, inst->midi_fx_params[midi_fx_slot][i].key)) {
+                    return &inst->midi_fx_params[midi_fx_slot][i];
+                }
+            }
+        }
+    }
+
     return NULL;
 }
 
@@ -6655,6 +7500,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     /* Route synth: prefixed params to synth (strip prefix) */
     if (strncmp(key, "synth:", 6) == 0) {
         const char *subkey = key + 6;
+        int base_result = chain_mod_get_base_for_subkey(inst, "synth", subkey, buf, buf_len);
+        if (base_result >= 0) return base_result;
 
         /* Return synth's default forward channel from module.json capabilities */
         if (strcmp(subkey, "default_forward_channel") == 0) {
@@ -6720,6 +7567,20 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     /* Route fx1: prefixed params to FX1 (strip prefix) */
     if (strncmp(key, "fx1:", 4) == 0) {
         const char *subkey = key + 4;
+        int base_result = chain_mod_get_base_for_subkey(inst, "fx1", subkey, buf, buf_len);
+        if (base_result >= 0) return base_result;
+
+        /* For ui_hierarchy: return cached JSON from module.json */
+        if (strcmp(subkey, "ui_hierarchy") == 0 && inst->fx_count > 0) {
+            if (inst->fx_ui_hierarchy[0][0]) {
+                int len = strlen(inst->fx_ui_hierarchy[0]);
+                if (len < buf_len) {
+                    strcpy(buf, inst->fx_ui_hierarchy[0]);
+                    return len;
+                }
+            }
+            return -1;
+        }
 
         /* For chain_params: try plugin first, fall back to parsed module.json data */
         if (strcmp(subkey, "chain_params") == 0 && inst->fx_count > 0) {
@@ -6782,6 +7643,20 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     /* Route fx2: prefixed params to FX2 (strip prefix) */
     if (strncmp(key, "fx2:", 4) == 0) {
         const char *subkey = key + 4;
+        int base_result = chain_mod_get_base_for_subkey(inst, "fx2", subkey, buf, buf_len);
+        if (base_result >= 0) return base_result;
+
+        /* For ui_hierarchy: return cached JSON from module.json */
+        if (strcmp(subkey, "ui_hierarchy") == 0 && inst->fx_count > 1) {
+            if (inst->fx_ui_hierarchy[1][0]) {
+                int len = strlen(inst->fx_ui_hierarchy[1]);
+                if (len < buf_len) {
+                    strcpy(buf, inst->fx_ui_hierarchy[1]);
+                    return len;
+                }
+            }
+            return -1;
+        }
 
         /* For chain_params: try plugin first, fall back to parsed module.json data */
         if (strcmp(subkey, "chain_params") == 0 && inst->fx_count > 1) {
@@ -6844,6 +7719,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     /* Route midi_fx1: prefixed params to MIDI FX1 (strip prefix) */
     if (strncmp(key, "midi_fx1:", 9) == 0) {
         const char *subkey = key + 9;
+        int base_result = chain_mod_get_base_for_subkey(inst, "midi_fx1", subkey, buf, buf_len);
+        if (base_result >= 0) return base_result;
         /* For ui_hierarchy: return cached JSON from module.json */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->midi_fx_count > 0) {
             if (inst->midi_fx_ui_hierarchy[0][0]) {
@@ -6908,6 +7785,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     /* Route midi_fx2: prefixed params to MIDI FX2 (strip prefix) */
     if (strncmp(key, "midi_fx2:", 9) == 0) {
         const char *subkey = key + 9;
+        int base_result = chain_mod_get_base_for_subkey(inst, "midi_fx2", subkey, buf, buf_len);
+        if (base_result >= 0) return base_result;
         /* For ui_hierarchy: return cached JSON from module.json */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->midi_fx_count > 1) {
             if (inst->midi_fx_ui_hierarchy[1][0]) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -230,6 +230,7 @@ const VIEWS = {
     FILEPATH_BROWSER: "filepathbrowser", // Generic filepath picker for filepath params
     KNOB_EDITOR: "knobedit",  // Edit knob assignments for a slot
     KNOB_PARAM_PICKER: "knobpick", // Pick parameter for a knob assignment
+    DYNAMIC_PARAM_PICKER: "dynamicpick", // Dedicated picker UI for module_picker/parameter_picker
     STORE_PICKER_CATEGORIES: "storepickercats", // Store: browse categories
     STORE_PICKER_LIST: "storepickerlist",     // Store: browse modules for category
     STORE_PICKER_DETAIL: "storepickerdetail", // Store: module info and actions
@@ -320,6 +321,7 @@ const VIEW_NAMES = {
     [VIEWS.FILEPATH_BROWSER]: "File Browser",
     [VIEWS.KNOB_EDITOR]: "Knob Editor",
     [VIEWS.KNOB_PARAM_PICKER]: "Parameter Picker",
+    [VIEWS.DYNAMIC_PARAM_PICKER]: "Parameter Picker",
     [VIEWS.STORE_PICKER_CATEGORIES]: "Module Store",
     [VIEWS.STORE_PICKER_LIST]: "Module Store",
     [VIEWS.STORE_PICKER_DETAIL]: "Module Details",
@@ -635,6 +637,14 @@ let knobParamPickerParams = [];  // Available params in current folder
 let knobParamPickerHierarchy = null; // Parsed ui_hierarchy for current target
 let knobParamPickerLevel = null;     // Current level name in hierarchy (null = flat mode)
 let knobParamPickerPath = [];        // Navigation path for back in hierarchy
+let dynamicPickerMeta = null;
+let dynamicPickerKey = "";
+let dynamicPickerTargetKey = "";
+let dynamicPickerMode = "target";  // target or param
+let dynamicPickerIndex = 0;
+let dynamicPickerTargets = [];
+let dynamicPickerParams = [];
+let dynamicPickerSelectedTarget = "";
 let lastSlotModuleSignatures = [];  // Track per-slot module changes for knob cache refresh
 
 /* Master FX state */
@@ -1272,6 +1282,8 @@ let hierEditorParams = [];        // current level's params
 let hierEditorKnobs = [];         // current level's knob-mapped params
 let hierEditorSelectedIdx = 0;
 let hierEditorEditMode = false;   // true when editing a param value
+let hierEditorEditKey = "";       // full key currently being edited
+let hierEditorEditValue = null;   // stable value during edit mode
 let hierEditorChainParams = [];   // metadata from chain_params
 
 /* Master FX flag - when true, exit returns to MASTER_FX view instead of CHAIN_EDIT */
@@ -5123,6 +5135,353 @@ function getKnobParamsForTarget(slot, target) {
     return params;
 }
 
+function getNumericParamsForTarget(slot, target, numericOnly = true) {
+    const params = [];
+    const seen = new Set();
+    const chainMetaByKey = new Map();
+    const chainParamsJson = getSlotParam(slot, `${target}:chain_params`);
+    if (!chainParamsJson) return params;
+
+    try {
+        const chainParams = JSON.parse(chainParamsJson);
+        if (!Array.isArray(chainParams)) return params;
+        for (const p of chainParams) {
+            if (!p || !p.key) continue;
+            chainMetaByKey.set(p.key, p);
+        }
+
+        const hierarchyJson = getSlotParam(slot, `${target}:ui_hierarchy`);
+        if (hierarchyJson) {
+            try {
+                const hierarchy = JSON.parse(hierarchyJson);
+                const levels = hierarchy && hierarchy.levels && typeof hierarchy.levels === "object"
+                    ? hierarchy.levels : null;
+                if (levels) {
+                    for (const levelName of Object.keys(levels)) {
+                        const level = levels[levelName];
+                        if (!level || !Array.isArray(level.params)) continue;
+
+                        const childPrefix = (typeof level.child_prefix === "string") ? level.child_prefix : "";
+                        const rawChildCount = parseInt(level.child_count, 10);
+                        const childCount = Number.isFinite(rawChildCount) ? Math.max(0, rawChildCount) : 0;
+                        const childLabel = (typeof level.child_label === "string" && level.child_label)
+                            ? level.child_label : "Item";
+
+                        for (const entry of level.params) {
+                            const key = (typeof entry === "string") ? entry : (entry && entry.key ? entry.key : "");
+                            if (!key) continue;
+
+                            const meta = chainMetaByKey.get(key);
+                            if (!meta) continue;
+                            const type = (meta.type || "").toLowerCase();
+                            const isNumeric = type === "float" || type === "int" ||
+                                (!type && (meta.min !== undefined || meta.max !== undefined));
+                            if (numericOnly && !isNumeric) continue;
+
+                            if (childPrefix && childCount > 0) {
+                                for (let i = 0; i < childCount; i++) {
+                                    const fullKey = `${childPrefix}${i}_${key}`;
+                                    if (seen.has(fullKey)) continue;
+                                    const baseLabel = meta.name || meta.label || key;
+                                    params.push({ key: fullKey, label: `${childLabel} ${i + 1} ${baseLabel}` });
+                                    seen.add(fullKey);
+                                }
+                            } else {
+                                if (seen.has(key)) continue;
+                                params.push({ key, label: meta.name || meta.label || key });
+                                seen.add(key);
+                            }
+                        }
+                    }
+                }
+            } catch (e) {
+                /* Ignore ui_hierarchy parse errors and fall back to chain_params list. */
+            }
+        }
+
+        if (params.length > 0) return params;
+
+        for (const p of chainParams) {
+            if (!p || !p.key) continue;
+            const type = (p.type || "").toLowerCase();
+            const isNumeric = type === "float" || type === "int" ||
+                (!type && (p.min !== undefined || p.max !== undefined));
+            if (numericOnly && !isNumeric) continue;
+            if (!seen.has(p.key)) {
+                params.push({ key: p.key, label: p.name || p.label || p.key });
+                seen.add(p.key);
+            }
+        }
+    } catch (e) {
+        /* Ignore parse errors and return empty numeric set. */
+    }
+
+    return params;
+}
+
+function inferLinkedTargetComponentKey(paramKey, meta) {
+    if (meta && typeof meta.target_key === "string" && meta.target_key.trim()) {
+        return meta.target_key.trim();
+    }
+    return "";
+}
+
+function inferLinkedTargetParamKey(componentKey, meta) {
+    if (meta && typeof meta.param_key === "string" && meta.param_key.trim()) {
+        return meta.param_key.trim();
+    }
+    return "";
+}
+
+function parseMetaStringList(value) {
+    if (Array.isArray(value)) {
+        return value
+            .map(v => String(v).trim())
+            .filter(Boolean);
+    }
+    if (typeof value === "string") {
+        return value
+            .split(",")
+            .map(v => v.trim())
+            .filter(Boolean);
+    }
+    return [];
+}
+
+function buildModulePickerOptions(meta) {
+    if (hierEditorSlot < 0 || !hierEditorComponent || hierEditorIsMasterFx) {
+        return [];
+    }
+
+    const opts = [];
+    const seen = new Set();
+    const allowNone = meta && meta.allow_none !== undefined ? parseMetaBool(meta.allow_none) : true;
+    const allowSelf = meta && meta.allow_self !== undefined ? parseMetaBool(meta.allow_self) : false;
+    const allowedTargets = new Set(parseMetaStringList(meta && meta.allowed_targets));
+    const selfTarget = getComponentParamPrefix(hierEditorComponent);
+
+    if (allowNone) {
+        opts.push("");
+        seen.add("");
+    }
+
+    const targets = getKnobTargets(hierEditorSlot);
+    for (const target of targets) {
+        if (!target || !target.id) continue;
+        if (!allowSelf && selfTarget && target.id === selfTarget) continue;
+        if (allowedTargets.size > 0 && !allowedTargets.has(target.id)) continue;
+        if (seen.has(target.id)) continue;
+        opts.push(target.id);
+        seen.add(target.id);
+    }
+
+    return opts;
+}
+
+function buildParameterPickerOptions(paramKey, meta) {
+    if (hierEditorSlot < 0 || !hierEditorComponent || hierEditorIsMasterFx) {
+        return [];
+    }
+
+    const opts = [];
+    const seen = new Set();
+    const allowNone = meta && meta.allow_none !== undefined ? parseMetaBool(meta.allow_none) : true;
+    if (allowNone) {
+        opts.push("");
+        seen.add("");
+    }
+
+    const prefix = getComponentParamPrefix(hierEditorComponent);
+    if (!prefix) return opts;
+
+    const targetKey = inferLinkedTargetComponentKey(paramKey, meta);
+    if (!targetKey) return opts;
+
+    const selectedTarget = getSlotParam(hierEditorSlot, `${prefix}:${targetKey}`) || "";
+    if (!selectedTarget) return opts;
+
+    const numericOnly = meta && meta.numeric_only !== undefined ? parseMetaBool(meta.numeric_only) : true;
+    const params = getNumericParamsForTarget(hierEditorSlot, selectedTarget, numericOnly);
+    for (const param of params) {
+        if (!param || !param.key || seen.has(param.key)) continue;
+        opts.push(param.key);
+        seen.add(param.key);
+    }
+
+    return opts;
+}
+
+function getDynamicPickerMeta(key, meta) {
+    if (!meta || typeof meta !== "object") return meta;
+    const rawType = String(meta.type || "").toLowerCase();
+    if (rawType !== "module_picker" && rawType !== "parameter_picker") return meta;
+
+    const dynamicOptions = rawType === "module_picker"
+        ? buildModulePickerOptions(meta)
+        : buildParameterPickerOptions(key, meta);
+
+    return {
+        ...meta,
+        type: "enum",
+        options: dynamicOptions,
+        picker_type: rawType,
+        none_label: meta.none_label || "(none)"
+    };
+}
+
+function buildDynamicPickerTargetItems(meta) {
+    const optionIds = buildModulePickerOptions(meta);
+    const sourceTargets = getKnobTargets(hierEditorSlot);
+    const nameById = new Map();
+    for (const target of sourceTargets) {
+        if (!target || !target.id) continue;
+        nameById.set(target.id, target.name || target.label || target.id);
+    }
+    return optionIds.map(id => ({
+        id,
+        label: id ? (nameById.get(id) || id) : (meta.none_label || "(none)")
+    }));
+}
+
+function buildDynamicPickerParamItemsForTarget(meta, targetId) {
+    if (!targetId) return [];
+    const numericOnly = meta && meta.numeric_only !== undefined ? parseMetaBool(meta.numeric_only) : true;
+    const params = getNumericParamsForTarget(hierEditorSlot, targetId, numericOnly);
+    return params.map(p => ({ key: p.key, label: p.label || p.key }));
+}
+
+function resetDynamicParamPickerState() {
+    dynamicPickerMeta = null;
+    dynamicPickerKey = "";
+    dynamicPickerTargetKey = "";
+    dynamicPickerMode = "target";
+    dynamicPickerIndex = 0;
+    dynamicPickerTargets = [];
+    dynamicPickerParams = [];
+    dynamicPickerSelectedTarget = "";
+}
+
+function closeDynamicParamPicker(announcement) {
+    resetDynamicParamPickerState();
+    setView(VIEWS.HIERARCHY_EDITOR);
+    needsRedraw = true;
+    if (announcement) {
+        announce(announcement);
+    }
+}
+
+function openDynamicParamPicker(key, meta) {
+    if (!meta || !meta.picker_type) return false;
+    if (hierEditorSlot < 0 || !hierEditorComponent || hierEditorIsMasterFx) return false;
+
+    const prefix = getComponentParamPrefix(hierEditorComponent);
+    if (!prefix) return false;
+
+    resetDynamicParamPickerState();
+    dynamicPickerMeta = meta;
+    dynamicPickerKey = key;
+    dynamicPickerTargetKey = inferLinkedTargetComponentKey(key, meta);
+    dynamicPickerTargets = buildDynamicPickerTargetItems(meta);
+
+    const currentValue = getSlotParam(hierEditorSlot, `${prefix}:${key}`) || "";
+    if (meta.picker_type === "module_picker") {
+        const idx = dynamicPickerTargets.findIndex(t => t.id === currentValue);
+        dynamicPickerIndex = idx >= 0 ? idx : 0;
+        dynamicPickerMode = "target";
+        dynamicPickerSelectedTarget = currentValue;
+    } else {
+        const currentTarget = dynamicPickerTargetKey
+            ? (getSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerTargetKey}`) || "")
+            : "";
+        dynamicPickerSelectedTarget = currentTarget;
+        dynamicPickerParams = buildDynamicPickerParamItemsForTarget(meta, currentTarget);
+
+        if (currentTarget && dynamicPickerParams.length > 0) {
+            dynamicPickerMode = "param";
+            const idx = dynamicPickerParams.findIndex(p => p.key === currentValue);
+            dynamicPickerIndex = idx >= 0 ? idx : 0;
+        } else {
+            dynamicPickerMode = "target";
+            const idx = dynamicPickerTargets.findIndex(t => t.id === currentTarget);
+            dynamicPickerIndex = idx >= 0 ? idx : 0;
+        }
+    }
+
+    setView(VIEWS.DYNAMIC_PARAM_PICKER);
+    needsRedraw = true;
+    if (meta.picker_type === "parameter_picker" && dynamicPickerMode === "param") {
+        announce("Select target parameter");
+    } else {
+        announce("Select target component");
+    }
+    return true;
+}
+
+function handleDynamicParamPickerSelect() {
+    if (!dynamicPickerMeta || !dynamicPickerKey) {
+        closeDynamicParamPicker("Hierarchy Editor");
+        return;
+    }
+
+    const prefix = getComponentParamPrefix(hierEditorComponent);
+    if (!prefix) {
+        closeDynamicParamPicker("Hierarchy Editor");
+        return;
+    }
+
+    if (dynamicPickerMode === "target") {
+        const selectedTarget = dynamicPickerTargets[dynamicPickerIndex];
+        if (!selectedTarget) return;
+
+        if (dynamicPickerMeta.picker_type === "module_picker") {
+            setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerKey}`, selectedTarget.id || "");
+            const linkedParamKey = inferLinkedTargetParamKey(dynamicPickerKey, dynamicPickerMeta);
+            if (linkedParamKey) {
+                setSlotParam(hierEditorSlot, `${prefix}:${linkedParamKey}`, "");
+            }
+            closeDynamicParamPicker(`Target component ${selectedTarget.label || "(none)"}`);
+            return;
+        }
+
+        /* parameter_picker target stage */
+        if (!dynamicPickerTargetKey) {
+            closeDynamicParamPicker("No target key");
+            return;
+        }
+
+        setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerTargetKey}`, selectedTarget.id || "");
+        dynamicPickerSelectedTarget = selectedTarget.id || "";
+
+        if (!dynamicPickerSelectedTarget) {
+            setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerKey}`, "");
+            closeDynamicParamPicker("Target cleared");
+            return;
+        }
+
+        dynamicPickerParams = buildDynamicPickerParamItemsForTarget(dynamicPickerMeta, dynamicPickerSelectedTarget);
+        if (dynamicPickerParams.length === 0) {
+            setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerKey}`, "");
+            closeDynamicParamPicker("No matching params");
+            return;
+        }
+
+        dynamicPickerMode = "param";
+        dynamicPickerIndex = 0;
+        announceMenuItem("Param", dynamicPickerParams[0].label || dynamicPickerParams[0].key || "");
+        needsRedraw = true;
+        return;
+    }
+
+    const selectedParam = dynamicPickerParams[dynamicPickerIndex];
+    if (!selectedParam) return;
+
+    if (dynamicPickerTargetKey) {
+        setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerTargetKey}`, dynamicPickerSelectedTarget || "");
+    }
+    setSlotParam(hierEditorSlot, `${prefix}:${dynamicPickerKey}`, selectedParam.key || "");
+    closeDynamicParamPicker(`Target ${dynamicPickerSelectedTarget}:${selectedParam.key}`);
+}
+
 /* Get display label for a knob assignment */
 function getKnobAssignmentLabel(assignment) {
     if (!assignment || !assignment.target || !assignment.param) {
@@ -5324,6 +5683,7 @@ function enterHierarchyEditor(slotIndex, componentKey) {
 
     /* Dismiss any active overlay and clear pending knob state */
     hideOverlay();
+    invalidateKnobContextCache();
     pendingHierKnobIndex = -1;
     pendingHierKnobDelta = 0;
 
@@ -5337,10 +5697,12 @@ function enterHierarchyEditor(slotIndex, componentKey) {
     hierEditorChildLabel = "";
     hierEditorSelectedIdx = 0;
     hierEditorEditMode = false;
+    resetHierarchyEditState();
     hierEditorIsMasterFx = false;
     hierEditorMasterFxSlot = -1;
     filepathBrowserState = null;
     filepathBrowserParamKey = "";
+    resetDynamicParamPickerState();
 
     /* Fetch chain_params metadata for this component */
     hierEditorChainParams = getComponentChainParams(slotIndex, componentKey);
@@ -5389,6 +5751,7 @@ function enterMasterFxHierarchyEditor(fxSlot) {
 
     /* Dismiss any active overlay and clear pending knob state */
     hideOverlay();
+    invalidateKnobContextCache();
     pendingHierKnobIndex = -1;
     pendingHierKnobDelta = 0;
 
@@ -5406,8 +5769,10 @@ function enterMasterFxHierarchyEditor(fxSlot) {
     hierEditorChildLabel = "";
     hierEditorSelectedIdx = 0;
     hierEditorEditMode = false;
+    resetHierarchyEditState();
     hierEditorIsMasterFx = true;
     hierEditorMasterFxSlot = fxSlot;
+    resetDynamicParamPickerState();
 
     /* Fetch chain_params metadata for this Master FX slot */
     hierEditorChainParams = getMasterFxChainParams(fxSlot);
@@ -5597,10 +5962,12 @@ function exitHierarchyEditor() {
     hierEditorChildLabel = "";
     hierEditorIsPresetLevel = false;
     hierEditorPresetEditMode = false;
+    resetHierarchyEditState();
     hierEditorIsMasterFx = false;
     hierEditorMasterFxSlot = -1;
     filepathBrowserState = null;
     filepathBrowserParamKey = "";
+    resetDynamicParamPickerState();
 
     view = returnToMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT;
     needsRedraw = true;
@@ -5693,13 +6060,15 @@ function closeHierarchyFilepathBrowser() {
 
     filepathBrowserState = null;
     filepathBrowserParamKey = "";
+    resetDynamicParamPickerState();
     setView(VIEWS.HIERARCHY_EDITOR);
 }
 
 /* Get param metadata from chain_params */
 function getParamMetadata(key) {
     if (!hierEditorChainParams) return null;
-    return hierEditorChainParams.find(p => p.key === key);
+    const rawMeta = hierEditorChainParams.find(p => p.key === key);
+    return getDynamicPickerMeta(key, rawMeta);
 }
 
 /* Format a param value for setting (respects type) */
@@ -5717,6 +6086,9 @@ function formatParamForOverlay(val, meta) {
     }
     /* Enum/bool: show value as-is (string) */
     if (meta && (meta.type === "enum" || meta.type === "bool")) {
+        if (meta.picker_type && (val === "" || val === null || val === undefined)) {
+            return meta.none_label || "(none)";
+        }
         return String(val);
     }
     /* Float: show as percentage if 0-1 or 0-2 range */
@@ -5742,6 +6114,26 @@ function buildHierarchyParamKey(key) {
     return `${prefix}:${key}`;
 }
 
+function resetHierarchyEditState() {
+    hierEditorEditKey = "";
+    hierEditorEditValue = null;
+}
+
+function beginHierarchyParamEdit(key) {
+    const fullKey = buildHierarchyParamKey(key);
+    const baseVal = getSlotParam(hierEditorSlot, `${fullKey}:base`);
+    const liveVal = getSlotParam(hierEditorSlot, fullKey);
+    if (baseVal === null && liveVal === null) return false;
+
+    hierEditorEditKey = fullKey;
+    hierEditorEditValue = (baseVal !== null) ? baseVal : liveVal;
+    return true;
+}
+
+function shouldRefreshDynamicRateMeta(key) {
+    return typeof key === "string" && /_rate_mode$/.test(key);
+}
+
 /* Adjust selected param value via jog */
 function adjustHierSelectedParam(delta) {
     if (hierEditorSelectedIdx >= hierEditorParams.length) return;
@@ -5754,7 +6146,10 @@ function adjustHierSelectedParam(delta) {
     if (key === SWAP_MODULE_ACTION) return;
     const fullKey = buildHierarchyParamKey(key);
 
-    const currentVal = getSlotParam(hierEditorSlot, fullKey);
+    const usingStableEditVal = hierEditorEditMode &&
+                               hierEditorEditKey === fullKey &&
+                               hierEditorEditValue !== null;
+    const currentVal = usingStableEditVal ? String(hierEditorEditValue) : getSlotParam(hierEditorSlot, fullKey);
     if (currentVal === null) return;
 
     const meta = getParamMetadata(key);
@@ -5768,7 +6163,15 @@ function adjustHierSelectedParam(delta) {
         let newIndex = currentIndex + delta;
         if (newIndex < 0) newIndex = meta.options.length - 1;
         if (newIndex >= meta.options.length) newIndex = 0;
-        setSlotParam(hierEditorSlot, fullKey, meta.options[newIndex]);
+        const newVal = meta.options[newIndex];
+        setSlotParam(hierEditorSlot, fullKey, newVal);
+        if (usingStableEditVal) {
+            hierEditorEditValue = newVal;
+        }
+        if (shouldRefreshDynamicRateMeta(key)) {
+            refreshHierarchyChainParams();
+            invalidateKnobContextCache();
+        }
         return;
     }
 
@@ -5783,7 +6186,11 @@ function adjustHierSelectedParam(delta) {
     const max = meta && typeof meta.max === "number" ? meta.max : 1;
 
     const newVal = Math.max(min, Math.min(max, num + delta * step));
-    setSlotParam(hierEditorSlot, fullKey, formatParamForSet(newVal, meta));
+    const formatted = formatParamForSet(newVal, meta);
+    setSlotParam(hierEditorSlot, fullKey, formatted);
+    if (usingStableEditVal) {
+        hierEditorEditValue = formatted;
+    }
 }
 
 /*
@@ -6019,7 +6426,7 @@ function rebuildKnobContextCache() {
     }
     cachedKnobContextsView = view;
     cachedKnobContextsSlot = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorSlot : selectedSlot;
-    cachedKnobContextsComp = (view === VIEWS.HIERARCHY_EDITOR) ? -1 : selectedChainComponent;
+    cachedKnobContextsComp = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorComponent : selectedChainComponent;
     cachedKnobContextsLevel = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorLevel : "";
     cachedKnobContextsChildIndex = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorChildIndex : -1;
 }
@@ -6034,7 +6441,7 @@ let cachedKnobContextsMasterFxComp = -1;  /* Track Master FX component for cache
 function getKnobContext(knobIndex) {
     /* Check if cache is valid */
     const currentSlot = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorSlot : selectedSlot;
-    const currentComp = (view === VIEWS.HIERARCHY_EDITOR) ? -1 : selectedChainComponent;
+    const currentComp = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorComponent : selectedChainComponent;
     const currentLevel = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorLevel : "";
     const currentChildIndex = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorChildIndex : -1;
     const currentMasterFxComp = (view === VIEWS.MASTER_FX) ? selectedMasterFxComponent : -1;
@@ -6207,6 +6614,10 @@ function processPendingHierKnob() {
         if (newIndex >= ctx.meta.options.length) newIndex = ctx.meta.options.length - 1;
         const newVal = ctx.meta.options[newIndex];
         setSlotParam(ctx.slot, ctx.fullKey, newVal);
+        if (shouldRefreshDynamicRateMeta(ctx.key)) {
+            refreshHierarchyChainParams();
+            invalidateKnobContextCache();
+        }
         showOverlay(ctx.title, newVal);
         return;
     }
@@ -6241,6 +6652,9 @@ function formatHierDisplayValue(key, val) {
 
     /* For enums, always return the raw string value */
     if (meta && meta.type === "enum") {
+        if (meta.picker_type && (val === "" || val === null || val === undefined)) {
+            return meta.none_label || "(none)";
+        }
         return val;
     }
 
@@ -6452,7 +6866,10 @@ function drawHierarchyEditor() {
                 /* Only fetch param value if this item is visible on screen */
                 let displayVal = "";
                 if (idx >= visibleStart && idx < visibleEnd) {
-                    const val = getSlotParam(hierEditorSlot, buildHierarchyParamKey(key));
+                    const fullKey = buildHierarchyParamKey(key);
+                    const usingStableEditVal = hierEditorEditMode &&
+                                               hierEditorEditKey === fullKey && hierEditorEditValue !== null;
+                    const val = usingStableEditVal ? String(hierEditorEditValue) : getSlotParam(hierEditorSlot, fullKey);
                     displayVal = val !== null ? formatHierDisplayValue(key, val) : "";
                 }
                 return { label, value: displayVal, key };
@@ -6909,7 +7326,9 @@ function handleJog(delta) {
                     const param = hierEditorParams[hierEditorSelectedIdx];
                     const key = typeof param === "string" ? param : param.key || param;
                     const fullKey = buildHierarchyParamKey(key);
-                    const freshVal = getSlotParam(hierEditorSlot, fullKey);
+                    const freshVal = (hierEditorEditKey === fullKey && hierEditorEditValue !== null)
+                        ? String(hierEditorEditValue)
+                        : getSlotParam(hierEditorSlot, fullKey);
                     const displayVal = freshVal !== null ? formatHierDisplayValue(key, freshVal) : "";
                     announceParameter(param.label || key, displayVal);
                 }
@@ -6961,6 +7380,21 @@ function handleJog(delta) {
                 if (knobParamPickerParams.length > 0) {
                     const kp = knobParamPickerParams[knobParamPickerIndex];
                     announceMenuItem("Param", kp.label || kp.key || "Unknown");
+                }
+            }
+            break;
+        case VIEWS.DYNAMIC_PARAM_PICKER:
+            if (dynamicPickerMode === "param") {
+                dynamicPickerIndex = Math.max(0, Math.min(dynamicPickerParams.length - 1, dynamicPickerIndex + delta));
+                if (dynamicPickerParams.length > 0) {
+                    const paramItem = dynamicPickerParams[dynamicPickerIndex];
+                    announceMenuItem("Param", paramItem.label || paramItem.key || "");
+                }
+            } else {
+                dynamicPickerIndex = Math.max(0, Math.min(dynamicPickerTargets.length - 1, dynamicPickerIndex + delta));
+                if (dynamicPickerTargets.length > 0) {
+                    const targetItem = dynamicPickerTargets[dynamicPickerIndex];
+                    announceMenuItem("Target", targetItem.label || targetItem.id || "");
                 }
             }
             break;
@@ -7568,10 +8002,19 @@ function handleSelect() {
                         ? (selectedParam.key || selectedParam)
                         : selectedParam;
                     const meta = getParamMetadata(selectedKey);
-                    if (!hierEditorEditMode && meta && meta.type === "filepath") {
+                    if (!hierEditorEditMode && meta && meta.picker_type) {
+                        openDynamicParamPicker(selectedKey, meta);
+                    } else if (!hierEditorEditMode && meta && meta.type === "filepath") {
                         openHierarchyFilepathBrowser(selectedKey, meta);
                     } else {
-                        hierEditorEditMode = !hierEditorEditMode;
+                        if (!hierEditorEditMode) {
+                            if (beginHierarchyParamEdit(selectedKey)) {
+                                hierEditorEditMode = true;
+                            }
+                        } else {
+                            hierEditorEditMode = false;
+                            resetHierarchyEditState();
+                        }
                     }
                 }
             }
@@ -7670,6 +8113,9 @@ function handleSelect() {
                     applyKnobAssignment(knobParamPickerFolder, selected.key);
                 }
             }
+            break;
+        case VIEWS.DYNAMIC_PARAM_PICKER:
+            handleDynamicParamPickerSelect();
             break;
         case VIEWS.UPDATE_PROMPT:
             if (pendingUpdateIndex === pendingUpdates.length) {
@@ -8054,6 +8500,7 @@ function handleBack() {
             if (hierEditorEditMode) {
                 /* Exit param edit mode first */
                 hierEditorEditMode = false;
+                resetHierarchyEditState();
                 needsRedraw = true;
                 announceHierLevel();
             } else if (hierEditorPresetEditMode) {
@@ -8162,6 +8609,17 @@ function handleBack() {
                 setView(VIEWS.KNOB_EDITOR);
                 announce("Knob Editor");
                 needsRedraw = true;
+            }
+            break;
+        case VIEWS.DYNAMIC_PARAM_PICKER:
+            if (dynamicPickerMode === "param" && dynamicPickerMeta && dynamicPickerMeta.picker_type === "parameter_picker") {
+                dynamicPickerMode = "target";
+                const targetIdx = dynamicPickerTargets.findIndex(t => t.id === dynamicPickerSelectedTarget);
+                dynamicPickerIndex = targetIdx >= 0 ? targetIdx : 0;
+                needsRedraw = true;
+                announce("Select target component");
+            } else {
+                closeDynamicParamPicker("Hierarchy Editor");
             }
             break;
         case VIEWS.UPDATE_PROMPT:
@@ -8768,6 +9226,32 @@ function drawKnobParamPicker() {
         });
 
         drawFooter({left: "Back: targets", right: "Click: assign"});
+    }
+}
+
+function drawDynamicParamPicker() {
+    clear_screen();
+
+    if (dynamicPickerMode === "param") {
+        drawHeader("Select Param");
+        drawMenuList({
+            items: dynamicPickerParams,
+            selectedIndex: dynamicPickerIndex,
+            listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
+            getLabel: (item) => item.label || item.key || "",
+            getValue: () => ""
+        });
+        drawFooter({left: "Back: targets", right: "Click: select"});
+    } else {
+        drawHeader("Select Target");
+        drawMenuList({
+            items: dynamicPickerTargets,
+            selectedIndex: dynamicPickerIndex,
+            listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
+            getLabel: (item) => item.label || item.id || "",
+            getValue: () => ""
+        });
+        drawFooter({left: "Back: cancel", right: "Click: select"});
     }
 }
 
@@ -9711,6 +10195,9 @@ globalThis.tick = function() {
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             drawKnobParamPicker();
+            break;
+        case VIEWS.DYNAMIC_PARAM_PICKER:
+            drawDynamicParamPicker();
             break;
         case VIEWS.STORE_PICKER_CATEGORIES:
             drawStorePickerCategories();

--- a/tests/host/test_chain_mod_base_effective_semantics.sh
+++ b/tests/host/test_chain_mod_base_effective_semantics.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'chain_mod_update_base_from_set_param' "$file"; then
+  echo "FAIL: missing base update hook for set_param path" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_apply_effective_value' "$file"; then
+  echo "FAIL: missing effective value apply helper" >&2
+  exit 1
+fi
+if ! rg -Fq 'if (chain_mod_is_target_active' "$file"; then
+  echo "FAIL: set/get flow missing mod-target active guard" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_get_base_for_subkey' "$file"; then
+  echo "FAIL: missing base-value getter helper for UI edit flows" >&2
+  exit 1
+fi
+
+echo "PASS: base/effective modulation semantics hooks are present"

--- a/tests/host/test_chain_mod_child_prefix_lookup_hooks.sh
+++ b/tests/host/test_chain_mod_child_prefix_lookup_hooks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'static int chain_param_key_matches\(' "$file"; then
+  echo "FAIL: missing chain_param_key_matches helper for modulation key matching" >&2
+  exit 1
+fi
+if ! rg -q '\*\(suffix - 1\) != '\''_'\''' "$file"; then
+  echo "FAIL: child-prefix key matching delimiter check is missing" >&2
+  exit 1
+fi
+if ! rg -q 'isdigit\(\(unsigned char\)\*p\)' "$file"; then
+  echo "FAIL: child-prefix key matching does not validate numeric child index segment" >&2
+  exit 1
+fi
+if ! rg -q 'for \(const char \*p = idx_start; p < idx_end; p\+\+\)' "$file"; then
+  echo "FAIL: child-prefix key matching does not isolate the immediate child index segment" >&2
+  exit 1
+fi
+if ! rg -q 'chain_param_key_matches\(key, inst->synth_params\[i\]\.key\)' "$file"; then
+  echo "FAIL: synth modulation metadata lookup is not using child-prefix matching" >&2
+  exit 1
+fi
+
+echo "PASS: chain modulation metadata lookup supports child-prefixed parameter keys"

--- a/tests/host/test_chain_mod_dynamic_param_lookup.sh
+++ b/tests/host/test_chain_mod_dynamic_param_lookup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'static int parse_chain_params_array_json\(' "$file"; then
+  echo "FAIL: missing runtime chain_params array parser" >&2
+  exit 1
+fi
+if ! rg -q 'static int chain_mod_refresh_target_param_cache\(' "$file"; then
+  echo "FAIL: missing runtime target param cache refresh helper" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_refresh_target_param_cache\(inst, target\)' "$file"; then
+  echo "FAIL: find_param_by_key does not retry through runtime cache refresh" >&2
+  exit 1
+fi
+if ! rg -q 'static void chain_mod_clear_target_entry\(' "$file"; then
+  echo "FAIL: missing targeted modulation clear helper for stale mappings" >&2
+  exit 1
+fi
+if ! rg -Fq 'if (!pinfo) {' "$file" || ! rg -q 'chain_mod_clear_target_entry\(inst, stale, 0\);' "$file"; then
+  echo "FAIL: missing stale-target cleanup when modulation metadata lookup fails" >&2
+  exit 1
+fi
+if ! rg -q 'strcmp\(subkey, "plugin_id"\) == 0' "$file"; then
+  echo "FAIL: missing plugin_id cache invalidation hook for dynamic FX params" >&2
+  exit 1
+fi
+
+echo "PASS: dynamic param lookup and stale-target modulation cleanup hooks are present"

--- a/tests/host/test_chain_mod_host_api_surface.sh
+++ b/tests/host/test_chain_mod_host_api_surface.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file_api="src/host/plugin_api_v1.h"
+file_chain="src/modules/chain/dsp/chain_host.c"
+
+# Host API should expose modulation callback hooks.
+if ! rg -q 'mod_emit_value' "$file_api"; then
+  echo "FAIL: host_api_v1 missing mod_emit_value callback" >&2
+  exit 1
+fi
+if ! rg -q 'mod_clear_source' "$file_api"; then
+  echo "FAIL: host_api_v1 missing mod_clear_source callback" >&2
+  exit 1
+fi
+if ! rg -q 'mod_host_ctx' "$file_api"; then
+  echo "FAIL: host_api_v1 missing mod_host_ctx pointer" >&2
+  exit 1
+fi
+
+# Chain host should wire callbacks for instance host API.
+if ! rg -q 'inst->subplugin_host_api.mod_emit_value' "$file_chain"; then
+  echo "FAIL: chain host instance API missing mod_emit_value wiring" >&2
+  exit 1
+fi
+
+echo "PASS: modulation host API surface is present"

--- a/tests/host/test_chain_mod_int_enum_safeguard_hooks.sh
+++ b/tests/host/test_chain_mod_int_enum_safeguard_hooks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q '#define MOD_INT_ENUM_MIN_INTERVAL_MS 50' "$file"; then
+  echo "FAIL: missing global int/enum modulation min-interval constant" >&2
+  exit 1
+fi
+if ! rg -q 'static void chain_mod_apply_effective_value\(chain_instance_t \*inst, mod_target_state_t \*entry, int force_write\)' "$file"; then
+  echo "FAIL: chain_mod_apply_effective_value force-write signature missing" >&2
+  exit 1
+fi
+if ! rg -q 'if \(entry->type == KNOB_TYPE_INT \|\| entry->type == KNOB_TYPE_ENUM\)' "$file"; then
+  echo "FAIL: missing generic int/enum modulation throttle guard" >&2
+  exit 1
+fi
+if ! rg -q 'entry->last_applied_ms > 0 && \(now_ms - entry->last_applied_ms\) < min_interval_ms' "$file"; then
+  echo "FAIL: missing time-based modulation throttle check" >&2
+  exit 1
+fi
+if rg -q 'strcmp\(inst->current_synth_module, "minijv"\) == 0' "$file"; then
+  echo "FAIL: modulation throttle must not be Mini-JV specific" >&2
+  exit 1
+fi
+if ! rg -q 'if \(\(int\)entry->effective_value == \(int\)entry->last_applied_value\)' "$file"; then
+  echo "FAIL: integer modulation dedupe guard missing" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_apply_effective_value\(inst, entry, 1\)' "$file"; then
+  echo "FAIL: force-write restore path missing on modulation clear" >&2
+  exit 1
+fi
+
+echo "PASS: chain modulation includes global int/enum flood safeguards"

--- a/tests/host/test_chain_mod_module_swap_invalidation_hooks.sh
+++ b/tests/host/test_chain_mod_module_swap_invalidation_hooks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'static void chain_mod_clear_target_entries\(' "$file"; then
+  echo "FAIL: missing helper to clear modulation entries for a specific target" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_clear_target_entries\(inst, "synth", 0\);' "$file"; then
+  echo "FAIL: synth unload path does not clear modulation entries without base restore" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_clear_target_entries\(inst, target_name, 0\);' "$file"; then
+  echo "FAIL: audio FX slot unload path does not clear target modulation entries" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_clear_target_entries\(inst, target, 0\);' "$file"; then
+  echo "FAIL: MIDI FX unload path does not clear per-slot modulation entries" >&2
+  exit 1
+fi
+
+echo "PASS: module unload/swap paths clear modulation target entries"

--- a/tests/host/test_chain_mod_multi_source_sum_hooks.sh
+++ b/tests/host/test_chain_mod_multi_source_sum_hooks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'typedef struct mod_source_contribution' "$file"; then
+  echo "FAIL: missing per-source modulation contribution struct" >&2
+  exit 1
+fi
+if ! rg -q 'sources\[MAX_MOD_SOURCES_PER_TARGET\]' "$file"; then
+  echo "FAIL: modulation target state does not store per-source contributions" >&2
+  exit 1
+fi
+if ! rg -q 'static float chain_mod_sum_contributions\(' "$file"; then
+  echo "FAIL: missing contribution summing helper" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_find_or_alloc_source_contribution\(' "$file"; then
+  echo "FAIL: missing source allocation path for per-source contributions" >&2
+  exit 1
+fi
+if ! rg -q 'chain_mod_remove_source_contribution\(' "$file"; then
+  echo "FAIL: missing per-source contribution removal helper" >&2
+  exit 1
+fi
+if ! rg -q 'source_entry->contribution =' "$file"; then
+  echo "FAIL: modulation emit path is not writing per-source contribution values" >&2
+  exit 1
+fi
+
+echo "PASS: modulation runtime supports additive per-source contribution summing"

--- a/tests/host/test_chain_mod_range_scaled_depth.sh
+++ b/tests/host/test_chain_mod_range_scaled_depth.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'float range_span = entry->max_val - entry->min_val;' "$file"; then
+  echo "FAIL: missing modulation range span computation" >&2
+  exit 1
+fi
+if ! rg -Fq 'if (range_span <= 0.0f) {' "$file"; then
+  echo "FAIL: missing range span fallback guard" >&2
+  exit 1
+fi
+if ! rg -q 'float range_scale = bipolar \? \(0.5f \* range_span\) : range_span;' "$file"; then
+  echo "FAIL: missing polarity-aware range scaling" >&2
+  exit 1
+fi
+if ! rg -q 'entry->contribution = \(\(mod_signal \* depth\) \+ offset\) \* range_scale;' "$file"; then
+  echo "FAIL: modulation contribution is not range-scaled" >&2
+  exit 1
+fi
+
+echo "PASS: modulation depth/offset is scaled to target parameter range"

--- a/tests/host/test_chain_mod_runtime_state.sh
+++ b/tests/host/test_chain_mod_runtime_state.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'typedef struct mod_target_state' "$file"; then
+  echo "FAIL: missing mod_target_state definition" >&2
+  exit 1
+fi
+if ! rg -q 'mod_target_state_t mod_targets' "$file"; then
+  echo "FAIL: chain instance missing mod_targets storage" >&2
+  exit 1
+fi
+if ! rg -q 'static int chain_mod_emit_value' "$file"; then
+  echo "FAIL: missing chain_mod_emit_value callback" >&2
+  exit 1
+fi
+if ! rg -q 'static void chain_mod_clear_source' "$file"; then
+  echo "FAIL: missing chain_mod_clear_source callback" >&2
+  exit 1
+fi
+
+echo "PASS: modulation runtime state surface is present"

--- a/tests/host/test_chain_mod_slot_agnostic_wiring.sh
+++ b/tests/host/test_chain_mod_slot_agnostic_wiring.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'inst->subplugin_host_api.mod_emit_value = chain_mod_emit_value' "$file"; then
+  echo "FAIL: instance host API missing mod_emit_value wiring" >&2
+  exit 1
+fi
+if ! rg -q 'inst->subplugin_host_api.mod_clear_source = chain_mod_clear_source' "$file"; then
+  echo "FAIL: instance host API missing mod_clear_source wiring" >&2
+  exit 1
+fi
+if ! rg -q 'inst->subplugin_host_api.mod_host_ctx = inst' "$file"; then
+  echo "FAIL: instance host API missing mod_host_ctx wiring" >&2
+  exit 1
+fi
+if ! rg -q 'g_subplugin_host_api.mod_emit_value = chain_mod_emit_value' "$file"; then
+  echo "FAIL: v1 host API copy missing mod_emit_value wiring" >&2
+  exit 1
+fi
+
+echo "PASS: slot-agnostic modulation callback wiring is present"

--- a/tests/host/test_chain_mod_time_gate_hooks.sh
+++ b/tests/host/test_chain_mod_time_gate_hooks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q '#define MOD_INT_ENUM_MIN_INTERVAL_MS 50' "$file"; then
+  echo "FAIL: missing global int/enum modulation min-interval constant" >&2
+  exit 1
+fi
+if ! rg -q 'uint64_t last_applied_ms;' "$file"; then
+  echo "FAIL: modulation target state missing last_applied_ms timestamp" >&2
+  exit 1
+fi
+if ! rg -q 'get_time_ms\(\)' "$file"; then
+  echo "FAIL: modulation path is not using monotonic time for gating" >&2
+  exit 1
+fi
+if ! rg -q 'if \(entry->last_applied_ms > 0 && \(now_ms - entry->last_applied_ms\) < min_interval_ms\)' "$file"; then
+  echo "FAIL: missing global time-based modulation throttle guard" >&2
+  exit 1
+fi
+if rg -q 'strcmp\(inst->current_synth_module, "minijv"\) == 0' "$file"; then
+  echo "FAIL: modulation throttle must not be Mini-JV specific" >&2
+  exit 1
+fi
+
+echo "PASS: chain modulation includes global time-based int/enum rate limiting"


### PR DESCRIPTION
## Summary
This PR contains only the core infrastructure required for parameter modulation support in modules.

It adds:
- Chain-host modulation API/runtime support
- Non-destructive base/effective parameter semantics
- Range-aware depth scaling for target parameters
- Robust target resolution for dynamic/child-prefixed params
- Standardized metadata-driven picker types in Shadow UI
- Regression tests and documentation updates

## Core Changes
- Added modulation callback/API surface in chain host runtime
- Added runtime modulation state model (base vs effective values)
- Enforced non-destructive parameter semantics during modulation
- Added modulation depth scaling to target param min/max range
- Improved lookup for dynamic and child-prefixed target params
- Added int/enum-safe modulation write throttling in core path
- Added fail-silent behavior when target module/param no longer exists
- Added metadata-driven standardized picker plumbing in Shadow UI for chain params

## Scope Clarification
- No Param LFO module implementation is included in this PR
- No MIDI FX / Audio FX module bundling is included in this PR
- This PR is core plumbing only

## Test Plan
- [x] Build host successfully  
  - `/bin/zsh -lc 'PATH=/opt/homebrew/bin:$PATH ./scripts/build.sh'`
- [x] Install local build  
  - `./scripts/install.sh local --skip-confirmation --skip-modules`
- [x] Run chain modulation regression tests  
  - `tests/host/test_chain_mod_*.sh`
- [x] Run shadow picker/runtime regression tests relevant to core behavior

## Documentation
- Updated `docs/API.md`
- Updated `docs/MODULES.md` for standardized picker parameter types

## Risks
- Third-party module metadata quality may affect dynamic target menu quality
- Plugin-specific parameter behavior can still vary under heavy modulation workloads
