### PR TITLE
Add Punch-In FX to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -550,7 +550,7 @@
     {
       "id": "verglas",
       "name": "Verglas",
-      "description": "Mutable Instruments Clouds granular processor — granular, stretch, looper, and spectral modes with output filters and limiter",
+      "description": "Mutable Instruments Clouds granular processor \u00e2\u20ac\u201d granular, stretch, looper, and spectral modes with output filters and limiter",
       "author": "Emilie Gillet (port: fillioning)",
       "component_type": "audio_fx",
       "github_repo": "fillioning/move-everything-verglas",
@@ -572,13 +572,24 @@
     {
       "id": "dragonfly-hall",
       "name": "Dragonfly Hall",
-      "description": "Dragonfly Hall Reverb — lush hall reverb with 25 presets and full parameter control",
+      "description": "Dragonfly Hall Reverb \u00e2\u20ac\u201d lush hall reverb with 25 presets and full parameter control",
       "author": "bradcoomber",
       "component_type": "audio_fx",
       "github_repo": "wolfrenegade1976/move-anything-dragonfly-hall",
       "default_branch": "main",
       "asset_name": "dragonfly-hall-module.tar.gz",
       "min_host_version": "0.1.0"
+    },
+    {
+      "id": "punchfx",
+      "name": "Punch-In FX",
+      "description": "PO-33 style punch-in effects with pressure control \u2014 16 effects on left 4x4 pad grid",
+      "author": "fillioning",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/MovePunchFX",
+      "default_branch": "main",
+      "asset_name": "punchfx-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **Punch-In FX** (`punchfx`) to the module catalog
- PO-33 K.O. style punch-in effects for Ableton Move
- 16 pressure-sensitive effects on the left 4x4 pad grid (Shift+Pad to trigger)
- Up to 3 effects stackable in series
- Effects: loop (4 divisions), unison/chorus, octave up/down, stutter, scratch, 6/8 quantize, retrigger, reverse
- Knobs: BPM (auto-syncs MIDI clock), Volume, Dry/Wet
- Repo: [fillioning/MovePunchFX](https://github.com/fillioning/MovePunchFX)
- Release: [v0.1.0](https://github.com/fillioning/MovePunchFX/releases/tag/v0.1.0)

## Test plan
- [ ] Verify `release.json` resolves correctly
- [ ] Verify `src/module.json` exists (desktop installer compatibility)
- [ ] Install from Module Store on device
- [ ] Test Shift+Pad triggering for all 16 effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)