### PR TITLE
Add Genera to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -645,6 +645,17 @@
       "default_branch": "main",
       "asset_name": "chowtape-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "genera",
+      "name": "Genera",
+      "description": "Generative note and chord sequencer with 7 generation modes, stutter engine with beat-repeat, 20 scales, chord stacking, capture/loop, and humanize",
+      "author": "Vincent Fillion",
+      "component_type": "midi_fx",
+      "github_repo": "fillioning/genera-move",
+      "default_branch": "master",
+      "asset_name": "genera-module.tar.gz",
+      "min_host_version": "0.5.8"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **Genera** (midi_fx) to the module catalog
- Generative note & chord sequencer with 7 generation modes, stutter engine with beat-repeat, 20 scales, chord stacking, capture/loop, and humanize

## Module Details
- **Repo**: https://github.com/fillioning/genera-move
- **Release**: [v0.1.0](https://github.com/fillioning/genera-move/releases/tag/v0.1.0)
- **Type**: `midi_fx`
- **Author**: Vincent Fillion
- **License**: MIT

## Features
- 7 generation modes: Up, Down, Up/Down, Down/Up, Exclude, Walk, Random
- 20 musical scales with chromatic root selection
- Stutter engine with off-grid chaotic notes + beat-repeat bursts (Chaos/Timed)
- Chord generation (triads through 6-note voicings)
- Capture/loop co-sequence, Evolve note deviation, Octave shifts
- 4 velocity modes: Human (default ±20%), Fixed, Random, Moving
- Humanize timing jitter, 18 time divisions (dotted/normal/triplet)
- Internal BPM or Move MIDI clock sync

## Checklist
- [x] Repo is public
- [x] release.json has valid version and download_url
- [x] src/module.json exists (desktop installer discovery)
- [x] Shell scripts have execute permission (100755)
- [x] Tarball contains `genera/dsp.so` + `genera/module.json`
- [x] destroy_instance sends all-notes-off
- [x] get_param returns -1 for unknown keys
- [x] No rand(), no heap allocation in tick/process

🤖 Generated with [Claude Code](https://claude.com/claude-code)