### PR TITLE
Add Essaim (32-voice rhythmic oscillator) to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -636,6 +636,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "essaim",
+      "name": "Essaim",
+      "description": "32-voice rhythmic oscillator swarm — polyphonic self-triggering voices with envelope→FM, SVF filtering, LFO modulation routing, scale quantization, delay, and saturation",
+      "author": "fillioning",
+      "component_type": "sound_generator",
+      "github_repo": "fillioning/essaim-move",
+      "default_branch": "main",
+      "asset_name": "essaim-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
       "id": "chowtape",
       "name": "CHOWTape",
       "description": "Analog tape model with Jiles-Atherton magnetic hysteresis, loss filter, wow & flutter, chew, and degradation",


### PR DESCRIPTION
Adds Essaim module to the Schwung module catalog.

Essaim is a 32-voice rhythmic oscillator swarm for Ableton Move with:
- 32 independent self-triggering voices
- Envelope→FM modulation
- Polyphonic SVF filtering with random modes per voice
- 6 LFO shapes with 3 routing modes (Volume, Vol+Filter, Filter only)
- Scale quantization with 6 scales
- Smooth delay with BBD character
- Hot saturation circuit
- 24 presets + randomization

v0.1.0 released at: https://github.com/fillioning/essaim-move/releases/tag/v0.1.0