### PR TITLE
Text Entry: Text Preview toggle & tail-truncated title

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -78,7 +78,9 @@ import {
     drawTextEntry,
     tickTextEntry,
     padSelectGlobal,
-    setPadSelectGlobal
+    setPadSelectGlobal,
+    textPreviewGlobal,
+    setTextPreviewGlobal
 } from '/data/UserData/move-anything/shared/text_entry.mjs';
 
 import {
@@ -690,7 +692,8 @@ const GLOBAL_SETTINGS_SECTIONS = [
             { key: "display_mirror", label: "Mirror Display", type: "bool" },
             { key: "overlay_knobs", label: "Overlay Knobs", type: "enum",
               options: ["+Shift", "+Jog Touch", "Off", "Native"], values: [0, 1, 2, 3] },
-            { key: "pad_typing", label: "Pad Typing", type: "bool" }
+            { key: "pad_typing", label: "Pad Typing", type: "bool" },
+            { key: "text_preview", label: "Text Preview", type: "bool" }
         ]
     },
     {
@@ -4204,6 +4207,31 @@ function loadPadTypingConfig() {
     } catch (e) {}
 }
 
+function saveTextPreviewConfig() {
+    try {
+        const configPath = "/data/UserData/move-anything/shadow_config.json";
+        let config = {};
+        try {
+            const content = host_read_file(configPath);
+            if (content) config = JSON.parse(content);
+        } catch (e) {}
+        config.text_preview = textPreviewGlobal;
+        host_write_file(configPath, JSON.stringify(config, null, 2));
+    } catch (e) {}
+}
+
+function loadTextPreviewConfig() {
+    try {
+        const configPath = "/data/UserData/move-anything/shadow_config.json";
+        const content = host_read_file(configPath);
+        if (!content) return;
+        const config = JSON.parse(content);
+        if (config.text_preview !== undefined) {
+            setTextPreviewGlobal(config.text_preview);
+        }
+    } catch (e) {}
+}
+
 /* Load master FX chain from config at startup.
  * The shim handles actual module loading + state restore from
  * slot_state/master_fx_N.json files at boot. This function just
@@ -7044,6 +7072,9 @@ function getMasterFxSettingValue(setting) {
     if (setting.key === "pad_typing") {
         return padSelectGlobal ? "On" : "Off";
     }
+    if (setting.key === "text_preview") {
+        return textPreviewGlobal ? "On" : "Off";
+    }
     return "-";
 }
 
@@ -7194,6 +7225,12 @@ function adjustMasterFxSetting(setting, delta) {
     if (setting.key === "pad_typing") {
         setPadSelectGlobal(!padSelectGlobal);
         savePadTypingConfig();
+        return;
+    }
+
+    if (setting.key === "text_preview") {
+        setTextPreviewGlobal(!textPreviewGlobal);
+        saveTextPreviewConfig();
         return;
     }
 }
@@ -9696,6 +9733,7 @@ globalThis.init = function() {
     loadAutoUpdateConfig();
     loadBrowserPreviewConfig();
     loadPadTypingConfig();
+    loadTextPreviewConfig();
 
     /* Legacy: migrate old single master_fx config to slot 1 */
     const savedMasterFx = loadMasterFxFromConfig();

--- a/src/shared/text_entry.mjs
+++ b/src/shared/text_entry.mjs
@@ -37,6 +37,10 @@ const MIDI_NOTE_ON = 0x90;
 export let padSelectGlobal = false;
 export function setPadSelectGlobal(enabled) { padSelectGlobal = !!enabled; }
 
+/* Global text preview setting — toggled via Settings > Display > Text Preview */
+export let textPreviewGlobal = true;
+export function setTextPreviewGlobal(enabled) { textPreviewGlobal = !!enabled; }
+
 /* Tunable pad entry parameters */
 export let padConfig = {
     velocityThreshold: 31,
@@ -500,6 +504,7 @@ function appendToBuffer(char) {
  * Show the preview screen
  */
 function showPreview(fromPad) {
+    if (!textPreviewGlobal) return;
     state.showingPreview = true;
     state.previewTimeout = fromPad ? PREVIEW_DURATION_PAD_TICKS : PREVIEW_DURATION_TICKS;
 }
@@ -610,7 +615,7 @@ function drawKeyboardScreen() {
         const combined = `${state.title}: ${bufferDisplay}`;
         const maxChars = Math.floor((SCREEN_WIDTH - 4) / 6);  /* 6px per char */
         const displayText = combined.length > maxChars
-            ? combined.slice(0, maxChars - 1) + '…'
+            ? '…' + combined.slice(-(maxChars - 1))
             : combined;
         print(2, TITLE_Y, displayText, 1);
     } else {


### PR DESCRIPTION
### Changes

**`src/shared/text_entry.mjs`**

- Added `textPreviewGlobal` flag (default `true`) and `setTextPreviewGlobal()` export, following the same pattern as `padSelectGlobal`
- `showPreview()` now respects `textPreviewGlobal` — when disabled, character entry is immediate without the preview interstitial
- Title line in `drawKeyboardScreen()` now tail-truncates: when the combined title + buffer exceeds the display width, the *end* of the string (most recently typed characters) stays visible instead of being cut off

**`src/shadow/shadow_ui.js`**

- Imported `textPreviewGlobal` / `setTextPreviewGlobal` from `text_entry.mjs`
- Added **"Text Preview"** toggle to **Settings → Display**, alongside the existing "Pad Typing" setting
- Added `saveTextPreviewConfig()` / `loadTextPreviewConfig()` (persisted to `shadow_config.json`, key `text_preview`)
- `loadTextPreviewConfig()` called at startup

### Behaviour

| Setting | Effect |
|---|---|
| Text Preview: On (default) | After typing a character, the preview screen briefly appears showing the current buffer |
| Text Preview: Off | Preview is skipped; keyboard stays visible at all times |