### PR TITLE
Document fork provenance and license terms in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,5 +15,13 @@ Full license text: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 
 ---
 
+## Fork Provenance
+
+This project (Move Everything) is forked from [Move Anything](https://github.com/bobbydigitales/move-anything) by Bobby Digitales. At the time of forking, the upstream repository was licensed solely under CC BY-NC-SA 4.0, without additional restrictions. The upstream repository has since added supplementary terms regarding AI training and AI-generated derivative works. Those additional terms were not part of the license at the time this fork was created, and this project does not incorporate any upstream changes made after the fork.
+
+This fork continues under CC BY-NC-SA 4.0 as it was received.
+
+---
+
 This project includes third-party code under various licenses.
 See THIRD_PARTY_LICENSES for details.


### PR DESCRIPTION
The upstream Move Anything repo has added AI training and derivative
restrictions on top of CC BY-NC-SA 4.0. This documents that the fork
was made before those terms were added and that no upstream changes
have been incorporated since.

https://claude.ai/code/session_014rC9sGUDZHSAKXQsNtBDsH