### PR TITLE
feat: host plumbing for voice-driven tool modules

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -548,6 +548,13 @@ else
     echo "Warning: .cache/move_manual.json not found - no bundled manual"
 fi
 
+# Bundle Schwung's own user manual so the Assistant tool can include it
+# in the LLM system prompt (and other tools could reference it too).
+if [ -f "MANUAL.md" ]; then
+    cp -u MANUAL.md ./build/shared/MANUAL.md
+    echo "Bundled Schwung MANUAL.md"
+fi
+
 # Copy host files (only if source is newer)
 cp -u ./src/host/menu_ui.js ./build/host/
 cp -u ./src/host/*.mjs ./build/host/ 2>/dev/null || true

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -149,7 +149,8 @@ typedef struct shadow_control_t {
     volatile uint8_t open_tool_cmd;     /* 0=none, 1=open tool (path in /data/UserData/schwung/open_tool_cmd.json) */
     volatile uint8_t long_press_shadow; /* 1=enable long-press Track/Menu/Step2 shortcuts */
     volatile uint8_t speaker_active;    /* 1=built-in speaker active (from CC 115 line-out detect) */
-    /* Compiler inserts 1 byte of padding here for uint16 alignment. */
+    volatile uint8_t sampler_source_request; /* 0=no request, 1=set Resample, 2=set Move Input. Shim resets to 0 after applying. */
+    volatile uint8_t sampler_silent;     /* 1=suppress sampler screen-reader announcements (e.g. "Sample saved") for tool-driven recordings */
     volatile uint16_t skipback_seconds; /* Skipback rolling buffer length: 30/60/120/180/240/300 */
     volatile uint8_t reserved[2];
 } shadow_control_t;

--- a/src/host/shadow_sampler.c
+++ b/src/host/shadow_sampler.c
@@ -79,6 +79,12 @@ int sampler_menu_cursor = SAMPLER_MENU_SOURCE;
 int16_t sampler_vu_peak = 0;
 int sampler_vu_hold_frames = 0;
 
+/* Diagnostic: max sample magnitude observed during the active recording.
+ * Reset on start_recording, logged on stop. Helps tell silent-capture from
+ * silent-output (e.g. did MOVE_INPUT actually deliver audio at all). */
+static int32_t sampler_recording_max_peak = 0;
+static uint64_t sampler_recording_blocks_captured = 0;
+
 /* Full-screen mode flag */
 int sampler_fullscreen_active = 0;
 
@@ -492,8 +498,8 @@ void sampler_start_recording_to(const char *output_path) {
         return;
     }
 
-    /* Force resample source */
-    sampler_source = SAMPLER_SOURCE_RESAMPLE;
+    /* Honor whatever source the caller selected via host_sampler_set_source.
+     * Older callers that want the Schwung mix should request source 0 first. */
 
     /* Create parent directory */
     char dir_buf[256];
@@ -559,6 +565,8 @@ void sampler_start_recording_to(const char *output_path) {
     sampler_writer_running = 1;
     sampler_state = SAMPLER_RECORDING;
     sampler_fade_in_remaining = SAMPLER_FADE_SAMPLES;
+    sampler_recording_max_peak = 0;
+    sampler_recording_blocks_captured = 0;
     /* Don't touch overlay — this is driven by external JS, not the sampler UI */
 
     char msg[256];
@@ -740,7 +748,15 @@ void sampler_stop_recording(void) {
 
     if (!sampler_writer_running) return;
 
-    s_host.log("Sampler: stopping recording");
+    {
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "Sampler: stopping recording (source=%d blocks=%llu max_peak=%d)",
+                 (int)sampler_source,
+                 (unsigned long long)sampler_recording_blocks_captured,
+                 (int)sampler_recording_max_peak);
+        s_host.log(msg);
+    }
 
     /* Signal writer thread to exit */
     pthread_mutex_lock(&sampler_ring_mutex);
@@ -843,6 +859,7 @@ static void sampler_capture_audio_common(const int16_t *audio) {
     /* Write to ring buffer if space available */
     if (sampler_ring_available_write() >= samples_to_write) {
         size_t write_pos = __atomic_load_n(&sampler_ring_write_pos, __ATOMIC_ACQUIRE);
+        int32_t block_peak = 0;
         for (size_t i = 0; i < samples_to_write; i++) {
             int16_t sample = audio[i];
             /* Apply fade-in ramp on first block(s) to avoid click */
@@ -851,9 +868,13 @@ static void sampler_capture_audio_common(const int16_t *audio) {
                 sample = (int16_t)((int32_t)sample * pos / SAMPLER_FADE_SAMPLES);
                 sampler_fade_in_remaining--;
             }
+            int32_t mag = sample < 0 ? -(int32_t)sample : (int32_t)sample;
+            if (mag > block_peak) block_peak = mag;
             sampler_ring_buffer[write_pos] = sample;
             write_pos = (write_pos + 1) % buffer_samples;
         }
+        if (block_peak > sampler_recording_max_peak) sampler_recording_max_peak = block_peak;
+        sampler_recording_blocks_captured++;
         __atomic_store_n(&sampler_ring_write_pos, write_pos, __ATOMIC_RELEASE);
 
         pthread_mutex_lock(&sampler_ring_mutex);

--- a/src/modules/tools/song-mode/ui.js
+++ b/src/modules/tools/song-mode/ui.js
@@ -831,6 +831,10 @@ function drainInjectQueue() {
             playStartTime = Date.now();
             /* Start deferred recording now that transport is stable */
             if (recordPendingPath) {
+                /* Song mode records the Schwung mix output, not mic. */
+                if (typeof host_sampler_set_source === "function") {
+                    host_sampler_set_source(0); /* 0 = Resample */
+                }
                 host_sampler_start(recordPendingPath);
                 console.log("song-mode: recording started -> " + recordPendingPath);
                 recordPendingPath = "";

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2128,6 +2128,23 @@ skip_la_rebuild:
             }
         }
 
+        /* Sampler source request from shadow UI (used by tool modules that need
+         * to record from a specific source — e.g. the assistant needs Move Input
+         * for voice). 1=Resample, 2=Move Input. Reset to 0 after applying.
+         * Processed BEFORE sampler_cmd so a "set source then start" sequence in
+         * the same tick captures audio from the requested source. */
+        uint8_t src_req = shadow_control->sampler_source_request;
+        if (src_req != 0) {
+            shadow_control->sampler_source_request = 0;
+            sampler_source = (src_req == 2)
+                ? SAMPLER_SOURCE_MOVE_INPUT
+                : SAMPLER_SOURCE_RESAMPLE;
+            shadow_overlay_sync();
+            unified_log("shim", LOG_LEVEL_INFO,
+                       "sampler source request applied: req=%u -> source=%d (0=Resample,1=MoveInput)",
+                       src_req, (int)sampler_source);
+        }
+
         /* Skipback buffer resize: settings UI writes new desired length to
          * shadow_control->skipback_seconds. We compare against the actually
          * allocated size and dispatch a worker thread to resize. The worker
@@ -2161,6 +2178,9 @@ skip_la_rebuild:
                 fclose(pf);
             }
             if (path_buf[0]) {
+                unified_log("shim", LOG_LEVEL_INFO,
+                           "sampler start: path=%s source=%d (0=Resample,1=MoveInput)",
+                           path_buf, (int)sampler_source);
                 sampler_start_recording_to(path_buf);
             }
         } else if (cmd == 2) {
@@ -3390,6 +3410,16 @@ static ssize_t (*real_read)(int fd, void *buf, size_t count) = NULL;
  * ============================================================================ */
 static int shim_subsystems_initialized = 0;
 
+/* Sampler-specific announce wrapper. Tool modules that drive the sampler
+ * programmatically set shadow_control->sampler_silent to suppress the
+ * system "Sample saved" / "Recording failed" voice messages so the user
+ * only hears the tool's own TTS (if any). */
+static void sampler_announce_maybe_silent(const char *msg)
+{
+    if (shadow_control && shadow_control->sampler_silent) return;
+    send_screenreader_announcement(msg);
+}
+
 static void shim_init_subsystems(void)
 {
     if (shim_subsystems_initialized) return;
@@ -3431,11 +3461,16 @@ static void shim_init_subsystems(void)
         };
         chain_mgmt_init(&cm_host);
     }
-    /* Initialize sampler subsystem with callbacks to shim functions */
+    /* Sampler announce wrapper: defined inline above so this scope can
+     * reference it. (Hoisted via the prototype near the top of the file.) */
+    /* Initialize sampler subsystem with callbacks to shim functions.
+     * Use a wrapper for `announce` so tool modules can suppress sampler
+     * chatter ("Sample saved", etc.) by setting
+     * shadow_control->sampler_silent. */
     {
         sampler_host_t sampler_host = {
             .log = shadow_log,
-            .announce = send_screenreader_announcement,
+            .announce = sampler_announce_maybe_silent,
             .overlay_sync = shadow_overlay_sync,
             .run_command = shim_run_command,
             .global_mmap_addr = &global_mmap_addr,

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -1078,6 +1078,404 @@ static JSValue js_host_http_download_background(JSContext *ctx, JSValueConst thi
     return JS_UNDEFINED;
 }
 
+/* ----------------------------------------------------------------
+ * host_http_request_background
+ *
+ * General-purpose HTTP client wrapping the bundled curl binary.
+ * Supports POST/PUT/etc, custom headers (kept out of `ps` via -K
+ * config file with mode 0600), JSON or multipart bodies, and reports
+ * completion to JS via a status file.
+ *
+ * Options object:
+ *   url             string  required. http(s) only.
+ *   method          string  optional, default "GET".
+ *   headers         array   optional, strings like "Authorization: Bearer ...".
+ *   body_path       string  optional, path under BASE_DIR with raw body.
+ *   body_form       array   optional, multipart parts.
+ *                           {name, value} or {name, file, type}.
+ *   response_path   string  required, where curl writes the body.
+ *   status_path     string  required, written when curl exits with
+ *                           {"http_status":N,"curl_exit":N}.
+ *   timeout_seconds number  optional, default 60.
+ *
+ * body_path and body_form are mutually exclusive.
+ * Returns true if launched, false on validation failure.
+ * ---------------------------------------------------------------- */
+
+/* Write a curl -K config file containing headers, mode 0600.
+ * Returns 0 on success, -1 on failure. Empty headers list -> deletes the
+ * file if it existed and returns 0. */
+static int write_curl_headers_config(const char *path,
+                                     char **headers,
+                                     int header_count) {
+    if (header_count <= 0) {
+        unlink(path);
+        return 0;
+    }
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) return -1;
+    FILE *f = fdopen(fd, "w");
+    if (!f) {
+        close(fd);
+        return -1;
+    }
+    for (int i = 0; i < header_count; i++) {
+        const char *h = headers[i];
+        /* Reject CR/LF to prevent header injection */
+        if (strchr(h, '\r') || strchr(h, '\n')) {
+            fclose(f);
+            unlink(path);
+            return -1;
+        }
+        fputs("header = \"", f);
+        for (const char *p = h; *p; p++) {
+            if (*p == '\\' || *p == '"') fputc('\\', f);
+            fputc(*p, f);
+        }
+        fputs("\"\n", f);
+    }
+    fclose(f);
+    return 0;
+}
+
+/* Fork+exec curl in the background. Reads curl's stdout (the http_code from
+ * -w "%{http_code}"), waits for it to exit, then writes a JSON status file.
+ * If cleanup_path is non-NULL it is unlinked after curl exits. The runner
+ * frees argv_storage and headers_storage on the way out. */
+static void run_curl_with_status_background(char **argv_storage,
+                                            int argv_owned_count,
+                                            char *cleanup_path,
+                                            char *status_path) {
+    pid_t pid = fork();
+    if (pid != 0) {
+        /* parent: free our copies */
+        for (int i = 0; i < argv_owned_count; i++) free(argv_storage[i]);
+        free(argv_storage);
+        free(cleanup_path);
+        free(status_path);
+        return;
+    }
+
+    /* child: detach */
+    setsid();
+    int devnull = open("/dev/null", O_RDWR);
+    if (devnull >= 0) dup2(devnull, STDIN_FILENO);
+
+    int pipe_fd[2] = {-1, -1};
+    if (pipe(pipe_fd) != 0) {
+        if (status_path) {
+            FILE *f = fopen(status_path, "w");
+            if (f) { fputs("{\"http_status\":0,\"curl_exit\":-1}", f); fclose(f); }
+        }
+        _exit(1);
+    }
+
+    pid_t curl_pid = fork();
+    if (curl_pid == 0) {
+        /* grandchild: run curl */
+        close(pipe_fd[0]);
+        dup2(pipe_fd[1], STDOUT_FILENO);
+        if (devnull >= 0) dup2(devnull, STDERR_FILENO);
+        close(pipe_fd[1]);
+        if (devnull > 2) close(devnull);
+        execvp(argv_storage[0], argv_storage);
+        _exit(127);
+    }
+
+    close(pipe_fd[1]);
+    if (devnull >= 0) close(devnull);
+
+    char status_buf[64];
+    int total = 0;
+    while (total < (int)sizeof(status_buf) - 1) {
+        ssize_t n = read(pipe_fd[0], status_buf + total,
+                         sizeof(status_buf) - 1 - total);
+        if (n <= 0) break;
+        total += n;
+    }
+    status_buf[total] = '\0';
+    close(pipe_fd[0]);
+
+    int wstat = 0;
+    waitpid(curl_pid, &wstat, 0);
+    int exit_code = WIFEXITED(wstat) ? WEXITSTATUS(wstat) : -1;
+    int http_code = atoi(status_buf);
+
+    if (cleanup_path) unlink(cleanup_path);
+
+    if (status_path) {
+        FILE *f = fopen(status_path, "w");
+        if (f) {
+            fprintf(f, "{\"http_status\":%d,\"curl_exit\":%d}",
+                    http_code, exit_code);
+            fclose(f);
+        }
+    }
+    _exit(0);
+}
+
+/* Helper: get a string property from a JS object. Caller must JS_FreeCString. */
+static const char *js_get_str_prop(JSContext *ctx, JSValueConst obj,
+                                   const char *name) {
+    JSValue v = JS_GetPropertyStr(ctx, obj, name);
+    if (JS_IsUndefined(v) || JS_IsNull(v)) {
+        JS_FreeValue(ctx, v);
+        return NULL;
+    }
+    const char *s = JS_ToCString(ctx, v);
+    JS_FreeValue(ctx, v);
+    return s;
+}
+
+/* Append a heap-allocated copy of `s` to argv at index *idx, growing *idx. */
+static int argv_push_dup(char ***argv, int *idx, int *cap, const char *s) {
+    if (*idx + 1 >= *cap) {
+        int new_cap = *cap * 2;
+        char **new_argv = realloc(*argv, sizeof(char *) * new_cap);
+        if (!new_argv) return -1;
+        *argv = new_argv;
+        *cap = new_cap;
+    }
+    char *copy = strdup(s ? s : "");
+    if (!copy) return -1;
+    (*argv)[(*idx)++] = copy;
+    return 0;
+}
+
+static JSValue js_host_http_request_background(JSContext *ctx,
+                                               JSValueConst this_val,
+                                               int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1 || !JS_IsObject(argv[0])) return JS_FALSE;
+    JSValueConst opts = argv[0];
+
+    const char *url = js_get_str_prop(ctx, opts, "url");
+    const char *response_path = js_get_str_prop(ctx, opts, "response_path");
+    const char *status_path = js_get_str_prop(ctx, opts, "status_path");
+    const char *method = js_get_str_prop(ctx, opts, "method");
+    const char *body_path = js_get_str_prop(ctx, opts, "body_path");
+
+    if (!url || !response_path || !status_path) goto fail;
+
+    if (strncmp(url, "https://", 8) != 0 && strncmp(url, "http://", 7) != 0) {
+        fprintf(stderr, "host_http_request: bad URL scheme\n");
+        goto fail;
+    }
+    if (!validate_path(response_path) || !validate_path(status_path)) {
+        fprintf(stderr, "host_http_request: bad response/status path\n");
+        goto fail;
+    }
+    if (body_path && !validate_path(body_path)) {
+        fprintf(stderr, "host_http_request: bad body_path\n");
+        goto fail;
+    }
+
+    /* timeout */
+    int timeout = 60;
+    JSValue tv = JS_GetPropertyStr(ctx, opts, "timeout_seconds");
+    if (!JS_IsUndefined(tv) && !JS_IsNull(tv)) {
+        int t = 0;
+        if (JS_ToInt32(ctx, &t, tv) == 0 && t > 0 && t <= 600) timeout = t;
+    }
+    JS_FreeValue(ctx, tv);
+
+    /* headers -> write config file alongside status_path */
+    JSValue headers_v = JS_GetPropertyStr(ctx, opts, "headers");
+    char **header_strs = NULL;
+    int header_count = 0;
+    int has_headers = 0;
+    if (JS_IsArray(ctx, headers_v)) {
+        JSValue len_v = JS_GetPropertyStr(ctx, headers_v, "length");
+        int n = 0;
+        JS_ToInt32(ctx, &n, len_v);
+        JS_FreeValue(ctx, len_v);
+        if (n > 0) {
+            header_strs = calloc(n, sizeof(char *));
+            if (!header_strs) { JS_FreeValue(ctx, headers_v); goto fail; }
+            for (int i = 0; i < n; i++) {
+                JSValue h = JS_GetPropertyUint32(ctx, headers_v, (uint32_t)i);
+                const char *hs = JS_ToCString(ctx, h);
+                JS_FreeValue(ctx, h);
+                if (!hs) {
+                    for (int j = 0; j < header_count; j++) free(header_strs[j]);
+                    free(header_strs);
+                    JS_FreeValue(ctx, headers_v);
+                    goto fail;
+                }
+                header_strs[header_count++] = strdup(hs);
+                JS_FreeCString(ctx, hs);
+            }
+            has_headers = 1;
+        }
+    }
+    JS_FreeValue(ctx, headers_v);
+
+    char *cfg_path = NULL;
+    if (has_headers) {
+        size_t cl = strlen(status_path) + 5;
+        cfg_path = malloc(cl);
+        if (!cfg_path) goto fail_headers;
+        snprintf(cfg_path, cl, "%s.cfg", status_path);
+        if (write_curl_headers_config(cfg_path, header_strs, header_count) != 0) {
+            fprintf(stderr, "host_http_request: failed to write headers cfg\n");
+            free(cfg_path);
+            cfg_path = NULL;
+            goto fail_headers;
+        }
+    }
+
+    /* Free our copies of the header strings now that they are persisted. */
+    for (int i = 0; i < header_count; i++) free(header_strs[i]);
+    free(header_strs);
+    header_strs = NULL;
+    header_count = 0;
+
+    /* Build curl argv */
+    int cap = 32;
+    char **cargv = malloc(sizeof(char *) * cap);
+    if (!cargv) goto fail_cfg;
+    int ci = 0;
+
+    char timeout_str[16];
+    snprintf(timeout_str, sizeof(timeout_str), "%d", timeout);
+
+    if (argv_push_dup(&cargv, &ci, &cap, CURL_PATH) ||
+        argv_push_dup(&cargv, &ci, &cap, "-sSk") ||
+        argv_push_dup(&cargv, &ci, &cap, "-w") ||
+        argv_push_dup(&cargv, &ci, &cap, "%{http_code}") ||
+        argv_push_dup(&cargv, &ci, &cap, "--connect-timeout") ||
+        argv_push_dup(&cargv, &ci, &cap, "10") ||
+        argv_push_dup(&cargv, &ci, &cap, "--max-time") ||
+        argv_push_dup(&cargv, &ci, &cap, timeout_str) ||
+        argv_push_dup(&cargv, &ci, &cap, "-o") ||
+        argv_push_dup(&cargv, &ci, &cap, response_path)) goto fail_argv;
+
+    if (method) {
+        if (argv_push_dup(&cargv, &ci, &cap, "-X") ||
+            argv_push_dup(&cargv, &ci, &cap, method)) goto fail_argv;
+    }
+    if (cfg_path) {
+        if (argv_push_dup(&cargv, &ci, &cap, "-K") ||
+            argv_push_dup(&cargv, &ci, &cap, cfg_path)) goto fail_argv;
+    }
+    if (body_path) {
+        char data_arg[PATH_MAX + 2];
+        snprintf(data_arg, sizeof(data_arg), "@%s", body_path);
+        if (argv_push_dup(&cargv, &ci, &cap, "--data-binary") ||
+            argv_push_dup(&cargv, &ci, &cap, data_arg)) goto fail_argv;
+    }
+
+    /* body_form: array of {name, value} or {name, file, type?} */
+    JSValue form_v = JS_GetPropertyStr(ctx, opts, "body_form");
+    if (JS_IsArray(ctx, form_v)) {
+        JSValue len_v = JS_GetPropertyStr(ctx, form_v, "length");
+        int fn = 0;
+        JS_ToInt32(ctx, &fn, len_v);
+        JS_FreeValue(ctx, len_v);
+        for (int i = 0; i < fn; i++) {
+            JSValue part = JS_GetPropertyUint32(ctx, form_v, (uint32_t)i);
+            const char *pname = js_get_str_prop(ctx, part, "name");
+            const char *pvalue = js_get_str_prop(ctx, part, "value");
+            const char *pfile = js_get_str_prop(ctx, part, "file");
+            const char *ptype = js_get_str_prop(ctx, part, "type");
+            if (!pname || (!pvalue && !pfile)) {
+                if (pname) JS_FreeCString(ctx, pname);
+                if (pvalue) JS_FreeCString(ctx, pvalue);
+                if (pfile) JS_FreeCString(ctx, pfile);
+                if (ptype) JS_FreeCString(ctx, ptype);
+                JS_FreeValue(ctx, part);
+                JS_FreeValue(ctx, form_v);
+                goto fail_argv;
+            }
+            if (pfile && !validate_path(pfile)) {
+                fprintf(stderr, "host_http_request: bad form file path\n");
+                JS_FreeCString(ctx, pname);
+                if (pvalue) JS_FreeCString(ctx, pvalue);
+                JS_FreeCString(ctx, pfile);
+                if (ptype) JS_FreeCString(ctx, ptype);
+                JS_FreeValue(ctx, part);
+                JS_FreeValue(ctx, form_v);
+                goto fail_argv;
+            }
+            char part_buf[PATH_MAX + 256];
+            if (pfile) {
+                if (ptype && *ptype) {
+                    snprintf(part_buf, sizeof(part_buf), "%s=@%s;type=%s",
+                             pname, pfile, ptype);
+                } else {
+                    snprintf(part_buf, sizeof(part_buf), "%s=@%s",
+                             pname, pfile);
+                }
+            } else {
+                snprintf(part_buf, sizeof(part_buf), "%s=%s", pname, pvalue);
+            }
+            JS_FreeCString(ctx, pname);
+            if (pvalue) JS_FreeCString(ctx, pvalue);
+            if (pfile) JS_FreeCString(ctx, pfile);
+            if (ptype) JS_FreeCString(ctx, ptype);
+            JS_FreeValue(ctx, part);
+
+            if (argv_push_dup(&cargv, &ci, &cap, "-F") ||
+                argv_push_dup(&cargv, &ci, &cap, part_buf)) {
+                JS_FreeValue(ctx, form_v);
+                goto fail_argv;
+            }
+        }
+    }
+    JS_FreeValue(ctx, form_v);
+
+    if (argv_push_dup(&cargv, &ci, &cap, url)) goto fail_argv;
+
+    /* Sentinel NULL */
+    if (ci + 1 >= cap) {
+        char **na = realloc(cargv, sizeof(char *) * (cap + 1));
+        if (!na) goto fail_argv;
+        cargv = na;
+        cap++;
+    }
+    cargv[ci] = NULL;
+
+    /* Pre-clear status file so JS poll only sees the new result */
+    unlink(status_path);
+
+    /* Hand ownership of cfg_path to the background runner (it'll unlink the
+     * file and free the string). NULL our local so the fail_cfg cleanup path
+     * doesn't double-free if status_dup fails. */
+    char *cleanup_dup = cfg_path;
+    cfg_path = NULL;
+    char *status_dup = strdup(status_path);
+    if (!status_dup) { free(cleanup_dup); goto fail_argv; }
+
+    run_curl_with_status_background(cargv, ci, cleanup_dup, status_dup);
+
+    JS_FreeCString(ctx, url);
+    JS_FreeCString(ctx, response_path);
+    JS_FreeCString(ctx, status_path);
+    if (method) JS_FreeCString(ctx, method);
+    if (body_path) JS_FreeCString(ctx, body_path);
+    return JS_TRUE;
+
+fail_argv:
+    if (cargv) {
+        for (int i = 0; i < ci; i++) free(cargv[i]);
+        free(cargv);
+    }
+fail_cfg:
+    if (cfg_path) { unlink(cfg_path); free(cfg_path); }
+fail_headers:
+    if (header_strs) {
+        for (int i = 0; i < header_count; i++) free(header_strs[i]);
+        free(header_strs);
+    }
+fail:
+    if (url) JS_FreeCString(ctx, url);
+    if (response_path) JS_FreeCString(ctx, response_path);
+    if (status_path) JS_FreeCString(ctx, status_path);
+    if (method) JS_FreeCString(ctx, method);
+    if (body_path) JS_FreeCString(ctx, body_path);
+    return JS_FALSE;
+}
+
 /* host_extract_tar(tar_path, dest_dir) -> bool */
 static JSValue js_host_extract_tar(JSContext *ctx, JSValueConst this_val,
                                    int argc, JSValueConst *argv) {
@@ -2365,6 +2763,108 @@ static JSValue js_host_sampler_is_recording(JSContext *ctx, JSValueConst this_va
     return (shadow_control->sampler_state_val == 2) ? JS_TRUE : JS_FALSE;  /* 2 = SAMPLER_RECORDING */
 }
 
+/* Minimal RFC-4648 base64 encoder used by host_read_file_base64 below.
+ * Standalone so we don't pull in mbedTLS/OpenSSL just for this one spot. */
+static char *shadow_b64_encode(const unsigned char *in, size_t len, size_t *out_len) {
+    static const char alpha[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    size_t outlen = 4 * ((len + 2) / 3);
+    char *out = (char *)malloc(outlen + 1);
+    if (!out) return NULL;
+    size_t i, j;
+    for (i = 0, j = 0; i + 2 < len; i += 3, j += 4) {
+        uint32_t t = ((uint32_t)in[i] << 16) | ((uint32_t)in[i + 1] << 8)
+                    | (uint32_t)in[i + 2];
+        out[j]     = alpha[(t >> 18) & 0x3F];
+        out[j + 1] = alpha[(t >> 12) & 0x3F];
+        out[j + 2] = alpha[(t >> 6) & 0x3F];
+        out[j + 3] = alpha[t & 0x3F];
+    }
+    if (i < len) {
+        uint32_t t = (uint32_t)in[i] << 16;
+        if (i + 1 < len) t |= (uint32_t)in[i + 1] << 8;
+        out[j]     = alpha[(t >> 18) & 0x3F];
+        out[j + 1] = alpha[(t >> 12) & 0x3F];
+        out[j + 2] = (i + 1 < len) ? alpha[(t >> 6) & 0x3F] : '=';
+        out[j + 3] = '=';
+        j += 4;
+    }
+    out[j] = '\0';
+    if (out_len) *out_len = j;
+    return out;
+}
+
+/* host_read_file_base64(path) -> string | null
+ * Reads the raw bytes of a file and returns a base64-encoded string.
+ * Needed for providers like Gemini that take audio inline via JSON as
+ * base64 rather than multipart form. Caps input at 16 MB to keep memory
+ * usage bounded on the device. */
+static JSValue js_host_read_file_base64(JSContext *ctx, JSValueConst this_val,
+                                         int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1) return JS_NULL;
+    const char *path = JS_ToCString(ctx, argv[0]);
+    if (!path) return JS_NULL;
+    if (!validate_path(path)) {
+        JS_FreeCString(ctx, path);
+        return JS_NULL;
+    }
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        JS_FreeCString(ctx, path);
+        return JS_NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f); JS_FreeCString(ctx, path); return JS_NULL;
+    }
+    long size = ftell(f);
+    if (size < 0 || size > 16L * 1024 * 1024) {
+        fclose(f); JS_FreeCString(ctx, path); return JS_NULL;
+    }
+    rewind(f);
+    unsigned char *buf = (unsigned char *)malloc((size_t)size + 1);
+    if (!buf) { fclose(f); JS_FreeCString(ctx, path); return JS_NULL; }
+    size_t n = fread(buf, 1, (size_t)size, f);
+    fclose(f);
+    JS_FreeCString(ctx, path);
+
+    size_t b64_len = 0;
+    char *b64 = shadow_b64_encode(buf, n, &b64_len);
+    free(buf);
+    if (!b64) return JS_NULL;
+    JSValue result = JS_NewStringLen(ctx, b64, b64_len);
+    free(b64);
+    return result;
+}
+
+/* host_sampler_set_source(source) - request sampler source change.
+ * source: 0 = Resample (Schwung mix), 1 = Move Input (mic / line-in).
+ * Applied by shim on next idle tick. Returns true if request submitted. */
+static JSValue js_host_sampler_set_source(JSContext *ctx, JSValueConst this_val,
+                                           int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1 || !shadow_control) return JS_FALSE;
+    int src = 0;
+    JS_ToInt32(ctx, &src, argv[0]);
+    /* shim encoding: 1 = Resample, 2 = Move Input (0 = "no request") */
+    shadow_control->sampler_source_request = (src == 1) ? 2 : 1;
+    return JS_TRUE;
+}
+
+/* host_sampler_set_silent(enabled) - suppress sampler screen-reader chatter.
+ * Tools that record audio behind the user's back call set_silent(true) on
+ * entry so the system "Sample saved" voice prompt stays out of the way of
+ * their own replies. Reset to false on exit. */
+static JSValue js_host_sampler_set_silent(JSContext *ctx, JSValueConst this_val,
+                                           int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1 || !shadow_control) return JS_FALSE;
+    int enabled = 0;
+    JS_ToInt32(ctx, &enabled, argv[0]);
+    shadow_control->sampler_silent = enabled ? 1 : 0;
+    return JS_TRUE;
+}
+
 /* host_sampler_get_samples_written() - return number of samples written so far */
 static JSValue js_host_sampler_get_samples_written(JSContext *ctx, JSValueConst this_val,
                                                     int argc, JSValueConst *argv) {
@@ -2458,9 +2958,11 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     /* Register host functions for store operations */
     JS_SetPropertyStr(ctx, global_obj, "host_file_exists", JS_NewCFunction(ctx, js_host_file_exists, "host_file_exists", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_read_file", JS_NewCFunction(ctx, js_host_read_file, "host_read_file", 1));
+    JS_SetPropertyStr(ctx, global_obj, "host_read_file_base64", JS_NewCFunction(ctx, js_host_read_file_base64, "host_read_file_base64", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_write_file", JS_NewCFunction(ctx, js_host_write_file, "host_write_file", 2));
     JS_SetPropertyStr(ctx, global_obj, "host_http_download", JS_NewCFunction(ctx, js_host_http_download, "host_http_download", 2));
     JS_SetPropertyStr(ctx, global_obj, "host_http_download_background", JS_NewCFunction(ctx, js_host_http_download_background, "host_http_download_background", 2));
+    JS_SetPropertyStr(ctx, global_obj, "host_http_request_background", JS_NewCFunction(ctx, js_host_http_request_background, "host_http_request_background", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_extract_tar", JS_NewCFunction(ctx, js_host_extract_tar, "host_extract_tar", 2));
     JS_SetPropertyStr(ctx, global_obj, "host_extract_tar_strip", JS_NewCFunction(ctx, js_host_extract_tar_strip, "host_extract_tar_strip", 3));
     JS_SetPropertyStr(ctx, global_obj, "host_system_cmd", JS_NewCFunction(ctx, js_host_system_cmd, "host_system_cmd", 1));
@@ -2529,6 +3031,8 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_start", JS_NewCFunction(ctx, js_host_sampler_start, "host_sampler_start", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_stop", JS_NewCFunction(ctx, js_host_sampler_stop, "host_sampler_stop", 0));
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_is_recording", JS_NewCFunction(ctx, js_host_sampler_is_recording, "host_sampler_is_recording", 0));
+    JS_SetPropertyStr(ctx, global_obj, "host_sampler_set_source", JS_NewCFunction(ctx, js_host_sampler_set_source, "host_sampler_set_source", 1));
+    JS_SetPropertyStr(ctx, global_obj, "host_sampler_set_silent", JS_NewCFunction(ctx, js_host_sampler_set_silent, "host_sampler_set_silent", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_get_samples_written", JS_NewCFunction(ctx, js_host_sampler_get_samples_written, "host_sampler_get_samples_written", 0));
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_set_external_stop", JS_NewCFunction(ctx, js_host_sampler_set_external_stop, "host_sampler_set_external_stop", 1));
     JS_SetPropertyStr(ctx, global_obj, "host_sampler_pause", JS_NewCFunction(ctx, js_host_sampler_pause, "host_sampler_pause", 0));


### PR DESCRIPTION
## Summary

Adds reusable host infrastructure so a tool module can drive the sampler as a mic-capture path and talk to remote HTTP APIs. The AI Manual and AI Assistant tools that motivated this work now ship via the Module Store from dedicated external repos, per the split you suggested.

## What's in this PR (host-only)

### Shim / sampler bindings
- `shadow_control.sampler_source_request` (1=Resample, 2=Move Input) so a tool can switch the capture source atomically before kicking the sampler, independent of the user's last choice
- `shadow_control.sampler_silent` — suppresses the system \"Sample saved\" / \"Recording failed\" screen-reader announcements when a tool is driving the sampler programmatically

### New JS host bindings (shadow_ui.c)
- `host_http_request_background` — curl wrapper with POST/PUT/etc, custom headers (kept out of \`ps\` via \`-K\` config file, mode 0600), JSON or multipart bodies, status reported via \`status_path\`
- `host_read_file_base64` — for inlining audio into Gemini requests
- `host_sampler_set_source(0|1)` — 0=Resample, 1=Move Input
- `host_sampler_set_silent(bool)` — toggles sampler_silent above

### schwung-manager
- `password` / `textarea` / `string` settings field types
- `default_source` support (textarea pre-populated from a file a tool ships, with path-traversal + symlink guards)
- `SecurityHeaders` middleware (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`)
- Secrets dir hardening: root-owned 0710, `O_NOFOLLOW` writes, `Lchown` to prevent symlink-swap attacks

### Settings schema
- Assistant section (Gemini/OpenAI provider picker, keys, models, system prompt textarea) — UI metadata only; inert when no AI module is installed

### song-mode
- Explicitly requests Resample source before recording (follows the same new sampler_source_request pattern)

## External modules (separate repos, tagged releases)

These are what end users will install via the Module Store once a catalog entry PR lands:
- **AI Manual** — [eightfour-dev/schwung-ai-manual](https://github.com/eightfour-dev/schwung-ai-manual) v0.2.0
- **AI Assistant** — [eightfour-dev/schwung-ai-assistant](https://github.com/eightfour-dev/schwung-ai-assistant) v0.1.0

I'll open the catalog entry PR in a follow-up with \`min_host_version\` pinned to whatever release ships these bindings.

## Test plan

Verified on hardware with the external modules installed against this host:

- [x] \`./scripts/build.sh\` succeeds cleanly (no warnings on new code)
- [x] \`./scripts/install.sh local --skip-modules --skip-confirmation\` deploys, Move restarts with shim loaded
- [x] Web UI at \`http://move.local:7700/config\` shows the Assistant section: Provider selector, per-provider key + model fields, Wi-Fi-trust warning under password fields
- [x] Gemini path: free AI-Studio key + external AI Manual module → short headline + scrollable detailed answer
- [x] OpenAI path: same flow with Provider=OpenAI
- [x] AI Assistant (external) long-form prose reply, scrollable with jog wheel
- [x] TTS toggle via \"Speak AI Assistant Replies\" in config + mid-session knob toggle
- [x] Offline path shows \`Offline\` header + helpful body; auto-recovers within ~10s
- [x] Rate-limit path shows \`Rate limited\` + provider error message
- [x] Security headers present on \`/config\`
- [x] Secrets dir locked down: \`drwx--x--- root users\`, individual files \`-rw------- ableton users\`
- [x] Existing flows unaffected: native Move synths, Shadow UI slots, Shift+Sample, Song Mode recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)