### PR TITLE
Add Structor audio FX module to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -503,14 +503,14 @@
       "min_host_version": "0.3.0"
     },
     {
-      "id": "superboum",
-      "name": "Super Boum",
-      "description": "OTO Boum-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
+      "id": "superboom",
+      "name": "Super Boom",
+      "description": "Analog warming unit-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
       "author": "fillioning",
       "component_type": "audio_fx",
-      "github_repo": "fillioning/super-boum-move",
+      "github_repo": "fillioning/super-boom-move",
       "default_branch": "main",
-      "asset_name": "super-boum-module.tar.gz",
+      "asset_name": "super-boom-module.tar.gz",
       "min_host_version": "0.3.0"
     },
     {

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -494,7 +494,7 @@
     {
       "id": "superboom",
       "name": "Super Boom",
-      "description": "Analog warming unit-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
+      "description": "OTO Boum-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
       "author": "fillioning",
       "component_type": "audio_fx",
       "github_repo": "fillioning/super-boom-move",
@@ -578,6 +578,17 @@
       "github_repo": "fillioning/MovePunchFX",
       "default_branch": "main",
       "asset_name": "punchfx-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "structor",
+      "name": "Structor",
+      "description": "Musique concrete sound deconstructor/reconstructor — 8 algorithmic modes with per-grain DJ filtering, randomization, and sequencer",
+      "author": "fillioning",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/move-everything-structor",
+      "default_branch": "main",
+      "asset_name": "structor-module.tar.gz",
       "min_host_version": "0.3.0"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds **Structor** to the module catalog — a musique concrete sound deconstructor/reconstructor audio FX
- 8 algorithmic reconstruction modes (Random, Pitch Up/Down, Density Up, Time Warp, Dens Arp, Deltarupt, Spec Warp)
- Per-grain Isolator3 DJ LP/HP filter, randomization system with sequencer
- Original DSP with FFT spectral analysis (PFFFT)

**Repo:** [fillioning/move-everything-structor](https://github.com/fillioning/move-everything-structor)  
**Release:** [v0.1.0](https://github.com/fillioning/move-everything-structor/releases/tag/v0.1.0)  
**Asset:** `structor-module.tar.gz`

## Test plan
- [ ] Module appears in Module Store
- [ ] Download and install succeeds
- [ ] Module loads in Tracks FX and Master FX
- [ ] All 8 modes produce audio
- [ ] Knob overlay works (all 8 knobs + context-sensitive Special)

🤖 Generated with [Claude Code](https://claude.com/claude-code)