### PR TITLE
Add Super Boum to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -481,6 +481,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "superboum",
+      "name": "Super Boum",
+      "description": "OTO Boum-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
+      "author": "fillioning",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/super-boum-move",
+      "default_branch": "main",
+      "asset_name": "super-boum-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
       "id": "performance-fx",
       "name": "Performance FX",
       "description": "32 punch-in audio FX with pressure control, latch, and tempo sync",


### PR DESCRIPTION
## Summary
- Adds **Super Boum** (`superboum`) to the module catalog
- OTO Boum-inspired master bus destructor & harmonic sculptor (audio_fx)
- Features: 8-band filterbank, 4 distortion modes, 10 preamp models (2x oversampled), vocoder mode via mic/line-in, tape stage, output limiter
- Repo: https://github.com/fillioning/super-boum-move
- Release: https://github.com/fillioning/super-boum-move/releases/tag/v1.0.0

## Test plan
- [ ] Verify `release.json` is accessible at `fillioning/super-boum-move`
- [ ] Confirm module installs and loads on Move via Module Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)