### PR TITLE
fix: hierarchy editor knobs inert on root (page-select) level

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1850,9 +1850,11 @@ function applyHierarchyVisibilityFilters(levelDef) {
         const visibleKeys = new Set(
             hierEditorParams
                 .map(extractHierarchyParamKey)
-                .filter(Boolean)
+                .filter(k => k && k !== SWAP_MODULE_ACTION)
         );
         if (visibleKeys.size === 0) {
+            /* Root/page-select level: no editable params visible (only nav links)
+             * → keep all knobs so they control the first page's params */
             hierEditorKnobs = [...hierEditorAllKnobs];
         } else {
             hierEditorKnobs = hierEditorAllKnobs.filter(k => visibleKeys.has(k));


### PR DESCRIPTION
## Bug

When entering the hierarchy editor's root level (the page-select screen showing
sub-pages like "Granular", "Randomize", etc.), **all 8 knobs are inert**. Turning
them shows "Knob N: not mapped" instead of controlling the first page's parameters
via root.knobs.

This affects **every multi-page plugin** — any module whose `ui_hierarchy` root
level has navigation entries (`{level: "PageName"}`) instead of inline editable params.

## Root Cause

`applyHierarchyVisibilityFilters()` builds a `visibleKeys` set from
`hierEditorParams` to filter which knobs are active. On the root level:

1. `hierEditorParams` = `[{level: "Granular"}, {level: "Randomize"}, ..., "__swap_module__"]`
2. Navigation objects return `""` from `extractHierarchyParamKey` → filtered by `Boolean`
3. But `SWAP_MODULE_ACTION` (`"__swap_module__"`) is a **raw string**, so `extractHierarchyParamKey` returns it directly (`typeof param === "string"` → `return param`)
4. `visibleKeys = Set(["__swap_module__"])` — **size is 1, not 0**
5. This triggers `hierEditorKnobs = hierEditorAllKnobs.filter(k => visibleKeys.has(k))`
6. No knob key matches `"__swap_module__"` → **all knobs removed**

The `visibleKeys.size === 0` branch (which correctly preserves all knobs) is never reached.

## Fix

Exclude `SWAP_MODULE_ACTION` from the `visibleKeys` set:

```javascript
.filter(k => k && k !== SWAP_MODULE_ACTION)
```

This restores the intended behavior: when no real editable params are visible
(only navigation links), all knobs from `root.knobs` are preserved.

## Test plan

- [ ] Load any multi-page audio FX (e.g. Boris Granular, Dissolver, Structor) as Track FX
- [ ] Click into the effect to enter the hierarchy editor at root level (page-select screen)
- [ ] Turn knobs → should control the first page's params (matching root.knobs), with correct overlay
- [ ] Navigate into a sub-page → knobs should switch to that page's params
- [ ] Repeat with Master FX slot
- [ ] Single-page modules (flat root with inline params) should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)