### PR TITLE
Add Dissolver and Spectra audio FX modules

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -601,6 +601,28 @@
       "default_branch": "master",
       "asset_name": "weird-dreams-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "dissolver",
+      "name": "Dissolver",
+      "description": "Spectral smearing pad generator — dissolves transients into evolving ambient pads via FFT magnitude analysis and random phase reconstruction",
+      "author": "fillioning",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/dissolver-move",
+      "default_branch": "master",
+      "asset_name": "dissolver-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "spectra",
+      "name": "Spectra",
+      "description": "Multiband spectral resonator — pitch-tracking SVF resonator bank with scale quantizer, 12 scales x 12 roots, chord drift",
+      "author": "fillioning",
+      "component_type": "audio_fx",
+      "github_repo": "fillioning/spectra-move",
+      "default_branch": "master",
+      "asset_name": "spectra-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Dissolver** (`fillioning/dissolver-move`) — Spectral smearing pad generator. Dissolves transients into evolving ambient pads via FFT magnitude analysis and random phase reconstruction. PaulStretch-inspired, PFFFT, GPL-3.0.
- **Spectra** (`fillioning/spectra-move`) — Multiband spectral resonator. Pitch-tracking SVF resonator bank with scale quantizer (12 scales × 12 roots), chord drift. All original DSP, MIT.

Both are `audio_fx` modules with GitHub Actions release workflows and `release.json` on `master` branch.

## Test plan
- [ ] Dissolver appears in Module Store
- [ ] Spectra appears in Module Store
- [ ] Both install and load successfully
- [ ] DSP processes audio without crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)