### PR TITLE
Rename Super Boum to Super Boom in module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -503,14 +503,14 @@
       "min_host_version": "0.3.0"
     },
     {
-      "id": "superboum",
-      "name": "Super Boum",
-      "description": "OTO Boum-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
+      "id": "superboom",
+      "name": "Super Boom",
+      "description": "Analog warming unit-inspired master bus destructor with 8-band filterbank, 10 preamp models, vocoder mode, and tape stage",
       "author": "fillioning",
       "component_type": "audio_fx",
-      "github_repo": "fillioning/super-boum-move",
+      "github_repo": "fillioning/super-boom-move",
       "default_branch": "main",
-      "asset_name": "super-boum-module.tar.gz",
+      "asset_name": "super-boom-module.tar.gz",
       "min_host_version": "0.3.0"
     },
     {


### PR DESCRIPTION
## Summary
- Rename "Super Boum" to "Super Boom" across module catalog entry to avoid potential trademark concerns with OTO hardware
- Updated: module ID (`superboom`), display name, description, repo URL (`fillioning/super-boom-move`), and asset name (`super-boom-module.tar.gz`)
- Repo has been renamed on GitHub and v1.3.0 released with the new naming

## Test plan
- [ ] Verify the module installs from Module Store with updated catalog entry
- [ ] Confirm `release.json` at new repo URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)