### PR TITLE
Improve Shadow/Chain LFO modulation behavior and persistence

### DIFF
--- a/src/host/lfo_common.h
+++ b/src/host/lfo_common.h
@@ -11,7 +11,7 @@
  * ============================================================================ */
 
 #define LFO_COUNT 2
-#define LFO_NUM_DIVISIONS 14
+#define LFO_NUM_DIVISIONS 27
 #define LFO_SHAPE_SINE   0
 #define LFO_SHAPE_TRI    1
 #define LFO_SHAPE_SAW    2
@@ -31,7 +31,8 @@ typedef struct {
     float rate_hz;        /* Free-running rate (0.1-20.0 Hz) */
     int rate_div;         /* Tempo-synced division index */
     int sync;             /* 0=free, 1=tempo-sync */
-    float depth;          /* 0.0-1.0 */
+    float depth;          /* -1.0..1.0 */
+    int bipolar;          /* 0=unipolar (default), 1=bipolar */
     float phase_offset;   /* 0.0-1.0 (displayed as 0-360 degrees) */
     char target[16];      /* Component key (e.g. "synth", "fx1", "fx2") */
     char param[32];       /* Parameter key within target */
@@ -75,20 +76,33 @@ typedef struct {
 } lfo_division_t;
 
 static const lfo_division_t lfo_divisions[LFO_NUM_DIVISIONS] = {
-    { "8bar", 32.0f  },
-    { "4bar", 16.0f  },
-    { "2bar",  8.0f  },
-    { "1/1",   4.0f  },
-    { "1/2",   2.0f  },
-    { "1/4",   1.0f  },
-    { "1/8",   0.5f  },
-    { "1/16",  0.25f },
-    { "1/32",  0.125f },
-    { "1/4T",  1.333f },
-    { "1/8T",  0.667f },
-    { "1/16T", 0.333f },
-    { "1/4D",  1.5f  },
-    { "1/8D",  0.75f },
+    { "16bar", 64.0f   },
+    { "15bar", 60.0f   },
+    { "14bar", 56.0f   },
+    { "13bar", 52.0f   },
+    { "12bar", 48.0f   },
+    { "11bar", 44.0f   },
+    { "10bar", 40.0f   },
+    { "9bar",  36.0f   },
+    { "8bar",  32.0f   },
+    { "7bar",  28.0f   },
+    { "6bar",  24.0f   },
+    { "5bar",  20.0f   },
+    { "4bar",  16.0f   },
+    { "3bar",  12.0f   },
+    { "2bar",   8.0f   },
+    { "1/1",    4.0f   },
+    { "1/1T",   2.667f },
+    { "1/2",    2.0f   },
+    { "1/2T",   1.333f },
+    { "1/4",    1.0f   },
+    { "1/4T",   0.667f },
+    { "1/8",    0.5f   },
+    { "1/8T",   0.333f },
+    { "1/16",   0.25f  },
+    { "1/16T",  0.167f },
+    { "1/32",   0.125f },
+    { "1/32T",  0.083f },
 };
 
 static const char *lfo_shape_names[LFO_NUM_SHAPES] = {

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -48,6 +48,11 @@ master_fx_slot_t shadow_master_fx_slots[MASTER_FX_SLOTS];
 lfo_state_t shadow_master_fx_lfos[MASTER_FX_LFO_COUNT];
 static float mfx_lfo_base_value[MASTER_FX_LFO_COUNT];
 static int mfx_lfo_base_valid[MASTER_FX_LFO_COUNT];
+#define MFX_RUNTIME_CHAIN_PARAMS_MAX 65536
+#define MFX_RUNTIME_CHAIN_PARAMS_REFRESH_MS 500
+static char mfx_runtime_chain_params_cache[MASTER_FX_SLOTS][MFX_RUNTIME_CHAIN_PARAMS_MAX];
+static int mfx_runtime_chain_params_cached[MASTER_FX_SLOTS];
+static uint64_t mfx_runtime_chain_params_last_fetch_ms[MASTER_FX_SLOTS];
 
 /* MIDI out log file */
 FILE *shadow_midi_out_log = NULL;
@@ -588,6 +593,9 @@ void shadow_master_fx_slot_unload(int slot) {
     s->module_path[0] = '\0';
     s->module_id[0] = '\0';
     capture_clear(&s->capture);
+    mfx_runtime_chain_params_cached[slot] = 0;
+    mfx_runtime_chain_params_cache[slot][0] = '\0';
+    mfx_runtime_chain_params_last_fetch_ms[slot] = 0;
 }
 
 void shadow_master_fx_unload_all(void) {
@@ -674,6 +682,9 @@ int shadow_master_fx_slot_load_with_config(int slot, const char *dsp_path, const
     snprintf(module_json_path, sizeof(module_json_path), "%s/module.json", module_dir);
     s->chain_params_cached = 0;
     s->chain_params_cache[0] = '\0';
+    mfx_runtime_chain_params_cached[slot] = 0;
+    mfx_runtime_chain_params_cache[slot][0] = '\0';
+    mfx_runtime_chain_params_last_fetch_ms[slot] = 0;
     FILE *f = fopen(module_json_path, "r");
     if (f) {
         fseek(f, 0, SEEK_END);
@@ -1526,7 +1537,7 @@ typedef struct {
 } lfo_param_meta_t;
 
 static const lfo_param_meta_t mfx_lfo_param_meta[] = {
-    { "depth",        0.0f, 1.0f,  1 },
+    { "depth",       -1.0f, 1.0f,  1 },
     { "rate_hz",      0.1f, 20.0f, 1 },
     { "phase_offset", 0.0f, 1.0f,  1 },
 };
@@ -1537,6 +1548,326 @@ static const lfo_param_meta_t *mfx_lfo_find_param_meta(const char *key) {
         if (strcmp(mfx_lfo_param_meta[j].key, key) == 0) return &mfx_lfo_param_meta[j];
     }
     return NULL;
+}
+
+static const char *mfx_json_skip_ws(const char *p) {
+    while (p && *p &&
+           (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) {
+        p++;
+    }
+    return p;
+}
+
+static const char *mfx_json_find_object_end(const char *obj_start) {
+    if (!obj_start || *obj_start != '{') return NULL;
+
+    int depth = 0;
+    int in_string = 0;
+    int escaped = 0;
+
+    for (const char *p = obj_start; *p; p++) {
+        if (in_string) {
+            if (escaped) {
+                escaped = 0;
+            } else if (*p == '\\') {
+                escaped = 1;
+            } else if (*p == '"') {
+                in_string = 0;
+            }
+            continue;
+        }
+
+        if (*p == '"') {
+            in_string = 1;
+        } else if (*p == '{') {
+            depth++;
+        } else if (*p == '}') {
+            depth--;
+            if (depth == 0) return p;
+        }
+    }
+
+    return NULL;
+}
+
+static int mfx_json_get_string_field(const char *obj_start,
+                                     const char *obj_end,
+                                     const char *field,
+                                     char *out,
+                                     size_t out_len) {
+    if (!obj_start || !obj_end || !field || !out || out_len == 0) return 0;
+
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"%s\"", field);
+    size_t needle_len = strlen(needle);
+
+    const char *cursor = obj_start;
+    while (cursor && cursor < obj_end) {
+        const char *pos = strstr(cursor, needle);
+        if (!pos || pos >= obj_end) break;
+
+        const char *p = mfx_json_skip_ws(pos + needle_len);
+        if (!p || p >= obj_end || *p != ':') {
+            cursor = pos + needle_len;
+            continue;
+        }
+
+        p = mfx_json_skip_ws(p + 1);
+        if (!p || p >= obj_end || *p != '"') {
+            cursor = pos + needle_len;
+            continue;
+        }
+        p++;
+
+        size_t n = 0;
+        int escaped = 0;
+        while (p < obj_end && *p) {
+            if (!escaped && *p == '"') break;
+            if (!escaped && *p == '\\') {
+                escaped = 1;
+                p++;
+                continue;
+            }
+            if (n < out_len - 1) out[n++] = *p;
+            escaped = 0;
+            p++;
+        }
+        out[n] = '\0';
+        return 1;
+    }
+
+    return 0;
+}
+
+static int mfx_json_get_number_field(const char *obj_start,
+                                     const char *obj_end,
+                                     const char *field,
+                                     float *out) {
+    if (!obj_start || !obj_end || !field || !out) return 0;
+
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"%s\"", field);
+    size_t needle_len = strlen(needle);
+
+    const char *cursor = obj_start;
+    while (cursor && cursor < obj_end) {
+        const char *pos = strstr(cursor, needle);
+        if (!pos || pos >= obj_end) break;
+
+        const char *p = mfx_json_skip_ws(pos + needle_len);
+        if (!p || p >= obj_end || *p != ':') {
+            cursor = pos + needle_len;
+            continue;
+        }
+
+        p = mfx_json_skip_ws(p + 1);
+        if (!p || p >= obj_end) break;
+
+        char *endptr = NULL;
+        float val = strtof(p, &endptr);
+        if (endptr && endptr != p && endptr <= obj_end) {
+            *out = val;
+            return 1;
+        }
+
+        cursor = pos + needle_len;
+    }
+
+    return 0;
+}
+
+static int mfx_chain_params_lookup_numeric_meta(const char *chain_params,
+                                                const char *param_key,
+                                                float *out_min,
+                                                float *out_max,
+                                                int *out_is_float);
+static int mfx_chain_params_lookup_default_value(const char *chain_params,
+                                                 const char *param_key,
+                                                 float *out_default);
+
+static uint64_t mfx_now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static int mfx_lfo_refresh_runtime_chain_params(int slot_idx, master_fx_slot_t *mfx) {
+    if (slot_idx < 0 || slot_idx >= MASTER_FX_SLOTS || !mfx || !mfx->instance ||
+        !mfx->api || !mfx->api->get_param) {
+        return 0;
+    }
+
+    uint64_t now_ms = mfx_now_ms();
+    if (mfx_runtime_chain_params_cached[slot_idx] &&
+        (now_ms - mfx_runtime_chain_params_last_fetch_ms[slot_idx]) < MFX_RUNTIME_CHAIN_PARAMS_REFRESH_MS) {
+        return 1;
+    }
+    if (!mfx_runtime_chain_params_cached[slot_idx] &&
+        mfx_runtime_chain_params_last_fetch_ms[slot_idx] > 0 &&
+        (now_ms - mfx_runtime_chain_params_last_fetch_ms[slot_idx]) < MFX_RUNTIME_CHAIN_PARAMS_REFRESH_MS) {
+        return 0;
+    }
+
+    int len = mfx->api->get_param(
+        mfx->instance,
+        "chain_params",
+        mfx_runtime_chain_params_cache[slot_idx],
+        MFX_RUNTIME_CHAIN_PARAMS_MAX
+    );
+    mfx_runtime_chain_params_last_fetch_ms[slot_idx] = now_ms;
+    if (len <= 0) {
+        return 0;
+    }
+
+    int n = len;
+    if (n >= MFX_RUNTIME_CHAIN_PARAMS_MAX) n = MFX_RUNTIME_CHAIN_PARAMS_MAX - 1;
+    mfx_runtime_chain_params_cache[slot_idx][n] = '\0';
+    mfx_runtime_chain_params_cached[slot_idx] = 1;
+    return 1;
+}
+
+static int mfx_lfo_try_runtime_chain_params_meta(int slot_idx,
+                                                 master_fx_slot_t *mfx,
+                                                 const char *param_key,
+                                                 float *out_min,
+                                                 float *out_max,
+                                                 int *out_is_float) {
+    if (!mfx_lfo_refresh_runtime_chain_params(slot_idx, mfx)) {
+        return 0;
+    }
+
+    return mfx_chain_params_lookup_numeric_meta(
+        mfx_runtime_chain_params_cache[slot_idx],
+        param_key,
+        out_min,
+        out_max,
+        out_is_float
+    );
+}
+
+static int mfx_lfo_try_runtime_chain_params_default(int slot_idx,
+                                                    master_fx_slot_t *mfx,
+                                                    const char *param_key,
+                                                    float *out_default) {
+    if (!mfx_lfo_refresh_runtime_chain_params(slot_idx, mfx)) {
+        return 0;
+    }
+
+    return mfx_chain_params_lookup_default_value(
+        mfx_runtime_chain_params_cache[slot_idx],
+        param_key,
+        out_default
+    );
+}
+
+static int mfx_chain_params_lookup_numeric_meta(const char *chain_params,
+                                                const char *param_key,
+                                                float *out_min,
+                                                float *out_max,
+                                                int *out_is_float) {
+    if (!chain_params || !param_key || !param_key[0] ||
+        !out_min || !out_max || !out_is_float) {
+        return 0;
+    }
+
+    const char *p = chain_params;
+    while (p && *p) {
+        const char *obj_start = strchr(p, '{');
+        if (!obj_start) break;
+        const char *obj_end = mfx_json_find_object_end(obj_start);
+        if (!obj_end) break;
+
+        char key_buf[64] = {0};
+        if (mfx_json_get_string_field(obj_start, obj_end, "key", key_buf, sizeof(key_buf)) &&
+            strcmp(key_buf, param_key) == 0) {
+            char type_buf[16] = {0};
+            if (mfx_json_get_string_field(obj_start, obj_end, "type", type_buf, sizeof(type_buf))) {
+                if (strcmp(type_buf, "int") == 0 ||
+                    strcmp(type_buf, "enum") == 0 ||
+                    strcmp(type_buf, "bool") == 0) {
+                    *out_is_float = 0;
+                } else if (strcmp(type_buf, "float") == 0) {
+                    *out_is_float = 1;
+                }
+            }
+
+            /* Keep existing defaults when min/max are missing. */
+            (void)mfx_json_get_number_field(obj_start, obj_end, "min", out_min);
+            (void)mfx_json_get_number_field(obj_start, obj_end, "max", out_max);
+            return 1;
+        }
+
+        p = obj_end + 1;
+    }
+
+    return 0;
+}
+
+static int mfx_chain_params_lookup_default_value(const char *chain_params,
+                                                 const char *param_key,
+                                                 float *out_default) {
+    if (!chain_params || !param_key || !param_key[0] || !out_default) {
+        return 0;
+    }
+
+    const char *p = chain_params;
+    while (p && *p) {
+        const char *obj_start = strchr(p, '{');
+        if (!obj_start) break;
+        const char *obj_end = mfx_json_find_object_end(obj_start);
+        if (!obj_end) break;
+
+        char key_buf[64] = {0};
+        if (mfx_json_get_string_field(obj_start, obj_end, "key", key_buf, sizeof(key_buf)) &&
+            strcmp(key_buf, param_key) == 0) {
+            return mfx_json_get_number_field(obj_start, obj_end, "default", out_default);
+        }
+
+        p = obj_end + 1;
+    }
+
+    return 0;
+}
+
+static void mfx_lfo_update_base_from_set_param(int slot_idx,
+                                               const char *param_key,
+                                               const char *val_str) {
+    if (slot_idx < 0 || slot_idx >= MASTER_FX_SLOTS || !param_key || !param_key[0] || !val_str) {
+        return;
+    }
+
+    char *endptr = NULL;
+    float parsed = strtof(val_str, &endptr);
+    if (!endptr || endptr == val_str) {
+        return;
+    }
+
+    char target_key[8];
+    snprintf(target_key, sizeof(target_key), "fx%d", slot_idx + 1);
+    for (int i = 0; i < MASTER_FX_LFO_COUNT; i++) {
+        lfo_state_t *lfo = &shadow_master_fx_lfos[i];
+        if (strcmp(lfo->target, target_key) != 0) continue;
+        if (strcmp(lfo->param, param_key) != 0) continue;
+        mfx_lfo_base_value[i] = parsed;
+        mfx_lfo_base_valid[i] = 1;
+    }
+}
+
+static int mfx_param_strip_suffix(const char *param_key,
+                                  const char *suffix,
+                                  char *out,
+                                  size_t out_len) {
+    if (!param_key || !suffix || !out || out_len < 2) return 0;
+    size_t key_len = strlen(param_key);
+    size_t suffix_len = strlen(suffix);
+    if (key_len <= suffix_len) return 0;
+    if (strcmp(param_key + key_len - suffix_len, suffix) != 0) return 0;
+
+    size_t bare_len = key_len - suffix_len;
+    if (bare_len >= out_len) return 0;
+    memcpy(out, param_key, bare_len);
+    out[bare_len] = '\0';
+    return 1;
 }
 
 void shadow_master_fx_lfo_tick(int frames) {
@@ -1591,32 +1922,32 @@ void shadow_master_fx_lfo_tick(int frames) {
         /* Determine param min/max and type */
         float p_min = 0.0f, p_max = 1.0f;
         int p_is_float = 1;
+        int have_meta = 0;
 
         if (target_lfo >= 0) {
             /* LFO-to-LFO: use hardcoded metadata */
             p_min = lfo_meta->min_val;
             p_max = lfo_meta->max_val;
             p_is_float = lfo_meta->is_float;
+            have_meta = 1;
         } else if (mfx->chain_params_cached && mfx->chain_params_cache[0]) {
-            char needle[64];
-            snprintf(needle, sizeof(needle), "\"key\":\"%s\"", lfo->param);
-            const char *pos = strstr(mfx->chain_params_cache, needle);
-            if (pos) {
-                const char *block_end = strchr(pos, '}');
-                if (block_end) {
-                    const char *min_pos = strstr(pos, "\"min\":");
-                    if (min_pos && min_pos < block_end) p_min = strtof(min_pos + 6, NULL);
-                    const char *max_pos = strstr(pos, "\"max\":");
-                    if (max_pos && max_pos < block_end) p_max = strtof(max_pos + 6, NULL);
-                    const char *type_pos = strstr(pos, "\"type\":\"");
-                    if (type_pos && type_pos < block_end) {
-                        if (strncmp(type_pos + 8, "int", 3) == 0 ||
-                            strncmp(type_pos + 8, "enum", 4) == 0) {
-                            p_is_float = 0;
-                        }
-                    }
-                }
-            }
+            have_meta = mfx_chain_params_lookup_numeric_meta(
+                mfx->chain_params_cache,
+                lfo->param,
+                &p_min,
+                &p_max,
+                &p_is_float
+            );
+        }
+        if (!have_meta && target_slot >= 0) {
+            have_meta = mfx_lfo_try_runtime_chain_params_meta(
+                target_slot,
+                mfx,
+                lfo->param,
+                &p_min,
+                &p_max,
+                &p_is_float
+            );
         }
 
         /* Rate-limit int/enum updates */
@@ -1638,23 +1969,52 @@ void shadow_master_fx_lfo_tick(int frames) {
                 else if (strcmp(lfo->param, "phase_offset") == 0) mfx_lfo_base_value[i] = tgt->phase_offset;
                 else continue;
                 mfx_lfo_base_valid[i] = 1;
-            } else if (mfx->api->get_param) {
-                char val_buf[64] = {0};
-                int got = mfx->api->get_param(mfx->instance, lfo->param, val_buf, sizeof(val_buf));
-                if (got > 0) {
-                    mfx_lfo_base_value[i] = strtof(val_buf, NULL);
-                    mfx_lfo_base_valid[i] = 1;
-                } else {
-                    continue;
-                }
             } else {
-                continue;
+                int snapped = 0;
+                if (mfx->api->get_param) {
+                    char val_buf[64] = {0};
+                    int got = mfx->api->get_param(mfx->instance, lfo->param, val_buf, sizeof(val_buf));
+                    if (got > 0) {
+                        mfx_lfo_base_value[i] = strtof(val_buf, NULL);
+                        mfx_lfo_base_valid[i] = 1;
+                        snapped = 1;
+                    }
+                }
+                if (!snapped) {
+                    float fallback_base = (p_min + p_max) * 0.5f;
+                    int have_default = 0;
+                    if (mfx->chain_params_cached && mfx->chain_params_cache[0]) {
+                        have_default = mfx_chain_params_lookup_default_value(
+                            mfx->chain_params_cache,
+                            lfo->param,
+                            &fallback_base
+                        );
+                    }
+                    if (!have_default && target_slot >= 0) {
+                        (void)mfx_lfo_try_runtime_chain_params_default(
+                            target_slot,
+                            mfx,
+                            lfo->param,
+                            &fallback_base
+                        );
+                    }
+                    if (fallback_base < p_min) fallback_base = p_min;
+                    if (fallback_base > p_max) fallback_base = p_max;
+                    mfx_lfo_base_value[i] = fallback_base;
+                    mfx_lfo_base_valid[i] = 1;
+                }
             }
         }
 
+        float mod_signal = signal;
+        if (!lfo->bipolar) {
+            mod_signal = (signal + 1.0f) * 0.5f;
+        }
+
         float base = mfx_lfo_base_value[i];
-        float half_range = (p_max - p_min) / 2.0f;
-        float modulated = base + signal * lfo->depth * half_range;
+        float range_span = p_max - p_min;
+        float range_scale = lfo->bipolar ? (0.5f * range_span) : range_span;
+        float modulated = base + (mod_signal * lfo->depth) * range_scale;
 
         /* Clamp */
         if (modulated < p_min) modulated = p_min;
@@ -1715,7 +2075,9 @@ void shadow_inprocess_handle_param_request(void) {
                     lfo->enabled = atoi(shadow_param->value);
                     if (lfo->enabled) {
                         if (lfo->rate_hz < 0.1f) lfo->rate_hz = 1.0f;
-                        if (lfo->depth <= 0.0f) lfo->depth = 0.5f;
+                        if (lfo->depth == 0.0f && !lfo->target[0] && !lfo->param[0]) {
+                            lfo->depth = 0.5f;
+                        }
                     }
                 } else if (strcmp(lfo_param, "shape") == 0) {
                     lfo->shape = atoi(shadow_param->value);
@@ -1731,11 +2093,13 @@ void shadow_inprocess_handle_param_request(void) {
                     if (lfo->rate_div >= LFO_NUM_DIVISIONS) lfo->rate_div = LFO_NUM_DIVISIONS - 1;
                 } else if (strcmp(lfo_param, "sync") == 0) {
                     lfo->sync = atoi(shadow_param->value);
-                    if (lfo->sync && lfo->rate_div == 0) lfo->rate_div = 3;  /* Default to 1/1 */
+                    if (lfo->sync && lfo->rate_div == 0) lfo->rate_div = 15;  /* Default to 1/1 */
                 } else if (strcmp(lfo_param, "depth") == 0) {
                     lfo->depth = strtof(shadow_param->value, NULL);
-                    if (lfo->depth < 0.0f) lfo->depth = 0.0f;
+                    if (lfo->depth < -1.0f) lfo->depth = -1.0f;
                     if (lfo->depth > 1.0f) lfo->depth = 1.0f;
+                } else if (strcmp(lfo_param, "polarity") == 0) {
+                    lfo->bipolar = atoi(shadow_param->value) ? 1 : 0;
                 } else if (strcmp(lfo_param, "phase_offset") == 0) {
                     lfo->phase_offset = strtof(shadow_param->value, NULL);
                     if (lfo->phase_offset < 0.0f) lfo->phase_offset = 0.0f;
@@ -1765,6 +2129,8 @@ void shadow_inprocess_handle_param_request(void) {
                     snprintf(result, sizeof(result), "%d", lfo->sync);
                 } else if (strcmp(lfo_param, "depth") == 0) {
                     snprintf(result, sizeof(result), "%.2f", lfo->depth);
+                } else if (strcmp(lfo_param, "polarity") == 0) {
+                    snprintf(result, sizeof(result), "%d", lfo->bipolar);
                 } else if (strcmp(lfo_param, "phase_offset") == 0) {
                     snprintf(result, sizeof(result), "%.2f", lfo->phase_offset);
                 } else if (strcmp(lfo_param, "target") == 0) {
@@ -1774,10 +2140,10 @@ void shadow_inprocess_handle_param_request(void) {
                 } else if (strcmp(lfo_param, "config") == 0) {
                     snprintf(result, sizeof(result),
                         "{\"enabled\":%d,\"shape\":%d,\"rate_hz\":%.2f,\"rate_div\":%d,"
-                        "\"sync\":%d,\"depth\":%.2f,\"phase_offset\":%.2f,"
+                        "\"sync\":%d,\"depth\":%.2f,\"polarity\":%d,\"phase_offset\":%.2f,"
                         "\"target\":\"%s\",\"target_param\":\"%s\"}",
                         lfo->enabled, lfo->shape, lfo->rate_hz, lfo->rate_div,
-                        lfo->sync, lfo->depth, lfo->phase_offset,
+                        lfo->sync, lfo->depth, lfo->bipolar, lfo->phase_offset,
                         lfo->target, lfo->param);
                 }
                 strncpy(shadow_param->value, result, SHADOW_PARAM_VALUE_LEN - 1);
@@ -1827,6 +2193,7 @@ void shadow_inprocess_handle_param_request(void) {
                 if (eq && mfx->api->set_param) {
                     *eq = '\0';
                     mfx->api->set_param(mfx->instance, shadow_param->value, eq + 1);
+                    mfx_lfo_update_base_from_set_param(mfx_slot, shadow_param->value, eq + 1);
                     *eq = '=';
                     shadow_param->error = 0;
                 } else {
@@ -1835,6 +2202,7 @@ void shadow_inprocess_handle_param_request(void) {
                 shadow_param->result_len = 0;
             } else if (mfx->api && mfx->instance && mfx->api->set_param) {
                 mfx->api->set_param(mfx->instance, param_key, shadow_param->value);
+                mfx_lfo_update_base_from_set_param(mfx_slot, param_key, shadow_param->value);
                 shadow_param->error = 0;
                 shadow_param->result_len = 0;
             } else {
@@ -1842,6 +2210,62 @@ void shadow_inprocess_handle_param_request(void) {
                 shadow_param->result_len = -1;
             }
         } else if (req_type == 2) {  /* GET */
+            if (has_slot_prefix) {
+                char bare_param[64];
+                char target_key[8];
+                snprintf(target_key, sizeof(target_key), "fx%d", mfx_slot + 1);
+
+                if (mfx_param_strip_suffix(param_key, ":modulated", bare_param, sizeof(bare_param))) {
+                    int modulated = 0;
+                    for (int i = 0; i < MASTER_FX_LFO_COUNT; i++) {
+                        lfo_state_t *lfo = &shadow_master_fx_lfos[i];
+                        if (!lfo->enabled) continue;
+                        if (strcmp(lfo->target, target_key) != 0) continue;
+                        if (strcmp(lfo->param, bare_param) != 0) continue;
+                        modulated = 1;
+                        break;
+                    }
+                    snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%d", modulated);
+                    shadow_param->error = 0;
+                    shadow_param->result_len = strlen(shadow_param->value);
+                    shadow_param_publish_response(req_id);
+                    return;
+                }
+
+                if (mfx_param_strip_suffix(param_key, ":base", bare_param, sizeof(bare_param))) {
+                    for (int i = 0; i < MASTER_FX_LFO_COUNT; i++) {
+                        lfo_state_t *lfo = &shadow_master_fx_lfos[i];
+                        if (!lfo->enabled) continue;
+                        if (strcmp(lfo->target, target_key) != 0) continue;
+                        if (strcmp(lfo->param, bare_param) != 0) continue;
+                        if (!mfx_lfo_base_valid[i]) break;
+
+                        snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%.6f", mfx_lfo_base_value[i]);
+                        shadow_param->error = 0;
+                        shadow_param->result_len = strlen(shadow_param->value);
+                        shadow_param_publish_response(req_id);
+                        return;
+                    }
+
+                    if (mfx->api && mfx->instance && mfx->api->get_param) {
+                        int len = mfx->api->get_param(mfx->instance, bare_param,
+                                                       shadow_param->value, SHADOW_PARAM_VALUE_LEN);
+                        if (len >= 0) {
+                            shadow_param->error = 0;
+                            shadow_param->result_len = len;
+                        } else {
+                            shadow_param->error = 10;
+                            shadow_param->result_len = -1;
+                        }
+                    } else {
+                        shadow_param->error = 11;
+                        shadow_param->result_len = -1;
+                    }
+                    shadow_param_publish_response(req_id);
+                    return;
+                }
+            }
+
             if (strcmp(param_key, "module") == 0) {
                 strncpy(shadow_param->value, mfx->module_path, SHADOW_PARAM_VALUE_LEN - 1);
                 shadow_param->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1728,6 +1728,29 @@ static int json_get_int(const char *json, const char *key, int *out) {
     return 0;
 }
 
+/* Simple JSON float extraction - finds "key": number */
+static int json_get_float(const char *json, const char *key, float *out) {
+    char search[128];
+    snprintf(search, sizeof(search), "\"%s\"", key);
+
+    const char *pos = strstr(json, search);
+    if (!pos) return -1;
+
+    /* Find the colon after the key */
+    pos = strchr(pos + strlen(search), ':');
+    if (!pos) return -1;
+
+    /* Skip whitespace */
+    while (*pos && (*pos == ' ' || *pos == '\t' || *pos == ':')) pos++;
+
+    char *endptr = NULL;
+    float value = strtof(pos, &endptr);
+    if (endptr == pos) return -1;
+
+    *out = value;
+    return 0;
+}
+
 static int json_get_section_bounds(const char *json, const char *section_key,
                                    const char **out_start, const char **out_end) {
     char search[64];
@@ -4506,6 +4529,34 @@ static int chain_mod_get_base_for_subkey(chain_instance_t *inst,
     return chain_mod_get_param_string(inst, target, param, buf, buf_len);
 }
 
+/* Optional getter helper: key suffix ':modulated' returns whether a target
+ * currently has at least one active modulation source. */
+static int chain_mod_get_modulated_for_subkey(chain_instance_t *inst,
+                                              const char *target,
+                                              const char *subkey,
+                                              char *buf,
+                                              int buf_len) {
+    if (!inst || !target || !subkey || !buf || buf_len < 2) return -1;
+
+    const size_t suffix_len = 10; /* ":modulated" */
+    const size_t subkey_len = strlen(subkey);
+    if (subkey_len <= suffix_len || strcmp(subkey + subkey_len - suffix_len, ":modulated") != 0) {
+        return -1;
+    }
+
+    char param[64];
+    const size_t param_len = subkey_len - suffix_len;
+    if (param_len == 0 || param_len >= sizeof(param)) return -1;
+    memcpy(param, subkey, param_len);
+    param[param_len] = '\0';
+
+    mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+    if (entry && entry->active && chain_mod_has_active_sources(entry)) {
+        return snprintf(buf, buf_len, "1");
+    }
+    return snprintf(buf, buf_len, "0");
+}
+
 /* Runtime modulation callback (initial stateful implementation).
  * Applies non-destructive contribution math and stores effective values. */
 static int chain_mod_emit_value(void *ctx,
@@ -6336,17 +6387,13 @@ static int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_i
             json_get_int(obj, "sync", &lfo->sync);
             json_get_int(obj, "rate_div", &lfo->rate_div);
 
-            /* Parse floats using json_get_string + strtof */
-            char tmpf[32];
-            if (json_get_string(obj, "rate_hz", tmpf, sizeof(tmpf)) == 0)
-                lfo->rate_hz = strtof(tmpf, NULL);
-            if (json_get_string(obj, "depth", tmpf, sizeof(tmpf)) == 0)
-                lfo->depth = strtof(tmpf, NULL);
-            if (json_get_string(obj, "phase_offset", tmpf, sizeof(tmpf)) == 0)
-                lfo->phase_offset = strtof(tmpf, NULL);
+            json_get_float(obj, "rate_hz", &lfo->rate_hz);
+            json_get_float(obj, "depth", &lfo->depth);
+            json_get_float(obj, "phase_offset", &lfo->phase_offset);
 
             json_get_string(obj, "target", lfo->target, sizeof(lfo->target));
             json_get_string(obj, "target_param", lfo->param, sizeof(lfo->param));
+            json_get_int(obj, "polarity", &lfo->bipolar);
             json_get_int(obj, "retrigger", &lfo->retrigger);
 
             lfo->active = (lfo->enabled && lfo->target[0] && lfo->param[0]);
@@ -7068,7 +7115,7 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                 if (lfo->rate_hz < 0.1f && !lfo->sync) {
                     lfo->rate_hz = 1.0f;
                 }
-                if (lfo->depth <= 0.0f) {
+                if (lfo->depth == 0.0f && !lfo->target[0] && !lfo->param[0]) {
                     lfo->depth = 0.5f;
                 }
                 lfo->active = (lfo->target[0] && lfo->param[0]);
@@ -7087,12 +7134,14 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             if (lfo->rate_div >= LFO_NUM_DIVISIONS) lfo->rate_div = LFO_NUM_DIVISIONS - 1;
         } else if (strcmp(subkey, "sync") == 0) {
             lfo->sync = atoi(val);
-            /* Default to 1/1 (index 3) if rate_div is still at 0 (8bar) */
-            if (lfo->sync && lfo->rate_div == 0) lfo->rate_div = 3;
+            /* Default to 1/1 (index 15) if rate_div is still at 0 (16bar) */
+            if (lfo->sync && lfo->rate_div == 0) lfo->rate_div = 15;
         } else if (strcmp(subkey, "depth") == 0) {
             lfo->depth = strtof(val, NULL);
-            if (lfo->depth < 0.0f) lfo->depth = 0.0f;
+            if (lfo->depth < -1.0f) lfo->depth = -1.0f;
             if (lfo->depth > 1.0f) lfo->depth = 1.0f;
+        } else if (strcmp(subkey, "polarity") == 0) {
+            lfo->bipolar = atoi(val) ? 1 : 0;
         } else if (strcmp(subkey, "phase_offset") == 0) {
             lfo->phase_offset = strtof(val, NULL);
             if (lfo->phase_offset < 0.0f) lfo->phase_offset = 0.0f;
@@ -7656,6 +7705,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             return snprintf(buf, buf_len, "%d", lfo->sync);
         if (strcmp(subkey, "depth") == 0)
             return snprintf(buf, buf_len, "%.2f", lfo->depth);
+        if (strcmp(subkey, "polarity") == 0)
+            return snprintf(buf, buf_len, "%d", lfo->bipolar);
         if (strcmp(subkey, "phase_offset") == 0)
             return snprintf(buf, buf_len, "%.2f", lfo->phase_offset);
         if (strcmp(subkey, "target") == 0)
@@ -7678,11 +7729,11 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             } else {
                 off += snprintf(buf + off, buf_len - off,
                     "\"lfo%d\":{\"enabled\":%d,\"shape\":%d,\"sync\":%d,"
-                    "\"rate_hz\":%.1f,\"rate_div\":%d,\"depth\":%.2f,"
+                    "\"rate_hz\":%.1f,\"rate_div\":%d,\"depth\":%.2f,\"polarity\":%d,"
                     "\"phase_offset\":%.2f,\"target\":\"%s\",\"target_param\":\"%s\","
                     "\"retrigger\":%d}",
                     i + 1, lfo->enabled, lfo->shape, lfo->sync,
-                    lfo->rate_hz, lfo->rate_div, lfo->depth,
+                    lfo->rate_hz, lfo->rate_div, lfo->depth, lfo->bipolar,
                     lfo->phase_offset, lfo->target, lfo->param,
                     lfo->retrigger);
             }
@@ -7814,6 +7865,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         const char *subkey = key + 6;
         int base_result = chain_mod_get_base_for_subkey(inst, "synth", subkey, buf, buf_len);
         if (base_result >= 0) return base_result;
+        int mod_result = chain_mod_get_modulated_for_subkey(inst, "synth", subkey, buf, buf_len);
+        if (mod_result >= 0) return mod_result;
 
         /* Return synth's default forward channel from module.json capabilities */
         if (strcmp(subkey, "default_forward_channel") == 0) {
@@ -7881,6 +7934,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         const char *subkey = key + 4;
         int base_result = chain_mod_get_base_for_subkey(inst, "fx1", subkey, buf, buf_len);
         if (base_result >= 0) return base_result;
+        int mod_result = chain_mod_get_modulated_for_subkey(inst, "fx1", subkey, buf, buf_len);
+        if (mod_result >= 0) return mod_result;
 
         /* For ui_hierarchy: return cached JSON from module.json, fall through to plugin if empty */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->fx_count > 0) {
@@ -7957,6 +8012,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         const char *subkey = key + 4;
         int base_result = chain_mod_get_base_for_subkey(inst, "fx2", subkey, buf, buf_len);
         if (base_result >= 0) return base_result;
+        int mod_result = chain_mod_get_modulated_for_subkey(inst, "fx2", subkey, buf, buf_len);
+        if (mod_result >= 0) return mod_result;
 
         /* For ui_hierarchy: return cached JSON from module.json, fall through to plugin if empty */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->fx_count > 1) {
@@ -8033,6 +8090,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         const char *subkey = key + 9;
         int base_result = chain_mod_get_base_for_subkey(inst, "midi_fx1", subkey, buf, buf_len);
         if (base_result >= 0) return base_result;
+        int mod_result = chain_mod_get_modulated_for_subkey(inst, "midi_fx1", subkey, buf, buf_len);
+        if (mod_result >= 0) return mod_result;
         /* For ui_hierarchy: return cached JSON from module.json, fall through to plugin if empty */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->midi_fx_count > 0) {
             if (inst->midi_fx_ui_hierarchy[0][0]) {
@@ -8099,6 +8158,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         const char *subkey = key + 9;
         int base_result = chain_mod_get_base_for_subkey(inst, "midi_fx2", subkey, buf, buf_len);
         if (base_result >= 0) return base_result;
+        int mod_result = chain_mod_get_modulated_for_subkey(inst, "midi_fx2", subkey, buf, buf_len);
+        if (mod_result >= 0) return mod_result;
         /* For ui_hierarchy: return cached JSON from module.json, fall through to plugin if empty */
         if (strcmp(subkey, "ui_hierarchy") == 0 && inst->midi_fx_count > 1) {
             if (inst->midi_fx_ui_hierarchy[1][0]) {
@@ -8182,7 +8243,7 @@ typedef struct {
 } slot_lfo_param_meta_t;
 
 static const slot_lfo_param_meta_t slot_lfo_param_meta[] = {
-    { "depth",        0.0f, 1.0f  },
+    { "depth",       -1.0f, 1.0f  },
     { "rate_hz",      0.1f, 20.0f },
     { "phase_offset", 0.0f, 1.0f  },
 };
@@ -8262,7 +8323,7 @@ static void lfo_tick(chain_instance_t *inst, int frames) {
             char source_id[8];
             snprintf(source_id, sizeof(source_id), "lfo%d", i + 1);
             chain_mod_emit_value(inst, source_id, lfo->target, lfo->param,
-                                 signal, lfo->depth, 0.0f, 1 /*bipolar*/, 1 /*enabled*/);
+                                 signal, lfo->depth, 0.0f, lfo->bipolar, 1 /*enabled*/);
         }
         /* target_lfo == i: self-targeting, skip */
     }

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1651,6 +1651,10 @@ static void shadow_inprocess_mix_from_buffer(void) {
         }
     }
 
+    /* Tick Master FX LFOs after processing so updated params apply next block.
+     * This mirrors the legacy in-process mix path behavior. */
+    shadow_master_fx_lfo_tick(FRAMES_PER_BLOCK);
+
     /* Capture native bridge source AFTER master FX, BEFORE master volume.
      * This bakes master FX into native bridge resampling while keeping
      * capture independent of master-volume attenuation. */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1347,7 +1347,12 @@ let selectedLfoItem = 0;
 let editingLfoValue = false;
 
 const LFO_SHAPES = ["Sine", "Tri", "Saw", "Square", "S&H", "Swishy"];
-const LFO_DIVISIONS = ["8bar", "4bar", "2bar", "1/1", "1/2", "1/4", "1/8", "1/16", "1/32", "1/4T", "1/8T", "1/16T", "1/4D", "1/8D"];
+const LFO_DIVISIONS = [
+    "16bar", "15bar", "14bar", "13bar", "12bar", "11bar", "10bar", "9bar",
+    "8bar", "7bar", "6bar", "5bar", "4bar", "3bar", "2bar",
+    "1/1", "1/1T", "1/2", "1/2T", "1/4", "1/4T", "1/8", "1/8T",
+    "1/16", "1/16T", "1/32", "1/32T"
+];
 
 /* LFO target picker state */
 let lfoTargetComponents = [];  /* Available components [{key, label}] */
@@ -3240,9 +3245,13 @@ function loadMasterPreset(index, presetName) {
                 if (lfoConfig.target) shadow_set_param(0, pfx + "target", lfoConfig.target);
                 if (lfoConfig.target_param) shadow_set_param(0, pfx + "target_param", lfoConfig.target_param);
                 shadow_set_param(0, pfx + "shape", String(lfoConfig.shape || 0));
+                shadow_set_param(0, pfx + "polarity", String(lfoConfig.polarity || 0));
                 shadow_set_param(0, pfx + "sync", String(lfoConfig.sync || 0));
                 shadow_set_param(0, pfx + "rate_hz", String(lfoConfig.rate_hz || 1.0));
-                shadow_set_param(0, pfx + "rate_div", String(lfoConfig.rate_div || 3));
+                const presetRateDiv = Number.isFinite(Number(lfoConfig.rate_div))
+                    ? Number(lfoConfig.rate_div)
+                    : 15;
+                shadow_set_param(0, pfx + "rate_div", String(presetRateDiv));
                 shadow_set_param(0, pfx + "depth", String(lfoConfig.depth || 0));
                 shadow_set_param(0, pfx + "phase_offset", String(lfoConfig.phase_offset || 0));
                 shadow_set_param(0, pfx + "enabled", String(lfoConfig.enabled || 0));
@@ -4514,6 +4523,21 @@ function saveMasterFxChainConfig() {
         config.master_fx_chain = {
             preset_name: currentMasterPresetName || ""
         };
+        let masterFxLfoConfig = null;
+        if (typeof shadow_get_param === "function") {
+            const lfos = {};
+            for (let li = 1; li <= 2; li++) {
+                try {
+                    const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
+                    if (configJson) {
+                        lfos["lfo" + li] = JSON.parse(configJson);
+                    }
+                } catch (e) {}
+            }
+            if (Object.keys(lfos).length > 0) {
+                masterFxLfoConfig = lfos;
+            }
+        }
         for (let i = 1; i <= 4; i++) {
             const key = `fx${i}`;
             const slotIdx = i - 1;
@@ -4521,8 +4545,12 @@ function saveMasterFxChainConfig() {
             const stateFilePath = activeSlotStateDir + "/master_fx_" + slotIdx + ".json";
 
             if (!moduleId) {
-                /* Empty slot - write empty marker */
-                host_write_file(stateFilePath, "{}\n");
+                /* Empty slot - keep LFO snapshot with fx1 state for per-set restore */
+                if (slotIdx === 0 && masterFxLfoConfig) {
+                    host_write_file(stateFilePath, JSON.stringify({ lfos: masterFxLfoConfig }, null, 2) + "\n");
+                } else {
+                    host_write_file(stateFilePath, "{}\n");
+                }
                 continue;
             }
 
@@ -4586,6 +4614,9 @@ function saveMasterFxChainConfig() {
             } else if (paramsObj) {
                 stateFile.params = paramsObj;
             }
+            if (slotIdx === 0 && masterFxLfoConfig) {
+                stateFile.lfos = masterFxLfoConfig;
+            }
             host_write_file(stateFilePath, JSON.stringify(stateFile, null, 2) + "\n");
         }
 
@@ -4603,18 +4634,6 @@ function saveMasterFxChainConfig() {
         config.resample_bridge_mode = cachedResampleBridgeMode;
         config.link_audio_routing = cachedLinkAudioRouting;
         config.link_audio_publish = cachedLinkAudioPublish;
-
-        /* Save master FX LFO configs */
-        if (typeof shadow_get_param === "function") {
-            for (let li = 1; li <= 2; li++) {
-                try {
-                    const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
-                    if (configJson) {
-                        config.master_fx_chain["lfo" + li] = JSON.parse(configJson);
-                    }
-                } catch (e) {}
-            }
-        }
 
         host_write_file(configPath, JSON.stringify(config, null, 2));
     } catch (e) {
@@ -4768,9 +4787,7 @@ function loadMasterFxChainFromConfig() {
     try {
         const configPath = "/data/UserData/schwung/shadow_config.json";
         const content = host_read_file(configPath);
-        if (!content) return;
-
-        const config = JSON.parse(content);
+        const config = content ? JSON.parse(content) : {};
 
         /* Restore overlay knobs mode */
         if (typeof config.overlay_knobs_mode === "number" && typeof overlay_knobs_set_mode === "function") {
@@ -4794,10 +4811,8 @@ function loadMasterFxChainFromConfig() {
             cachedLinkAudioPublish = !!config.link_audio_publish;
         }
 
-        if (!config.master_fx_chain) return;
-
         /* Restore loaded preset name */
-        if (config.master_fx_chain.preset_name) {
+        if (config.master_fx_chain && config.master_fx_chain.preset_name) {
             currentMasterPresetName = config.master_fx_chain.preset_name;
         }
 
@@ -4813,28 +4828,29 @@ function loadMasterFxChainFromConfig() {
                         masterFxConfig[key].module = stateFile.module_id;
                         debugLog(`MFX sync ${key}: module=${stateFile.module_id} (loaded by shim)`);
                     }
+                    if (i === 0 && stateFile.lfos && typeof shadow_set_param === "function") {
+                        for (let li = 1; li <= 2; li++) {
+                            const lfoConfig = stateFile.lfos["lfo" + li];
+                            if (!lfoConfig) continue;
+                            const pfx = "master_fx:lfo" + li + ":";
+                            if (lfoConfig.target) shadow_set_param(0, pfx + "target", lfoConfig.target);
+                            if (lfoConfig.target_param) shadow_set_param(0, pfx + "target_param", lfoConfig.target_param);
+                            shadow_set_param(0, pfx + "shape", String(lfoConfig.shape || 0));
+                            shadow_set_param(0, pfx + "polarity", String(lfoConfig.polarity || 0));
+                            shadow_set_param(0, pfx + "sync", String(lfoConfig.sync || 0));
+                            shadow_set_param(0, pfx + "rate_hz", String(lfoConfig.rate_hz || 1.0));
+                            const configRateDiv = Number.isFinite(Number(lfoConfig.rate_div))
+                                ? Number(lfoConfig.rate_div)
+                                : 15;
+                            shadow_set_param(0, pfx + "rate_div", String(configRateDiv));
+                            shadow_set_param(0, pfx + "depth", String(lfoConfig.depth || 0));
+                            shadow_set_param(0, pfx + "phase_offset", String(lfoConfig.phase_offset || 0));
+                            shadow_set_param(0, pfx + "enabled", String(lfoConfig.enabled || 0));
+                            debugLog(`MFX LFO ${li}: restored target=${lfoConfig.target || "none"}`);
+                        }
+                    }
                 }
             } catch (e) {}
-        }
-
-        /* Restore master FX LFO configs from shadow_config */
-        if (config.master_fx_chain && typeof shadow_set_param === "function") {
-            for (let li = 1; li <= 2; li++) {
-                const lfoConfig = config.master_fx_chain["lfo" + li];
-                if (lfoConfig) {
-                    const pfx = "master_fx:lfo" + li + ":";
-                    if (lfoConfig.target) shadow_set_param(0, pfx + "target", lfoConfig.target);
-                    if (lfoConfig.target_param) shadow_set_param(0, pfx + "target_param", lfoConfig.target_param);
-                    shadow_set_param(0, pfx + "shape", String(lfoConfig.shape || 0));
-                    shadow_set_param(0, pfx + "sync", String(lfoConfig.sync || 0));
-                    shadow_set_param(0, pfx + "rate_hz", String(lfoConfig.rate_hz || 1.0));
-                    shadow_set_param(0, pfx + "rate_div", String(lfoConfig.rate_div || 3));
-                    shadow_set_param(0, pfx + "depth", String(lfoConfig.depth || 0));
-                    shadow_set_param(0, pfx + "phase_offset", String(lfoConfig.phase_offset || 0));
-                    shadow_set_param(0, pfx + "enabled", String(lfoConfig.enabled || 0));
-                    debugLog(`MFX LFO ${li}: restored target=${lfoConfig.target || "none"}`);
-                }
-            }
         }
     } catch (e) {
         /* Ignore errors */
@@ -6777,6 +6793,24 @@ function buildHierarchyParamKey(key) {
     return `${prefix}:${key}`;
 }
 
+function getHierarchyDisplayRawValue(slot, fullKey) {
+    const baseVal = getSlotParam(slot, `${fullKey}:base`);
+    if (baseVal !== null && baseVal !== undefined) return baseVal;
+    return getSlotParam(slot, fullKey);
+}
+
+function isHierarchyParamModulated(slot, fullKey) {
+    const modulated = getSlotParam(slot, `${fullKey}:modulated`);
+    if (modulated === "1") return true;
+    if (modulated === "0") return false;
+
+    /* Fallback for targets that don't implement :modulated. */
+    const baseVal = getSlotParam(slot, `${fullKey}:base`);
+    if (baseVal === null || baseVal === undefined) return false;
+    const liveVal = getSlotParam(slot, fullKey);
+    return liveVal !== null && liveVal !== undefined && liveVal !== baseVal;
+}
+
 function resetHierarchyEditState() {
     hierEditorEditKey = "";
     hierEditorEditValue = null;
@@ -7143,13 +7177,14 @@ function showKnobOverlay(knobIndex, value) {
             showOverlay(`Knob ${knobIndex + 1}`, "not mapped");
         } else if (ctx.fullKey) {
             /* Mapped knob - show value */
+            const title = isHierarchyParamModulated(ctx.slot, ctx.fullKey) ? `${ctx.title}~` : ctx.title;
             let displayVal;
             const isEnum = ctx.meta && (ctx.meta.type === "enum" || ctx.meta.type === "bool");
             if (value !== undefined) {
                 /* For enums, show string directly; for numbers, format */
                 displayVal = isEnum ? String(value) : formatParamForOverlay(value, ctx.meta);
             } else {
-                const currentVal = getSlotParam(ctx.slot, ctx.fullKey);
+                const currentVal = getHierarchyDisplayRawValue(ctx.slot, ctx.fullKey);
                 /* For enums, show string directly; for numbers, parse and format */
                 if (isEnum) {
                     if (isTriggerEnumMeta(ctx.meta)) {
@@ -7162,7 +7197,7 @@ function showKnobOverlay(knobIndex, value) {
                     displayVal = !isNaN(num) ? formatParamForOverlay(num, ctx.meta) : (currentVal || "-");
                 }
             }
-            showOverlay(ctx.title, displayVal);
+            showOverlay(title, displayVal);
         }
         needsRedraw = true;
         return true;
@@ -7224,22 +7259,7 @@ function processPendingHierKnob() {
     if (pendingHierKnobIndex < 0 || pendingHierKnobDelta === 0) {
         /* No pending adjustment, but still show overlay if knob active */
         if (pendingHierKnobIndex >= 0) {
-            const ctx = getKnobContext(pendingHierKnobIndex);
-            if (ctx && ctx.fullKey) {
-                const currentVal = getSlotParam(ctx.slot, ctx.fullKey);
-                if (currentVal !== null) {
-                    /* For enums, pass string directly; for numbers, parse */
-                    if (ctx.meta && (ctx.meta.type === "enum" || ctx.meta.type === "bool")) {
-                        if (isTriggerEnumMeta(ctx.meta)) {
-                            showOverlay(ctx.title, getTriggerEnumOverlayValue(pendingHierKnobIndex));
-                        } else {
-                            showOverlay(ctx.title, currentVal);
-                        }
-                    } else {
-                        showKnobOverlay(pendingHierKnobIndex, parseFloat(currentVal));
-                    }
-                }
-            }
+            showKnobOverlay(pendingHierKnobIndex);
         }
         return;
     }
@@ -7252,8 +7272,10 @@ function processPendingHierKnob() {
     debugLog(`processPendingHierKnob: ctx=${ctx ? JSON.stringify({slot: ctx.slot, key: ctx.key, fullKey: ctx.fullKey, noMapping: ctx.noMapping, meta: ctx.meta ? 'present' : 'null'}) : 'null'}`);
     if (!ctx || ctx.noMapping || !ctx.fullKey) return;
 
-    /* Get current value */
-    const currentVal = getSlotParam(ctx.slot, ctx.fullKey);
+    /* Use stable base value when modulation is active, matching jog edit mode.
+     * Fallback to live value when no base value is available. */
+    const baseVal = getSlotParam(ctx.slot, `${ctx.fullKey}:base`);
+    const currentVal = (baseVal !== null) ? baseVal : getSlotParam(ctx.slot, ctx.fullKey);
     debugLog(`processPendingHierKnob: currentVal=${currentVal}`);
     if (currentVal === null) return;
 
@@ -7549,6 +7571,7 @@ function drawHierarchyEditor() {
 
                 const meta = getParamMetadata(key);
                 const label = meta && meta.name ? meta.name : key.replace(/_/g, " ");
+                let displayLabel = label;
 
                 /* Only fetch param value if this item is visible on screen */
                 let displayVal = "";
@@ -7556,10 +7579,13 @@ function drawHierarchyEditor() {
                     const fullKey = buildHierarchyParamKey(key);
                     const usingStableEditVal = hierEditorEditMode &&
                                                hierEditorEditKey === fullKey && hierEditorEditValue !== null;
-                    const val = usingStableEditVal ? String(hierEditorEditValue) : getSlotParam(hierEditorSlot, fullKey);
+                    const val = usingStableEditVal ? String(hierEditorEditValue) : getHierarchyDisplayRawValue(hierEditorSlot, fullKey);
                     displayVal = val !== null ? formatHierDisplayValue(key, val) : "";
+                    if (isHierarchyParamModulated(hierEditorSlot, fullKey)) {
+                        displayLabel = `${label}~`;
+                    }
                 }
-                return { label, value: displayVal, key };
+                return { label: displayLabel, value: displayVal, key };
             });
 
             drawMenuList({
@@ -8061,9 +8087,10 @@ function handleJog(delta) {
                     const fullKey = buildHierarchyParamKey(key);
                     const freshVal = (hierEditorEditKey === fullKey && hierEditorEditValue !== null)
                         ? String(hierEditorEditValue)
-                        : getSlotParam(hierEditorSlot, fullKey);
+                        : getHierarchyDisplayRawValue(hierEditorSlot, fullKey);
                     const displayVal = freshVal !== null ? formatHierDisplayValue(key, freshVal) : "";
-                    announceParameter(param.label || key, displayVal);
+                    const modSuffix = isHierarchyParamModulated(hierEditorSlot, fullKey) ? "~" : "";
+                    announceParameter((param.label || key) + modSuffix, displayVal);
                 }
             } else {
                 /* Scroll param list (includes preset edit mode) */
@@ -8071,7 +8098,16 @@ function handleJog(delta) {
                 /* Announce selected parameter */
                 if (hierEditorParams.length > 0 && hierEditorSelectedIdx >= 0 && hierEditorSelectedIdx < hierEditorParams.length) {
                     const param = hierEditorParams[hierEditorSelectedIdx];
-                    announceMenuItem(param.label || param.key, param.value || "");
+                    const key = typeof param === "string" ? param : param.key || param;
+                    if (typeof key !== "string" || key.startsWith("nav_") || key.startsWith("item_") || key === SWAP_MODULE_ACTION) {
+                        announceMenuItem(param.label || param.key, param.value || "");
+                    } else {
+                        const fullKey = buildHierarchyParamKey(key);
+                        const val = getHierarchyDisplayRawValue(hierEditorSlot, fullKey);
+                        const displayVal = val !== null ? formatHierDisplayValue(key, val) : "";
+                        const modSuffix = isHierarchyParamModulated(hierEditorSlot, fullKey) ? "~" : "";
+                        announceMenuItem((param.label || key) + modSuffix, displayVal);
+                    }
                 }
             }
             break;
@@ -10671,7 +10707,7 @@ function makeMfxLfoCtx(lfoIdx) {
             return result;
         },
         title: "MFX LFO " + (lfoIdx + 1),
-        returnView: VIEWS.MASTER_FX_SETTINGS,
+        returnView: VIEWS.MASTER_FX,
         returnAnnounce: "Master FX Settings",
     };
 }
@@ -10686,6 +10722,7 @@ function getLfoItems() {
         { key: "target", label: "Target", type: "action" },
         { key: "enabled", label: "Enabled", type: "enum", options: ["Off", "On"] },
         { key: "shape", label: "Shape", type: "enum", options: LFO_SHAPES },
+        { key: "polarity", label: "Mode", type: "enum", options: ["Unipolar", "Bipolar"] },
         { key: "sync", label: "Sync", type: "enum", options: ["Free", "Sync"] },
     ];
 
@@ -10695,7 +10732,7 @@ function getLfoItems() {
         items.push({ key: "rate_hz", label: "Rate", type: "float", min: 0.1, max: 20.0, step: 0.1, unit: "Hz" });
     }
 
-    items.push({ key: "depth", label: "Depth", type: "float", min: 0, max: 1, step: 0.01, unit: "%" });
+    items.push({ key: "depth", label: "Depth", type: "float", min: -1, max: 1, step: 0.01, unit: "%" });
     items.push({ key: "phase_offset", label: "Phase", type: "float", min: 0, max: 1, step: 0.0417, unit: "deg" });
     if (lfoCtx && lfoCtx.supportsRetrigger) {
         items.push({ key: "retrigger", label: "Retrigger", type: "enum", options: ["Off", "On"] });
@@ -10714,6 +10751,7 @@ function getLfoDisplayValue(item) {
         const idx = parseInt(raw);
         return (idx >= 0 && idx < LFO_SHAPES.length) ? LFO_SHAPES[idx] : raw;
     }
+    if (item.key === "polarity") return raw === "1" ? "Bipolar" : "Unipolar";
     if (item.key === "sync") return raw === "1" ? "Sync" : "Free";
     if (item.key === "rate_div") {
         const idx = parseInt(raw);
@@ -10866,9 +10904,6 @@ globalThis.init = function() {
     /* Scan for audio FX modules so display names are available */
     MASTER_FX_OPTIONS = scanForAudioFxModules();
 
-    /* Load and apply master FX chain from config */
-    loadMasterFxChainFromConfig();
-
     /* Load auto-update preference */
     loadAutoUpdateConfig();
     loadBrowserPreviewConfig();
@@ -10907,6 +10942,8 @@ globalThis.init = function() {
             }
         }
     }
+    /* Re-apply Master FX sync after activeSlotStateDir resolves to the active set. */
+    loadMasterFxChainFromConfig();
 
     /* Sync dirty cache and slot names from autosave files (shim loaded them on startup) */
     for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
@@ -11141,7 +11178,6 @@ globalThis.tick = function() {
                     debugLog("SET_CHANGED: slot " + (i + 1) + " no state file (already cleared)");
                 }
             }
-
             /* Refresh UI state immediately so display reflects new slot contents */
             for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                 lastSlotModuleSignatures[i] = "";  /* force refresh */
@@ -11157,11 +11193,12 @@ globalThis.tick = function() {
                 const mfxPath = activeSlotStateDir + "/master_fx_" + mfxi + ".json";
                 let mfxDspPath = "";
                 let mfxModuleId = "";
+                let mfxData = null;
                 if (host_file_exists(mfxPath)) {
                     try {
                         const mfxRaw = host_read_file(mfxPath);
                         if (mfxRaw && mfxRaw.length > 10) {
-                            const mfxData = JSON.parse(mfxRaw);
+                            mfxData = JSON.parse(mfxRaw);
                             mfxDspPath = mfxData.module_path || "";
                             mfxModuleId = mfxData.module_id || "";
                         }
@@ -11173,23 +11210,40 @@ globalThis.tick = function() {
                 masterFxConfig[key].module = mfxModuleId;
 
                 /* Restore plugin state/params if available */
-                if (mfxDspPath && host_file_exists(mfxPath)) {
+                if (mfxData) {
                     try {
-                        const mfxRaw = host_read_file(mfxPath);
-                        const mfxData = JSON.parse(mfxRaw);
-                        if (mfxData.state) {
+                        if (mfxDspPath && mfxData.state) {
                             shadow_set_param(0, `master_fx:fx${mfxi + 1}:state`, JSON.stringify(mfxData.state));
                         }
-                        if (mfxData.params) {
+                        if (mfxDspPath && mfxData.params) {
                             for (const [pk, pv] of Object.entries(mfxData.params)) {
                                 shadow_set_param(0, `master_fx:fx${mfxi + 1}:${pk}`, String(pv));
+                            }
+                        }
+                        if (mfxi === 0 && mfxData.lfos && typeof shadow_set_param === "function") {
+                            for (let li = 1; li <= 2; li++) {
+                                const lfoConfig = mfxData.lfos["lfo" + li];
+                                if (!lfoConfig) continue;
+                                const pfx = "master_fx:lfo" + li + ":";
+                                if (lfoConfig.target) shadow_set_param(0, pfx + "target", lfoConfig.target);
+                                if (lfoConfig.target_param) shadow_set_param(0, pfx + "target_param", lfoConfig.target_param);
+                                shadow_set_param(0, pfx + "shape", String(lfoConfig.shape || 0));
+                                shadow_set_param(0, pfx + "polarity", String(lfoConfig.polarity || 0));
+                                shadow_set_param(0, pfx + "sync", String(lfoConfig.sync || 0));
+                                shadow_set_param(0, pfx + "rate_hz", String(lfoConfig.rate_hz || 1.0));
+                                const configRateDiv = Number.isFinite(Number(lfoConfig.rate_div))
+                                    ? Number(lfoConfig.rate_div)
+                                    : 15;
+                                shadow_set_param(0, pfx + "rate_div", String(configRateDiv));
+                                shadow_set_param(0, pfx + "depth", String(lfoConfig.depth || 0));
+                                shadow_set_param(0, pfx + "phase_offset", String(lfoConfig.phase_offset || 0));
+                                shadow_set_param(0, pfx + "enabled", String(lfoConfig.enabled || 0));
                             }
                         }
                     } catch (e) {}
                 }
                 debugLog("SET_CHANGED: MFX " + mfxi + " -> " + (mfxModuleId || "(none)"));
             }
-
             /* 8. Refresh slot names from new autosave files */
             for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                 slots[i].name = "";

--- a/tests/host/test_chain_lfo_float_parse_hooks.sh
+++ b/tests/host/test_chain_lfo_float_parse_hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'static int json_get_float\(' "$file"; then
+  echo "FAIL: missing JSON float parser helper" >&2
+  exit 1
+fi
+
+if ! rg -q 'json_get_float\(obj, "rate_hz", &lfo->rate_hz\)' "$file"; then
+  echo "FAIL: slot LFO load does not parse rate_hz as numeric JSON" >&2
+  exit 1
+fi
+
+if ! rg -q 'json_get_float\(obj, "depth", &lfo->depth\)' "$file"; then
+  echo "FAIL: slot LFO load does not parse depth as numeric JSON" >&2
+  exit 1
+fi
+
+if ! rg -q 'json_get_float\(obj, "phase_offset", &lfo->phase_offset\)' "$file"; then
+  echo "FAIL: slot LFO load does not parse phase_offset as numeric JSON" >&2
+  exit 1
+fi
+
+echo "PASS: slot LFO load_file parses numeric float fields correctly"

--- a/tests/host/test_chain_lfo_polarity_hooks.sh
+++ b/tests/host/test_chain_lfo_polarity_hooks.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+common="src/host/lfo_common.h"
+
+if ! rg -q 'int bipolar;' "$common"; then
+  echo "FAIL: lfo_state_t is missing bipolar field" >&2
+  exit 1
+fi
+
+if ! rg -q 'strcmp\(subkey, "polarity"\) == 0' "$file"; then
+  echo "FAIL: slot LFO set_param handler missing polarity key" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(strcmp\(subkey, "polarity"\) == 0\)' "$file"; then
+  echo "FAIL: slot LFO get_param handler missing polarity key" >&2
+  exit 1
+fi
+
+if ! rg -q '\\\"polarity\\\":%d' "$file"; then
+  echo "FAIL: slot LFO JSON config is missing polarity persistence" >&2
+  exit 1
+fi
+
+if ! rg -q 'chain_mod_emit_value\(inst, source_id, lfo->target, lfo->param,' "$file"; then
+  echo "FAIL: slot LFO modulation emit call is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'signal, lfo->depth, 0.0f, lfo->bipolar, 1 /\*enabled\*/\);' "$file"; then
+  echo "FAIL: slot LFO modulation emit does not forward polarity mode" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(lfo->depth < -1.0f\) lfo->depth = -1.0f;' "$file"; then
+  echo "FAIL: slot LFO depth lower clamp is not negative" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(lfo->depth > 1.0f\) lfo->depth = 1.0f;' "$file"; then
+  echo "FAIL: slot LFO depth upper clamp is missing" >&2
+  exit 1
+fi
+
+echo "PASS: slot LFO supports polarity mode and negative depth range"

--- a/tests/host/test_chain_modulated_suffix_hooks.sh
+++ b/tests/host/test_chain_modulated_suffix_hooks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/modules/chain/dsp/chain_host.c"
+
+if ! rg -q 'static int chain_mod_get_modulated_for_subkey' "$file"; then
+  echo "FAIL: modulation status helper is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'const size_t suffix_len = 10; /\* ":modulated" \*/' "$file"; then
+  echo "FAIL: modulation status helper does not parse :modulated suffix" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(entry && entry->active && chain_mod_has_active_sources\(entry\)\)' "$file"; then
+  echo "FAIL: modulation status helper does not check active modulation sources" >&2
+  exit 1
+fi
+
+for target in synth fx1 fx2 midi_fx1 midi_fx2; do
+  if ! rg -q "chain_mod_get_modulated_for_subkey\\(inst, \"$target\", subkey, buf, buf_len\\);" "$file"; then
+    echo "FAIL: get_param path is missing :modulated support for $target" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: chain get_param supports :modulated suffix for UI modulation indicators"

--- a/tests/host/test_lfo_sync_divisions_full_order_hooks.sh
+++ b/tests/host/test_lfo_sync_divisions_full_order_hooks.sh
@@ -45,7 +45,7 @@ if ! rg -q 'lfoConfig\.rate_div\)\)\s*$' "$ui_file"; then
   exit 1
 fi
 
-if ! rg -q 'cfg\.rate_div\)\) \? Number\(cfg\.rate_div\) : 15;' "$ui_file"; then
+if ! rg -U -q 'Number\.isFinite\(Number\((cfg|lfoConfig)\.rate_div\)\)\s*\n\s*\?\s*Number\((cfg|lfoConfig)\.rate_div\)\s*\n\s*:\s*15;' "$ui_file"; then
   echo "FAIL: applied config fallback rate_div should be index 15 (1/1)" >&2
   exit 1
 fi

--- a/tests/host/test_lfo_sync_divisions_full_order_hooks.sh
+++ b/tests/host/test_lfo_sync_divisions_full_order_hooks.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host_file="src/host/lfo_common.h"
+ui_file="src/shadow/shadow_ui.js"
+chain_file="src/modules/chain/dsp/chain_host.c"
+mfx_file="src/host/shadow_chain_mgmt.c"
+
+expected_labels="16bar,15bar,14bar,13bar,12bar,11bar,10bar,9bar,8bar,7bar,6bar,5bar,4bar,3bar,2bar,1/1,1/1T,1/2,1/2T,1/4,1/4T,1/8,1/8T,1/16,1/16T,1/32,1/32T"
+
+if ! rg -q '^#define LFO_NUM_DIVISIONS 27$' "$host_file"; then
+  echo "FAIL: LFO_NUM_DIVISIONS should be 27 after removing duplicate 1bar/1/1" >&2
+  exit 1
+fi
+
+host_labels="$(sed -n '/static const lfo_division_t lfo_divisions/,/};/p' "$host_file" \
+  | rg -o '"[^"]+"' \
+  | tr -d '"' \
+  | paste -sd ',' -)"
+if [[ "$host_labels" != "$expected_labels" ]]; then
+  echo "FAIL: host LFO division labels are not in the expected full ordered list" >&2
+  echo "Expected: $expected_labels" >&2
+  echo "Actual:   $host_labels" >&2
+  exit 1
+fi
+
+ui_labels="$(sed -n '/const LFO_DIVISIONS = \[/,/];/p' "$ui_file" \
+  | rg -o '"[^"]+"' \
+  | tr -d '"' \
+  | paste -sd ',' -)"
+if [[ "$ui_labels" != "$expected_labels" ]]; then
+  echo "FAIL: UI LFO division labels are not in the expected full ordered list" >&2
+  echo "Expected: $expected_labels" >&2
+  echo "Actual:   $ui_labels" >&2
+  exit 1
+fi
+
+if rg -q 'rate_div \|\| 16' "$ui_file"; then
+  echo "FAIL: UI must not use falsy fallback for rate_div (breaks index 0 / 16bar)" >&2
+  exit 1
+fi
+
+if ! rg -q 'lfoConfig\.rate_div\)\)\s*$' "$ui_file"; then
+  echo "FAIL: preset restore should parse lfoConfig.rate_div numerically" >&2
+  exit 1
+fi
+
+if ! rg -q 'cfg\.rate_div\)\) \? Number\(cfg\.rate_div\) : 15;' "$ui_file"; then
+  echo "FAIL: applied config fallback rate_div should be index 15 (1/1)" >&2
+  exit 1
+fi
+
+if ! rg -q 'lfo->sync && lfo->rate_div == 0\) lfo->rate_div = 15;' "$mfx_file"; then
+  echo "FAIL: Master FX LFO sync default should map to index 15 (1/1)" >&2
+  exit 1
+fi
+
+if ! rg -q 'lfo->sync && lfo->rate_div == 0\) lfo->rate_div = 15;' "$chain_file"; then
+  echo "FAIL: Slot LFO sync default should map to index 15 (1/1)" >&2
+  exit 1
+fi
+
+echo "PASS: full ordered LFO sync timing list and 1/1 defaults are wired across host + UI"

--- a/tests/host/test_mfx_lfo_base_fallback_hooks.sh
+++ b/tests/host/test_mfx_lfo_base_fallback_hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/host/shadow_chain_mgmt.c"
+
+if ! rg -q 'static int mfx_chain_params_lookup_default_value\(' "$file"; then
+  echo "FAIL: missing chain_params default-value lookup helper" >&2
+  exit 1
+fi
+
+if ! rg -q 'float fallback_base = \(p_min \+ p_max\) \* 0.5f;' "$file"; then
+  echo "FAIL: MFX LFO tick missing fallback base for modules without get_param" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_chain_params_lookup_default_value\(' "$file"; then
+  echo "FAIL: MFX LFO tick does not try default from chain_params metadata" >&2
+  exit 1
+fi
+
+if ! rg -q 'static void mfx_lfo_update_base_from_set_param\(' "$file"; then
+  echo "FAIL: missing base-sync helper for manual parameter sets" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_lfo_update_base_from_set_param\(mfx_slot, param_key, shadow_param->value\);' "$file"; then
+  echo "FAIL: direct MFX param set path does not refresh LFO base snapshot" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_lfo_update_base_from_set_param\(mfx_slot, shadow_param->value, eq \+ 1\);' "$file"; then
+  echo "FAIL: key=value MFX param set path does not refresh LFO base snapshot" >&2
+  exit 1
+fi
+
+echo "PASS: master FX LFO has fallback base snapshot and base-sync on set_param"

--- a/tests/host/test_mfx_lfo_chain_params_range_lookup_hooks.sh
+++ b/tests/host/test_mfx_lfo_chain_params_range_lookup_hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/host/shadow_chain_mgmt.c"
+
+if ! rg -q 'static int mfx_chain_params_lookup_numeric_meta\(' "$file"; then
+  echo "FAIL: missing helper to parse Master FX chain_params metadata" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_chain_params_lookup_numeric_meta\(' "$file" || \
+   ! rg -q 'mfx->chain_params_cache' "$file"; then
+  echo "FAIL: Master FX LFO tick is not using robust chain_params metadata lookup" >&2
+  exit 1
+fi
+
+if rg -q 'snprintf\(needle, sizeof\(needle\), "\\\"key\\\":\\\"%s\\\""[^;]*lfo->param' "$file"; then
+  echo "FAIL: brittle exact key needle search is still present in Master FX LFO metadata lookup" >&2
+  exit 1
+fi
+
+echo "PASS: Master FX LFO metadata lookup parses chain_params without assuming exact JSON spacing"

--- a/tests/host/test_mfx_lfo_mix_from_buffer_tick_hooks.sh
+++ b/tests/host/test_mfx_lfo_mix_from_buffer_tick_hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/schwung_shim.c"
+
+if ! rg -q 'static void shadow_inprocess_mix_from_buffer\(' "$file"; then
+  echo "FAIL: missing shadow_inprocess_mix_from_buffer()" >&2
+  exit 1
+fi
+
+if ! rg -q 'shadow_master_fx_lfo_tick\(FRAMES_PER_BLOCK\);' "$file"; then
+  echo "FAIL: missing Master FX LFO tick call in shim audio path" >&2
+  exit 1
+fi
+
+echo "PASS: shim mix_from_buffer path ticks Master FX LFOs"

--- a/tests/host/test_mfx_lfo_polarity_hooks.sh
+++ b/tests/host/test_mfx_lfo_polarity_hooks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/host/shadow_chain_mgmt.c"
+
+if ! rg -q 'strcmp\(lfo_param, "polarity"\) == 0' "$file"; then
+  echo "FAIL: master FX LFO param handler missing polarity key" >&2
+  exit 1
+fi
+
+if ! rg -q '\\\"polarity\\\":%d' "$file"; then
+  echo "FAIL: master FX LFO config JSON missing polarity persistence" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(lfo->depth < -1.0f\) lfo->depth = -1.0f;' "$file"; then
+  echo "FAIL: master FX LFO depth lower clamp is not negative" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(lfo->depth > 1.0f\) lfo->depth = 1.0f;' "$file"; then
+  echo "FAIL: master FX LFO depth upper clamp is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'float mod_signal = signal;' "$file"; then
+  echo "FAIL: master FX LFO tick missing modulation signal path" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(!lfo->bipolar\)' "$file"; then
+  echo "FAIL: master FX LFO tick missing unipolar mapping branch" >&2
+  exit 1
+fi
+
+if ! rg -q 'float range_scale = lfo->bipolar \? \(0.5f \* range_span\) : range_span;' "$file"; then
+  echo "FAIL: master FX LFO tick missing polarity-aware range scaling" >&2
+  exit 1
+fi
+
+echo "PASS: master FX LFO supports polarity mode and negative depth range"

--- a/tests/host/test_mfx_lfo_runtime_chain_params_hooks.sh
+++ b/tests/host/test_mfx_lfo_runtime_chain_params_hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/host/shadow_chain_mgmt.c"
+
+if ! rg -q 'static int mfx_lfo_try_runtime_chain_params_meta\(' "$file"; then
+  echo "FAIL: missing Master FX runtime chain_params metadata fallback helper" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_lfo_try_runtime_chain_params_meta\(' "$file"; then
+  echo "FAIL: master FX LFO tick does not call runtime chain_params fallback" >&2
+  exit 1
+fi
+
+if ! rg -q 'get_param\(mfx->instance, "chain_params"' "$file"; then
+  echo "FAIL: runtime chain_params fetch for Master FX metadata is missing" >&2
+  exit 1
+fi
+
+echo "PASS: master FX LFO can fetch metadata from runtime chain_params when cache misses"

--- a/tests/host/test_mfx_modulated_suffix_hooks.sh
+++ b/tests/host/test_mfx_modulated_suffix_hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/host/shadow_chain_mgmt.c"
+
+if ! rg -q 'static int mfx_param_strip_suffix' "$file"; then
+  echo "FAIL: MFX param suffix parser helper is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_param_strip_suffix\(param_key, ":modulated", bare_param, sizeof\(bare_param\)\)' "$file"; then
+  echo "FAIL: MFX GET path does not handle :modulated suffix" >&2
+  exit 1
+fi
+
+if ! rg -q 'mfx_param_strip_suffix\(param_key, ":base", bare_param, sizeof\(bare_param\)\)' "$file"; then
+  echo "FAIL: MFX GET path does not handle :base suffix" >&2
+  exit 1
+fi
+
+if ! rg -q 'strcmp\(lfo->target, target_key\) != 0' "$file"; then
+  echo "FAIL: MFX suffix handlers do not filter by targeted FX slot" >&2
+  exit 1
+fi
+
+echo "PASS: master FX get_param supports :base and :modulated suffixes"

--- a/tests/shadow/test_shadow_hierarchy_knob_base_hooks.sh
+++ b/tests/shadow/test_shadow_hierarchy_knob_base_hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'const baseVal = getSlotParam\(ctx.slot, `\$\{ctx.fullKey\}:base`\);' "$file"; then
+  echo "FAIL: hierarchy knob path does not read base value via :base suffix" >&2
+  exit 1
+fi
+
+if ! rg -q 'const currentVal = \(baseVal !== null\) \? baseVal : getSlotParam\(ctx.slot, ctx.fullKey\);' "$file"; then
+  echo "FAIL: hierarchy knob path is not falling back from base to live value" >&2
+  exit 1
+fi
+
+echo "PASS: hierarchy knob adjustment uses stable base values when modulation is active"

--- a/tests/shadow/test_shadow_lfo_polarity_ui_hooks.sh
+++ b/tests/shadow/test_shadow_lfo_polarity_ui_hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -F -q '{ key: "polarity", label: "Mode", type: "enum", options: ["Unipolar", "Bipolar"] }' "$file"; then
+  echo "FAIL: LFO editor is missing polarity mode menu item" >&2
+  exit 1
+fi
+
+if ! rg -F -q 'items.push({ key: "depth", label: "Depth", type: "float", min: -1, max: 1, step: 0.01, unit: "%" });' "$file"; then
+  echo "FAIL: LFO depth menu item does not support negative range" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(item.key === "polarity"\) return raw === "1" \? "Bipolar" : "Unipolar";' "$file"; then
+  echo "FAIL: LFO polarity display formatting is missing" >&2
+  exit 1
+fi
+
+echo "PASS: shadow LFO editor exposes polarity mode and negative depth range"

--- a/tests/shadow/test_shadow_mfx_lfo_back_nav_hooks.sh
+++ b/tests/shadow/test_shadow_mfx_lfo_back_nav_hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'returnView: VIEWS\.MASTER_FX,' "$file"; then
+  echo "FAIL: Master FX LFO editor does not return to Master FX view on Back" >&2
+  exit 1
+fi
+
+if rg -q 'returnView: VIEWS\.MASTER_FX_SETTINGS' "$file"; then
+  echo "FAIL: Master FX LFO editor references undefined MASTER_FX_SETTINGS view" >&2
+  exit 1
+fi
+
+echo "PASS: Master FX LFO Back navigation returns to Master FX view"

--- a/tests/shadow/test_shadow_mfx_lfo_set_persistence_hooks.sh
+++ b/tests/shadow/test_shadow_mfx_lfo_set_persistence_hooks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'const configJson = shadow_get_param\(0, "master_fx:lfo" \+ li \+ ":config"\);' "$file"; then
+  echo "FAIL: save flow does not read Master FX LFO config directly from DSP" >&2
+  exit 1
+fi
+
+if ! rg -q 'stateFile\.lfos = masterFxLfoConfig;' "$file"; then
+  echo "FAIL: save flow does not persist Master FX LFO config into per-set master_fx_0.json" >&2
+  exit 1
+fi
+
+if ! rg -q 'JSON\.stringify\(\{ lfos: masterFxLfoConfig \}, null, 2\) \+ "\\n"' "$file"; then
+  echo "FAIL: empty fx1 slot save flow does not retain per-set Master FX LFO config" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(i === 0 && stateFile\.lfos && typeof shadow_set_param === "function"\)' "$file"; then
+  echo "FAIL: startup load flow does not restore Master FX LFOs from per-set state file" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(mfxi === 0 && mfxData\.lfos && typeof shadow_set_param === "function"\)' "$file"; then
+  echo "FAIL: set-change flow does not restore Master FX LFOs from per-set state file" >&2
+  exit 1
+fi
+
+if ! rg -q 'shadow_set_param\(0, pfx \+ "polarity", String\(lfoConfig\.polarity \|\| 0\)\);' "$file"; then
+  echo "FAIL: per-set load flow does not restore Master FX LFO polarity" >&2
+  exit 1
+fi
+
+if rg -q 'config\.master_fx_chain\["lfo" \+ li\]' "$file"; then
+  echo "FAIL: Master FX LFOs are still persisted in shadow_config master_fx_chain" >&2
+  exit 1
+fi
+
+echo "PASS: Master FX LFO persistence follows per-set master_fx_0.json flow"

--- a/tests/shadow/test_shadow_modulation_label_hooks.sh
+++ b/tests/shadow/test_shadow_modulation_label_hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'function getHierarchyDisplayRawValue\(slot, fullKey\)' "$file"; then
+  echo "FAIL: hierarchy display base-value helper is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'const baseVal = getSlotParam\(slot, `\$\{fullKey\}:base`\);' "$file"; then
+  echo "FAIL: hierarchy display helper does not read :base" >&2
+  exit 1
+fi
+
+if ! rg -q 'function isHierarchyParamModulated\(slot, fullKey\)' "$file"; then
+  echo "FAIL: hierarchy modulation status helper is missing" >&2
+  exit 1
+fi
+
+if ! rg -q 'const modulated = getSlotParam\(slot, `\$\{fullKey\}:modulated`\);' "$file"; then
+  echo "FAIL: hierarchy modulation helper does not read :modulated flag" >&2
+  exit 1
+fi
+
+if ! rg -q 'displayLabel = `\$\{label\}~`;' "$file"; then
+  echo "FAIL: hierarchy list does not append ~ to modulated labels" >&2
+  exit 1
+fi
+
+if ! rg -q 'const title = isHierarchyParamModulated\(ctx.slot, ctx.fullKey\) \? `\$\{ctx.title\}~` : ctx.title;' "$file"; then
+  echo "FAIL: knob overlay title does not mark modulated params" >&2
+  exit 1
+fi
+
+echo "PASS: hierarchy UI uses base values and marks modulated params with ~"

--- a/tests/shadow/test_shadow_slot_lfo_set_persistence_hooks.sh
+++ b/tests/shadow/test_shadow_slot_lfo_set_persistence_hooks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'getSlotParam\(slotIndex, "lfo_config"\)' "$file"; then
+  echo "FAIL: slot patch export does not fetch lfo_config from DSP" >&2
+  exit 1
+fi
+
+if ! rg -q 'patch\.lfos = lfos;' "$file"; then
+  echo "FAIL: slot patch export does not persist LFO config into chain JSON" >&2
+  exit 1
+fi
+
+if ! rg -q 'activeSlotStateDir \+ "/slot_" \+ i \+ "\.json"' "$file"; then
+  echo "FAIL: autosave path is not writing per-slot state files" >&2
+  exit 1
+fi
+
+if ! rg -q 'setSlotParamWithTimeout\(i, "load_file", path, 1500\)' "$file"; then
+  echo "FAIL: set restore flow is not loading slot state files" >&2
+  exit 1
+fi
+
+if ! rg -q 'host_write_file\(newDir \+ "/slot_" \+ i \+ "\.json", "\{\}\\n"\);' "$file"; then
+  echo "FAIL: new set initialization does not seed slot state files" >&2
+  exit 1
+fi
+
+if ! rg -q 'const src = host_read_file\(srcDir \+ "/slot_" \+ i \+ "\.json"\);' "$file"; then
+  echo "FAIL: duplicated set flow does not copy per-slot state files" >&2
+  exit 1
+fi
+
+if rg -q 'function getSlotLfoStatePath\(slotIndex, stateDir\)' "$file"; then
+  echo "FAIL: dedicated slot LFO file helper still present; expected main inline behavior" >&2
+  exit 1
+fi
+
+if rg -q 'restoreSlotLfosFromStateDir\(activeSlotStateDir' "$file"; then
+  echo "FAIL: dedicated slot LFO restore flow still present; expected main inline behavior" >&2
+  exit 1
+fi
+
+echo "PASS: slot LFO persistence follows main inline slot state flow"


### PR DESCRIPTION
## Summary
This PR improves Shadow/Chain LFO behavior across host runtime and Shadow UI, with a focus on correct parameter-range modulation, expanded sync timing options, clearer modulation UX, and reliable persistence.

## Diff Scope
Compared to `main`, this branch changes **21 files** (**1208 insertions**, **149 deletions**):
- 5 source files:
  - `src/host/lfo_common.h`
  - `src/host/shadow_chain_mgmt.c`
  - `src/modules/chain/dsp/chain_host.c`
  - `src/schwung_shim.c`
  - `src/shadow/shadow_ui.js`
- 16 hook tests added under `tests/host/` and `tests/shadow/`

## Functional Changes
1. LFO timing table expanded and ordered
- Sync divisions now cover full ordered options from `16bar` down to `1/32T`.
- Removes duplicate 1-bar representation and aligns defaults to `1/1` index mapping.

2. Polarity + negative depth support
- Adds LFO polarity mode (`Unipolar` default, `Bipolar` option) in UI and host runtime.
- Depth range now supports negative values (`-1.0..1.0`) for slot and Master FX LFOs.

3. Parameter-range aware modulation
- Runtime modulation scales against parameter min/max metadata instead of assuming a normalized 0..1 domain.
- Adds runtime `chain_params` metadata/default fallback lookup for Master FX targets when static metadata is missing.

4. Base/modulated value plumbing
- Adds `:base` and `:modulated` query handling in host modulation surfaces.
- Shadow hierarchy knob edits now use stable base values when modulation is active.
- UI indicates actively modulated params with a `~` suffix (label-level indicator).

5. Master FX modulation runtime fixes
- Ticks Master FX LFOs in the active shim in-process mix path so modulation is applied reliably during processing.

6. Master FX LFO persistence
- Persists Master FX LFO config per set in `set_state/.../master_fx_0.json`.
- Restores that state both at init (after active set resolution) and during set-switch reload.
- Removes Master FX LFO persistence dependency on global `shadow_config` chain keys.

7. Navigation polish
- Master FX LFO back navigation returns to Master FX view path consistently.

## Verification
- Built successfully with:
  - `./scripts/build.sh`
- Targeted hook checks pass, including:
  - `tests/host/test_lfo_sync_divisions_full_order_hooks.sh`
  - `tests/host/test_chain_lfo_polarity_hooks.sh`
  - `tests/host/test_mfx_lfo_polarity_hooks.sh`
  - `tests/shadow/test_shadow_lfo_polarity_ui_hooks.sh`
  - `tests/shadow/test_shadow_modulation_label_hooks.sh`
  - `tests/shadow/test_shadow_mfx_lfo_set_persistence_hooks.sh`
  - `tests/shadow/test_shadow_slot_lfo_set_persistence_hooks.sh`
