### PR TITLE
Add Wurl — Wurlitzer 200A electric piano

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -645,6 +645,17 @@
       "default_branch": "main",
       "asset_name": "chowtape-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "wurl",
+      "name": "Wurl",
+      "description": "Physically-modeled Wurlitzer 200A electric piano (OpenWurli port)",
+      "author": "hal0zer0 (port: fillioning)",
+      "component_type": "sound_generator",
+      "github_repo": "fillioning/wurl-move",
+      "default_branch": "master",
+      "asset_name": "wurl-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **Wurl** to the module catalog — a physically-modeled Wurlitzer 200A electric piano
- Port of [OpenWurli](https://github.com/hal0zer0/openwurli) (hal0zer0, GPL-3.0) to single-file C
- Repo: [fillioning/wurl-move](https://github.com/fillioning/wurl-move)

## Features
- 7-mode modal reed oscillator with per-note Euler-Bernoulli beam physics
- MLP v2 neural network per-note corrections (trained on real Wurlitzer recordings)
- Full analog chain: pickup → preamp → power amp → speaker (2x oversampled at 88.2kHz)
- Dispersive allpass spring reverb with macro control
- 16-voice polyphony with 5ms crossfade voice stealing
- 8 knobs + 3 menu params, 10 built-in presets

## Test plan
- [ ] Module loads on Move via Module Store
- [ ] All 8 knobs respond correctly
- [ ] Presets cycle via menu and apply in real time
- [ ] Spring reverb sounds clean across the range
- [ ] No CPU spikes with 16-voice polyphony

🤖 Generated with [Claude Code](https://claude.com/claude-code)