### PR TITLE
feat: per-slot MIDI semitone transpose (-12 to +12)

### DIFF
--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -361,6 +361,7 @@ void shadow_chain_defaults(void) {
         shadow_chain_slots[i].muted = 0;
         shadow_chain_slots[i].soloed = 0;
         shadow_chain_slots[i].forward_channel = -1;
+        shadow_chain_slots[i].transpose = 0;
         capture_clear(&shadow_chain_slots[i].capture);
         shadow_chain_slots[i].fade.gain = 0.0f;
         shadow_chain_slots[i].fade.target = 0.0f;
@@ -1628,6 +1629,14 @@ int shadow_handle_slot_param_set(int slot, const char *key, const char *value) {
         }
         return 1;
     }
+    if (strcmp(key, "slot:transpose") == 0) {
+        int t = atoi(value);
+        if (t < -12) t = -12;
+        if (t > 12) t = 12;
+        shadow_chain_slots[slot].transpose = t;
+        shadow_ui_state_update_slot(slot);
+        return 1;
+    }
     return 0;
 }
 
@@ -1647,6 +1656,9 @@ int shadow_handle_slot_param_get(int slot, const char *key, char *buf, int buf_l
     if (strcmp(key, "slot:receive_channel") == 0) {
         int ch = shadow_chain_slots[slot].channel;
         return snprintf(buf, buf_len, "%d", (ch < 0) ? 0 : ch + 1);
+    }
+    if (strcmp(key, "slot:transpose") == 0) {
+        return snprintf(buf, buf_len, "%d", shadow_chain_slots[slot].transpose);
     }
     if (strcmp(key, "active_set") == 0) {
         /* Return "uuid\nname" for UI thread to write active_set.txt */

--- a/src/host/shadow_chain_types.h
+++ b/src/host/shadow_chain_types.h
@@ -34,6 +34,7 @@ typedef struct shadow_chain_slot_t {
     int muted;              /* 1 = muted (Mute+Track or Move speakerOn sync) */
     int soloed;             /* 1 = soloed (Shift+Mute+Track or Move solo-cue sync) */
     int forward_channel;    /* -2 = passthrough, -1 = auto, 0-15 = forward MIDI to this channel */
+    int transpose;          /* semitone offset applied to incoming note-on/off/poly-AT, range -12..+12 */
     char patch_name[64];
     shadow_capture_rules_t capture;  /* MIDI controls this slot captures when focused */
     slot_fade_t fade;                /* fade envelope for seamless transitions */

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -8,6 +8,8 @@
 #include "shadow_chain_mgmt.h"
 #include "shadow_led_queue.h"
 
+static void shadow_chain_transpose_reset(void);
+
 /* ============================================================================
  * Host callbacks (set by midi_routing_init)
  * ============================================================================ */
@@ -71,6 +73,8 @@ void midi_routing_init(const midi_host_t *host)
     host_slot_silence_frames = host->slot_silence_frames;
     host_slot_fx_idle = host->slot_fx_idle;
     host_slot_fx_silence_frames = host->slot_fx_silence_frames;
+
+    shadow_chain_transpose_reset();
 }
 
 /* ============================================================================
@@ -96,6 +100,74 @@ uint8_t shadow_chain_remap_channel(int slot, uint8_t status)
         return status;  /* Recv=All + Fwd=Auto → passthrough */
     }
     return (status & 0xF0) | (uint8_t)host_chain_slots[slot].channel;
+}
+
+/* Per-slot active-note tracker: remembers the *transposed* note value that
+ * was actually dispatched on note-on, keyed by (slot, channel, original note).
+ * 0xFF means the note is not currently held.
+ *
+ * This lets a note-off close the same note that its note-on opened, even if
+ * the slot's transpose amount changed while the note was held — otherwise
+ * changing transpose during a sustained note leaves stuck notes because the
+ * note-off arrives with a different transposed value than the note-on used. */
+static uint8_t slot_active_note[SHADOW_CHAIN_INSTANCES][16][128];
+
+static void shadow_chain_transpose_reset(void)
+{
+    memset(slot_active_note, 0xFF, sizeof(slot_active_note));
+}
+
+/* Apply per-slot semitone transpose to a 3-byte MIDI message in place.
+ * Only affects note-off (0x80), note-on (0x90), and poly aftertouch (0xA0) —
+ * all other channel-voice messages pass through unchanged.
+ * Returns 1 if the message should be dispatched, 0 if a note-on would fall
+ * outside 0-127 (and must be dropped without registering as held). */
+static int shadow_chain_apply_transpose(int slot, uint8_t *msg)
+{
+    uint8_t type = msg[0] & 0xF0;
+    if (type != 0x80 && type != 0x90 && type != 0xA0) return 1;
+
+    uint8_t ch = msg[0] & 0x0F;
+    uint8_t orig = msg[1];
+    int transpose = host_chain_slots[slot].transpose;
+
+    /* Note-on with velocity > 0: apply current transpose and remember it. */
+    if (type == 0x90 && msg[2] > 0) {
+        int note = (int)orig + transpose;
+        if (note < 0 || note > 127) return 0;
+        slot_active_note[slot][ch][orig] = (uint8_t)note;
+        msg[1] = (uint8_t)note;
+        return 1;
+    }
+
+    /* Note-off (or note-on with vel 0): reuse the transposed value from
+     * note-on so the synth closes the correct voice regardless of current
+     * transpose. Fall back to current transpose if we have no record. */
+    if (type == 0x80 || type == 0x90) {
+        uint8_t held = slot_active_note[slot][ch][orig];
+        if (held != 0xFF) {
+            msg[1] = held;
+            slot_active_note[slot][ch][orig] = 0xFF;
+            return 1;
+        }
+        if (transpose == 0) return 1;
+        int note = (int)orig + transpose;
+        if (note < 0 || note > 127) return 0;
+        msg[1] = (uint8_t)note;
+        return 1;
+    }
+
+    /* Poly aftertouch: match the held note's transposed value if we know it. */
+    uint8_t held = slot_active_note[slot][ch][orig];
+    if (held != 0xFF) {
+        msg[1] = held;
+        return 1;
+    }
+    if (transpose == 0) return 1;
+    int note = (int)orig + transpose;
+    if (note < 0 || note > 127) return 0;
+    msg[1] = (uint8_t)note;
+    return 1;
 }
 
 /* ============================================================================
@@ -158,8 +230,10 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
         /* Send MIDI to this slot */
         if (pv2 && pv2->on_midi) {
             uint8_t msg[3] = { shadow_chain_remap_channel(i, pkt[1]), pkt[2], pkt[3] };
-            pv2->on_midi(host_chain_slots[i].instance, msg, 3,
-                         MOVE_MIDI_SOURCE_EXTERNAL);
+            if (shadow_chain_apply_transpose(i, msg)) {
+                pv2->on_midi(host_chain_slots[i].instance, msg, 3,
+                             MOVE_MIDI_SOURCE_EXTERNAL);
+            }
         }
         dispatched++;
     }
@@ -500,8 +574,10 @@ void shadow_dispatch_direct_external_midi(void)
 
             /* Send with original channel preserved (THRU mode) */
             uint8_t msg[3] = { status, d1, d2 };
-            pv2->on_midi(host_chain_slots[s].instance, msg, 3,
-                         MOVE_MIDI_SOURCE_EXTERNAL);
+            if (shadow_chain_apply_transpose(s, msg)) {
+                pv2->on_midi(host_chain_slots[s].instance, msg, 3,
+                             MOVE_MIDI_SOURCE_EXTERNAL);
+            }
         }
 
         /* Broadcast to audio FX on all active slots */

--- a/src/host/shadow_state.c
+++ b/src/host/shadow_state.c
@@ -212,6 +212,11 @@ void shadow_save_state(void)
             host_chain_slots[1].forward_channel,
             host_chain_slots[2].forward_channel,
             host_chain_slots[3].forward_channel);
+    fprintf(f, "  \"slot_transpose\": [%d, %d, %d, %d],\n",
+            host_chain_slots[0].transpose,
+            host_chain_slots[1].transpose,
+            host_chain_slots[2].transpose,
+            host_chain_slots[3].transpose);
     fprintf(f, "  \"slot_muted\": [%d, %d, %d, %d],\n",
             host_chain_slots[0].muted,
             host_chain_slots[1].muted,
@@ -333,6 +338,32 @@ void shadow_load_state(void)
                 char msg[128];
                 snprintf(msg, sizeof(msg), "Loaded slot fwd channels: [%d, %d, %d, %d]",
                          f0, f1, f2, f3);
+                if (host_log) host_log(msg);
+            }
+        }
+    }
+
+    /* Parse slot_transpose array */
+    const char *tr_key = "\"slot_transpose\":";
+    char *tr_pos = strstr(json, tr_key);
+    if (tr_pos) {
+        tr_pos = strchr(tr_pos, '[');
+        if (tr_pos) {
+            int t0, t1, t2, t3;
+            if (sscanf(tr_pos, "[%d, %d, %d, %d]", &t0, &t1, &t2, &t3) == 4) {
+                int *vals[4] = {&t0, &t1, &t2, &t3};
+                for (int i = 0; i < 4; i++) {
+                    if (*vals[i] < -12) *vals[i] = -12;
+                    if (*vals[i] > 12) *vals[i] = 12;
+                }
+                host_chain_slots[0].transpose = t0;
+                host_chain_slots[1].transpose = t1;
+                host_chain_slots[2].transpose = t2;
+                host_chain_slots[3].transpose = t3;
+
+                char msg[128];
+                snprintf(msg, sizeof(msg), "Loaded slot transpose: [%d, %d, %d, %d]",
+                         t0, t1, t2, t3);
                 if (host_log) host_log(msg);
             }
         }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1357,6 +1357,7 @@ const CHAIN_SETTINGS_ITEMS = [
     { key: "slot:soloed", label: "Soloed", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:receive_channel", label: "Recv Ch", type: "int", min: 0, max: 16, step: 1 },
     { key: "slot:forward_channel", label: "Fwd Ch", type: "int", min: -2, max: 15, step: 1 },  // -2 = passthrough, -1 = auto, 0-15 = ch 1-16
+    { key: "slot:transpose", label: "Transpose", type: "int", min: -12, max: 12, step: 1 },
     { key: "mpe_mode", label: "MPE Mode", type: "int", min: 0, max: 1, step: 1 },
     { key: "lfo1", label: "LFO 1", type: "action" },
     { key: "lfo2", label: "LFO 2", type: "action" },
@@ -6490,6 +6491,11 @@ function getChainSettingValue(slot, setting) {
     if (setting.key === "slot:receive_channel") {
         const ch = parseInt(val);
         return ch === 0 ? "All" : `Ch ${val}`;
+    }
+    if (setting.key === "slot:transpose") {
+        const n = parseInt(val) || 0;
+        if (n === 0) return "0 st";
+        return `${n > 0 ? "+" : ""}${n} st`;
     }
     return String(val);
 }

--- a/src/shadow/shadow_ui_slots.mjs
+++ b/src/shadow/shadow_ui_slots.mjs
@@ -31,6 +31,7 @@ export const SLOT_SETTINGS = [
     { key: "slot:soloed", label: "Soloed", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:receive_channel", label: "Recv Ch", type: "int", min: 0, max: 16, step: 1 },
     { key: "slot:forward_channel", label: "Fwd Ch", type: "int", min: -2, max: 15, step: 1 },
+    { key: "slot:transpose", label: "Transpose", type: "int", min: -12, max: 12, step: 1 },
     { key: "mpe_mode", label: "MPE Mode", type: "int", min: 0, max: 1, step: 1 },
 ];
 
@@ -80,6 +81,11 @@ export function getSlotSettingValue(slot, setting) {
     if (setting.key === "slot:receive_channel") {
         const ch = parseInt(val);
         return ch === 0 ? "All" : `Ch ${val}`;
+    }
+    if (setting.key === "slot:transpose") {
+        const n = parseInt(val) || 0;
+        if (n === 0) return "0 st";
+        return `${n > 0 ? "+" : ""}${n} st`;
     }
     return val;
 }


### PR DESCRIPTION
## Summary
- Adds a **Transpose** setting to each shadow slot (range -12 to +12 semitones), applied to incoming note-on / note-off / poly aftertouch before the synth receives them. CC, pitch bend, program change, and channel aftertouch pass through unchanged.
- Per-slot active-note tracker remembers the transposed value from each note-on and reuses it on the matching note-off — so changing transpose while notes are held doesn't leave stuck voices.
- Applied in both the standard `shadow_chain_dispatch_midi_to_slots` path and the MPE direct-external (`Recv=All + Fwd=THRU`) path. Persists across reboots via `shadow_chain_config.json`.

## Files touched
- `src/host/shadow_chain_types.h` — new `int transpose` field on `shadow_chain_slot_t`
- `src/host/shadow_chain_mgmt.c` — init to 0; `slot:transpose` set/get handlers clamped to [-12, 12]
- `src/host/shadow_midi.c` — `shadow_chain_apply_transpose()` helper + per-slot active-note tracker
- `src/host/shadow_state.c` — save/load `slot_transpose` array in the shadow config JSON
- `src/shadow/shadow_ui_slots.mjs` — "Transpose" entry in `SLOT_SETTINGS`, rendered as `+3 st` / `-5 st` / `0 st`
- `src/shadow/shadow_ui.js` — matching entry in `CHAIN_SETTINGS_ITEMS` (Signal Chain edit view) with the same formatter

## Test plan
- [x] Build succeeds (`./scripts/build.sh`) with no new warnings
- [x] Deploy to Move (`./scripts/install.sh local --skip-modules --skip-confirmation`)
- [x] Transpose setting appears in slot settings (Shift+Vol+Track1) between Fwd Ch and MPE Mode
- [x] External MIDI controller plays transposed notes through a Schwung slot synth (verified in MPE mode on hardware)
- [x] Holding a note, changing transpose, and releasing closes the originally-played pitch (no stuck notes)
- [x] Value persists across a Move reboot
- [ ] Confirm behavior in non-MPE (standard dispatch) routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)