### PR TITLE
Add Weird Dreams to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -539,7 +539,7 @@
     {
       "id": "verglas",
       "name": "Verglas",
-      "description": "Mutable Instruments Clouds granular processor \u00e2\u20ac\u201d granular, stretch, looper, and spectral modes with output filters and limiter",
+      "description": "Mutable Instruments Clouds granular processor â€” granular, stretch, looper, and spectral modes with output filters and limiter",
       "author": "Emilie Gillet (port: fillioning)",
       "component_type": "audio_fx",
       "github_repo": "fillioning/move-everything-verglas",
@@ -561,7 +561,7 @@
     {
       "id": "dragonfly-hall",
       "name": "Dragonfly Hall",
-      "description": "Dragonfly Hall Reverb \u00e2\u20ac\u201d lush hall reverb with 25 presets and full parameter control",
+      "description": "Dragonfly Hall Reverb â€” lush hall reverb with 25 presets and full parameter control",
       "author": "bradcoomber",
       "component_type": "audio_fx",
       "github_repo": "wolfrenegade1976/move-anything-dragonfly-hall",
@@ -572,7 +572,7 @@
     {
       "id": "punchfx",
       "name": "Punch-In FX",
-      "description": "PO-33 style punch-in effects with pressure control \u2014 16 effects on left 4x4 pad grid",
+      "description": "PO-33 style punch-in effects with pressure control — 16 effects on left 4x4 pad grid",
       "author": "fillioning",
       "component_type": "audio_fx",
       "github_repo": "fillioning/MovePunchFX",
@@ -589,6 +589,17 @@
       "github_repo": "fillioning/move-everything-structor",
       "default_branch": "main",
       "asset_name": "structor-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "weird-dreams",
+      "name": "Weird Dreams",
+      "description": "8-voice analog drum machine with 64 kits, 41 voice presets, 96 musical pitch scales, master bus FX — based on WeirdDrums by Daniele Filaretti",
+      "author": "fillioning (DSP: dfilaretti)",
+      "component_type": "sound_generator",
+      "github_repo": "fillioning/move-everything-weird-drum",
+      "default_branch": "master",
+      "asset_name": "weird-dreams-module.tar.gz",
       "min_host_version": "0.3.0"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds **Weird Dreams** (`weird-dreams`) to the module catalog as a `sound_generator`
- 8-voice analog drum machine based on [WeirdDrums](https://github.com/dfilaretti/WeirdDrums) by Daniele Filaretti (MIT)
- Repo: [fillioning/move-everything-weird-drum](https://github.com/fillioning/move-everything-weird-drum)
- Release: [v0.1.0](https://github.com/fillioning/move-everything-weird-drum/releases/tag/v0.1.0)

## Features
- 64 kit presets (classic machines, genre, character, hybrid)
- 41 voice presets across 8 categories (kicks, snares, toms, hi-hats, cymbals, claps, percussion, FX)
- 96 musical pitch scales (8 scale types x 12 root notes) with hardware-tuned frequency ranges
- Master bus: dirty compressor, Isolator3-style DJ filter, Massenburg 8200-inspired 3-band parametric EQ
- Per-voice panning, clap retrigger, continuous waveform morphing
- 12 UI pages

## Test plan
- [ ] Verify module appears in Module Store after catalog update
- [ ] Verify `src/module.json` accessible at `https://raw.githubusercontent.com/fillioning/move-everything-weird-drum/master/src/module.json`
- [ ] Verify release asset downloadable at `https://github.com/fillioning/move-everything-weird-drum/releases/download/v0.1.0/weird-dreams-module.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)