### PR TITLE
catalog: add Guitar Tuner (tool) by eightfour

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -559,6 +559,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "guitar-tuner",
+      "name": "Guitar Tuner",
+      "description": "Chromatic tuner for guitar (and any other instrument). Nearest note and cents deviation on the OLED; big letter glyph on the pad grid. Uses the Move's mic or 3.5mm line-in.",
+      "author": "eightfour",
+      "component_type": "tool",
+      "github_repo": "eightfour-dev/schwung-guitar-tuner",
+      "default_branch": "main",
+      "asset_name": "guitar-tuner-module.tar.gz",
+      "min_host_version": "0.9.8"
+    },
+    {
       "id": "tuner",
       "name": "Tuner",
       "description": "Chromatic and instrument tuner with step guide feedback",


### PR DESCRIPTION
## Summary

Adds the **Guitar Tuner** to `module-catalog.json`, pointing at [eightfour-dev/schwung-guitar-tuner](https://github.com/eightfour-dev/schwung-guitar-tuner) (v0.2.0 released).

Per review feedback on the previous version of this PR, the tool is now an **external module** instead of being built into Schwung core, following the `schwung-stretch` pattern.

## Changes

- `module-catalog.json` — catalog entry for `guitar-tuner` (component_type: `tool`)
- `src/shared/settings-schema.json` — Tuner section with the accidental-style toggle (flats vs sharps) that the tool reads via `host_get_setting("tuner_accidental_style")`. Matches the pattern of existing external-module settings like the AI Assistant's `openai_*` keys.

## Tool features (for reference)

Chromatic tuner for guitar and any other instrument.
- **Pitch detection**: YIN (cumulative-mean-normalized difference) on a 2048-sample window over the Move's built-in mic or 3.5mm line-in (plug-detect auto-switches).
- **OLED**: nearest note + signed cents + needle meter.
- **Pad grid**: 3×4 letter glyph with a sharp/flat accidental column.
- **Color grading by accuracy**: green (locked, <3¢), white (close, <10¢), amber (off, <25¢), red (very off).

## Test plan

- [x] External repo builds cleanly via \`./scripts/build.sh\` (Docker cross-compile to ARM64)
- [x] GitHub Actions tags + releases v0.2.0 with \`guitar-tuner-module.tar.gz\`
- [x] Release tarball installs to \`modules/tools/guitar-tuner/\` on device
- [x] Module appears in Tools menu and detects pitch from built-in mic
- [x] Accidental-style toggle in web config changes the pad glyph's sharp/flat column