### PR TITLE
Remove m8 module from module store catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,6 @@ External modules are maintained in separate repositories and available via Modul
 - `tapedelay` - Tape delay with flutter and saturation
 
 **Utilities/Overtake:**
-- `m8` - Dirtywave M8 Launchpad Pro emulator
 - `sidcontrol` - SID Control for SIDaster III
 - `controller` - MIDI Controller with 16 banks (built-in)
 

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -46,17 +46,6 @@
       "requires": "SFZ or DecentSampler instrument folders (place in module's instruments/ folder)"
     },
     {
-      "id": "m8",
-      "name": "M8 LPP Emulator",
-      "description": "Novation Launchpad Pro emulation for Dirtywave M8",
-      "author": "bobbydigitales (port: charlesvestal)",
-      "component_type": "overtake",
-      "github_repo": "charlesvestal/move-everything-m8",
-      "default_branch": "main",
-      "asset_name": "m8-module.tar.gz",
-      "min_host_version": "0.3.6"
-    },
-    {
       "id": "minijv",
       "name": "Mini-JV",
       "description": "ROM-based PCM rompler emulator",


### PR DESCRIPTION
Remove the M8 LPP Emulator entry from module-catalog.json and the corresponding reference in CLAUDE.md.

https://claude.ai/code/session_01CUQMN4YvMxogUjvG3qLz2a