### PR TITLE
feat: direct MIDI_IN dispatch for MPE passthrough slots

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -102,8 +102,10 @@ uint8_t shadow_chain_remap_channel(int slot, uint8_t status)
  * MIDI dispatch to chain slots
  * ============================================================================ */
 
-/* Dispatch MIDI to all matching slots (supports recv=All broadcasting) */
-void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count)
+/* Dispatch MIDI to all matching slots (supports recv=All broadcasting).
+ * When skip_direct is 1, slots with receive=All and forward=THRU are skipped
+ * because they receive MIDI via the direct MIDI_IN path instead. */
+void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count, int skip_direct)
 {
     const plugin_api_v2_t *pv2 = *host_plugin_v2;
     uint8_t status_usb = pkt[1];
@@ -113,6 +115,14 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
     int dispatched = 0;
 
     for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
+        /* Skip direct-dispatch slots when processing MIDI_OUT.
+         * These slots get MIDI from MIDI_IN directly to preserve
+         * original channels for MPE. */
+        if (skip_direct &&
+            host_chain_slots[i].channel == -1 &&
+            host_chain_slots[i].forward_channel == -2)
+            continue;
+
         /* Check channel match: slot receives this channel, or slot is set to All (-1) */
         if (host_chain_slots[i].channel != (int)midi_ch && host_chain_slots[i].channel != -1)
             continue;
@@ -398,7 +408,117 @@ void shadow_drain_ui_midi_dsp(void)
         uint8_t cin = (status >> 4) & 0x0F;
         uint8_t pkt[4] = { cin, status, d1, d2 };
 
-        shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count);
+        shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count, 0);
+    }
+}
+
+/* ============================================================================
+ * Direct external MIDI dispatch (MPE passthrough)
+ * ============================================================================ */
+
+/* Dispatch external MIDI from MIDI_IN cable 2 directly to slots configured
+ * for passthrough (receive=All, forward=THRU).  This bypasses Move's MIDI_OUT
+ * so that notes and per-note expression data (pitch bend, CC, aftertouch)
+ * arrive on their original channels — required for MPE controllers. */
+void shadow_dispatch_direct_external_midi(void)
+{
+    if (!*host_shadow_inprocess_ready || !*host_global_mmap_addr) return;
+
+    const plugin_api_v2_t *pv2 = *host_plugin_v2;
+    if (!pv2 || !pv2->on_midi) return;
+
+    /* Check whether any slot qualifies for direct dispatch. */
+    int has_direct = 0;
+    for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
+        if (host_chain_slots[i].channel == -1 &&
+            host_chain_slots[i].forward_channel == -2) {
+            has_direct = 1;
+            break;
+        }
+    }
+    if (!has_direct) return;
+
+    uint8_t *in_src = *host_global_mmap_addr + MIDI_IN_OFFSET;
+
+    for (int i = 0; i < MIDI_BUFFER_SIZE; i += 4) {
+        uint8_t cin = in_src[i] & 0x0F;
+        uint8_t cable = (in_src[i] >> 4) & 0x0F;
+
+        /* Only external USB MIDI (cable 2) */
+        if (cable != 0x02) continue;
+        if (cin < 0x08 || cin > 0x0E) continue;
+
+        uint8_t status = in_src[i + 1];
+        uint8_t type = status & 0xF0;
+        uint8_t d1 = in_src[i + 2];
+        uint8_t d2 = in_src[i + 3];
+
+        /* Valid channel voice messages only (0x80-0xE0) */
+        if (type < 0x80 || type > 0xE0) continue;
+
+        /* CIN must match status type */
+        if (cin != (type >> 4)) continue;
+
+        /* Data bytes must be 0-127 */
+        if ((d1 & 0x80) || (d2 & 0x80)) continue;
+
+        /* Filter knob touch notes (0-9) from internal MIDI */
+        if ((type == 0x90 || type == 0x80) && d1 < 10) continue;
+
+        /* Dispatch to qualifying slots: receive=All, forward=THRU */
+        for (int s = 0; s < SHADOW_CHAIN_INSTANCES; s++) {
+            if (host_chain_slots[s].channel != -1 ||
+                host_chain_slots[s].forward_channel != -2)
+                continue;
+
+            /* Lazy activation (same logic as main dispatch) */
+            if (!host_chain_slots[s].active) {
+                if (host_chain_slots[s].instance) {
+                    char buf[64];
+                    int len = pv2->get_param(host_chain_slots[s].instance,
+                                              "synth_module", buf, sizeof(buf));
+                    if (len > 0) {
+                        if (len < (int)sizeof(buf)) buf[len] = '\0';
+                        else buf[sizeof(buf) - 1] = '\0';
+                        if (buf[0] != '\0') {
+                            host_chain_slots[s].active = 1;
+                            if (host_ui_state_update_slot)
+                                host_ui_state_update_slot(s);
+                        }
+                    }
+                }
+                if (!host_chain_slots[s].active) continue;
+            }
+
+            /* Wake from idle */
+            if (host_slot_idle[s] || host_slot_fx_idle[s]) {
+                host_slot_idle[s] = 0;
+                host_slot_silence_frames[s] = 0;
+                host_slot_fx_idle[s] = 0;
+                host_slot_fx_silence_frames[s] = 0;
+            }
+
+            /* Send with original channel preserved (THRU mode) */
+            uint8_t msg[3] = { status, d1, d2 };
+            pv2->on_midi(host_chain_slots[s].instance, msg, 3,
+                         MOVE_MIDI_SOURCE_EXTERNAL);
+        }
+
+        /* Broadcast to audio FX on all active slots */
+        for (int s = 0; s < SHADOW_CHAIN_INSTANCES; s++) {
+            if (!host_chain_slots[s].active || !host_chain_slots[s].instance)
+                continue;
+            uint8_t msg[3] = { status, d1, d2 };
+            pv2->on_midi(host_chain_slots[s].instance, msg, 3,
+                         MOVE_MIDI_SOURCE_FX_BROADCAST);
+        }
+
+        /* Forward to master FX */
+        {
+            uint8_t msg[3] = { status, d1, d2 };
+            if (host_master_fx_forward_midi)
+                host_master_fx_forward_midi(msg, 3, MOVE_MIDI_SOURCE_EXTERNAL);
+        }
     }
 }
 

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -107,8 +107,16 @@ void midi_routing_init(const midi_host_t *host);
 /* Remap MIDI channel for a specific slot based on forward_channel config. */
 uint8_t shadow_chain_remap_channel(int slot, uint8_t status);
 
-/* Dispatch a USB-MIDI packet to matching chain slots (by channel). */
-void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count);
+/* Dispatch a USB-MIDI packet to matching chain slots (by channel).
+ * When skip_direct is 1, slots with receive=All and forward=THRU are skipped
+ * (they receive MIDI via the direct MIDI_IN path instead). */
+void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count, int skip_direct);
+
+/* Dispatch external MIDI from MIDI_IN cable 2 directly to slots configured
+ * for passthrough (receive=All, forward=THRU).  Bypasses Move's MIDI_OUT
+ * channel remapping so that MPE per-note expression data stays on the
+ * correct channels. */
+void shadow_dispatch_direct_external_midi(void);
 
 /* Forward CC/pitch bend/aftertouch from external MIDI (cable 2) into MIDI_OUT. */
 void shadow_forward_external_cc_to_out(void);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -882,7 +882,7 @@ static void shadow_inprocess_process_midi(void) {
             if ((type == 0x90 || type == 0x80) && p2 < 10) {
                 continue;
             }
-            shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count);
+            shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count, 1);
 
             /* Also route to overtake DSP if loaded */
             if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->on_midi) {
@@ -1069,7 +1069,7 @@ static int overtake_midi_send_internal(const uint8_t *msg, int len) {
     uint8_t pkt[4] = { cin, msg[1], msg[2], msg[3] };
     static int midi_log_count = 0;
     int log_on = shadow_midi_out_log_enabled();
-    shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count);
+    shadow_chain_dispatch_midi_to_slots(pkt, log_on, &midi_log_count, 0);
     return len;
 }
 
@@ -3390,6 +3390,7 @@ typedef struct {
     uint64_t ui_req_avg, ui_req_max;
     uint64_t param_req_avg, param_req_max;
     uint64_t fwd_cc_avg, fwd_cc_max;
+    uint64_t direct_midi_avg, direct_midi_max;
     uint64_t proc_midi_avg, proc_midi_max;
     uint64_t jack_stash_avg, jack_stash_max;
     uint64_t drain_dsp_avg, drain_dsp_max;
@@ -3443,6 +3444,7 @@ static uint64_t spi_jack_pre_sum = 0, spi_jack_pre_max = 0;
 static uint64_t spi_jack_disp_sum = 0, spi_jack_disp_max = 0;
 static uint64_t spi_pin_sum = 0, spi_pin_max = 0;
 static uint64_t spi_fwd_ext_cc_sum = 0, spi_fwd_ext_cc_max = 0;
+static uint64_t spi_direct_midi_sum = 0, spi_direct_midi_max = 0;
 static int spi_granular_count = 0;
 
 #define TIME_SECTION_START() clock_gettime(CLOCK_MONOTONIC, &spi_section_start)
@@ -3726,6 +3728,13 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     TIME_SECTION_START();
     shadow_forward_external_cc_to_out();
     TIME_SECTION_END(spi_fwd_ext_cc_sum, spi_fwd_ext_cc_max);
+
+    /* Direct MIDI dispatch for MPE passthrough slots (receive=All, forward=THRU).
+     * Reads MIDI_IN cable 2 and dispatches all message types directly to these
+     * slots, bypassing Move's MIDI_OUT channel remapping. */
+    TIME_SECTION_START();
+    shadow_dispatch_direct_external_midi();
+    TIME_SECTION_END(spi_direct_midi_sum, spi_direct_midi_max);
 
     TIME_SECTION_START();
     shadow_inprocess_process_midi();
@@ -5647,6 +5656,7 @@ post_timing:
         spi_snap.ui_req_avg = spi_ui_req_sum / n; spi_snap.ui_req_max = spi_ui_req_max;
         spi_snap.param_req_avg = spi_param_req_sum / n; spi_snap.param_req_max = spi_param_req_max;
         spi_snap.fwd_cc_avg = spi_fwd_ext_cc_sum / n; spi_snap.fwd_cc_max = spi_fwd_ext_cc_max;
+        spi_snap.direct_midi_avg = spi_direct_midi_sum / n; spi_snap.direct_midi_max = spi_direct_midi_max;
         spi_snap.proc_midi_avg = spi_proc_midi_sum / n; spi_snap.proc_midi_max = spi_proc_midi_max;
         spi_snap.jack_stash_avg = spi_jack_stash_sum / n; spi_snap.jack_stash_max = spi_jack_stash_max;
         spi_snap.drain_dsp_avg = spi_drain_ui_midi_sum / n; spi_snap.drain_dsp_max = spi_drain_ui_midi_max;
@@ -5678,6 +5688,7 @@ post_timing:
         spi_screenreader_sum = spi_screenreader_max = spi_jack_pre_sum = spi_jack_pre_max = 0;
         spi_jack_disp_sum = spi_jack_disp_max = spi_pin_sum = spi_pin_max = 0;
         spi_fwd_ext_cc_sum = spi_fwd_ext_cc_max = 0;
+        spi_direct_midi_sum = spi_direct_midi_max = 0;
         spi_granular_count = 0;
     }
 
@@ -5717,7 +5728,7 @@ static void *spi_timing_logger_thread(void *arg)
         if (spi_snap.granular_ready) {
             unified_log("spi_timing", LOG_LEVEL_DEBUG,
                 "Pre(us): midi_mon=%llu/%llu fwd_midi=%llu/%llu mix_audio=%llu/%llu "
-                "ui_req=%llu/%llu param=%llu/%llu fwd_cc=%llu/%llu proc_midi=%llu/%llu "
+                "ui_req=%llu/%llu param=%llu/%llu fwd_cc=%llu/%llu direct_midi=%llu/%llu proc_midi=%llu/%llu "
                 "jack_stash=%llu/%llu drain_dsp=%llu/%llu jack_wake=%llu/%llu "
                 "mix_buf=%llu/%llu tts=%llu/%llu display=%llu/%llu",
                 (unsigned long long)spi_snap.midi_mon_avg, (unsigned long long)spi_snap.midi_mon_max,
@@ -5726,6 +5737,7 @@ static void *spi_timing_logger_thread(void *arg)
                 (unsigned long long)spi_snap.ui_req_avg, (unsigned long long)spi_snap.ui_req_max,
                 (unsigned long long)spi_snap.param_req_avg, (unsigned long long)spi_snap.param_req_max,
                 (unsigned long long)spi_snap.fwd_cc_avg, (unsigned long long)spi_snap.fwd_cc_max,
+                (unsigned long long)spi_snap.direct_midi_avg, (unsigned long long)spi_snap.direct_midi_max,
                 (unsigned long long)spi_snap.proc_midi_avg, (unsigned long long)spi_snap.proc_midi_max,
                 (unsigned long long)spi_snap.jack_stash_avg, (unsigned long long)spi_snap.jack_stash_max,
                 (unsigned long long)spi_snap.drain_dsp_avg, (unsigned long long)spi_snap.drain_dsp_max,


### PR DESCRIPTION
## Summary

- Adds `shadow_dispatch_direct_external_midi()` which reads MIDI_IN cable 2 and dispatches all message types directly to slots configured with Receive=All + Forward=THRU
- Adds `skip_direct` parameter to `shadow_chain_dispatch_midi_to_slots()` to prevent double-dispatch of notes from MIDI_OUT to slots that already receive from the direct path
- Includes timing instrumentation for the new code path

This preserves per-note channel identity required by MPE controllers (LinnStrument, Roli, Sensel Morph) so pitch bend, CC74 slide, and channel aftertouch correlate correctly with their notes. Non-MPE slots continue to use the existing MIDI_OUT path unchanged.

## Context

Move remaps external MIDI note channels via track auto-mapping, but the existing CC forwarding path (`shadow_forward_external_cc_to_out`) preserves original channels. This creates a channel mismatch that breaks MPE. The fix bypasses Move's MIDI_OUT entirely for qualifying slots, reading raw external MIDI from MIDI_IN instead.

## Test plan

- [ ] Build: `./scripts/build.sh`
- [ ] Deploy: `./scripts/install.sh local --skip-modules --skip-confirmation`
- [ ] MPE: LinnStrument → Surge XT with Recv=All, Fwd=THRU — pitch bend (X), slide CC74 (Y), pressure (Z) all respond per-note
- [ ] Non-MPE: Slot with Recv=Ch1, Fwd=Auto still works normally
- [ ] Multi-slot: One MPE slot + one standard slot work independently
- [ ] Overtake/UI MIDI dispatch still reaches all slots