### PR TITLE
Add Verglas to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -535,6 +535,17 @@
       "default_branch": "main",
       "asset_name": "sconnect-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "verglas",
+      "name": "Verglas",
+      "description": "Mutable Instruments Clouds granular processor — granular, stretch, looper, and spectral modes with output filters and limiter",
+      "author": "Emilie Gillet (port: fillioning)",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/move-everything-verglas",
+      "default_branch": "main",
+      "asset_name": "verglas-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **Verglas** (Mutable Instruments Clouds granular processor) to the module catalog
- Port of Emilie Gillet's [Clouds](https://github.com/pichenettes/eurorack) (STM32F code, MIT license) as audio FX for Ableton Move
- 4 processing modes: Granular, Stretch (WSOLA), Looper, Spectral (phase vocoder)
- Extended with output HPF/LPF filters, low-shelf EQ, and tape-style soft limiter
- 20 parameters across 2 pages (Verglas + Filters)
- Repo: [fillioning/move-everything-verglas](https://github.com/fillioning/move-everything-verglas)
- Latest release: [v1.1.0](https://github.com/fillioning/move-everything-verglas/releases/tag/v1.1.0) — volume fixes, texture smoothing, low-shelf EQ

## Catalog entry
```json
{
  "id": "verglas",
  "name": "Verglas",
  "description": "Mutable Instruments Clouds granular processor — granular, stretch, looper, and spectral modes with output filters and limiter",
  "author": "Emilie Gillet (port: fillioning)",
  "component_type": "audio_fx",
  "github_repo": "fillioning/move-everything-verglas",
  "default_branch": "main",
  "asset_name": "verglas-module.tar.gz",
  "min_host_version": "0.3.0"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)