### PR TITLE
build.sh: Docker fallback for schwung-manager when 'go' is missing

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,27 +51,56 @@ if [ -z "$CROSS_PREFIX" ] && [ ! -f "/.dockerenv" ]; then
         -e REQUIRE_SCREEN_READER="$REQUIRE_SCREEN_READER" \
         "$IMAGE_NAME"
 
-    # Build schwung-manager (Go, cross-compiles natively — no Docker needed)
-    if command -v go &>/dev/null && [ -d "$REPO_ROOT/schwung-manager" ]; then
+    # Build schwung-manager (Go, ARM64 cross-compile).
+    # Prefer local `go` when available (fast). Fall back to a Docker
+    # `golang:1.26-bookworm` container so the build still produces a fresh
+    # binary on hosts without Go installed. If neither is available, warn
+    # loudly — silently skipping leaves a stale binary in the tarball and
+    # any new schwung-manager endpoints will appear broken on-device.
+    if [ -d "$REPO_ROOT/schwung-manager" ]; then
         echo ""
         echo "=== Building schwung-manager (Go) ==="
-        cd "$REPO_ROOT/schwung-manager"
-        GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .
-        echo "Built: schwung-manager ($(wc -c < "$REPO_ROOT/build/schwung-manager" | tr -d ' ') bytes)"
-        cd "$REPO_ROOT"
-        # Inject into existing tarball (append the file with the schwung/ prefix)
-        if [ -f "$REPO_ROOT/schwung.tar.gz" ]; then
-            cd build
-            # gunzip, append, re-gzip (tar -r doesn't work on .gz)
-            gunzip -k "$REPO_ROOT/schwung.tar.gz" -f
-            if tar --version 2>/dev/null | grep -q GNU; then
-                tar --format=posix -rf "$REPO_ROOT/schwung.tar" --transform 's,^\.,schwung,' ./schwung-manager
-            else
-                tar -rf "$REPO_ROOT/schwung.tar" -s ',^\.,schwung,' ./schwung-manager
-            fi
-            gzip -f "$REPO_ROOT/schwung.tar"
+        sm_built=0
+        if command -v go &>/dev/null; then
+            cd "$REPO_ROOT/schwung-manager"
+            GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .
             cd "$REPO_ROOT"
-            echo "Injected schwung-manager into tarball"
+            sm_built=1
+        elif command -v docker &>/dev/null; then
+            echo "Local 'go' not found — building via golang:1.26-bookworm container"
+            docker run --rm \
+                -v "$REPO_ROOT/schwung-manager:/src" \
+                -v "$REPO_ROOT/build:/out" \
+                -u "$(id -u):$(id -g)" \
+                -w /src \
+                -e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
+                -e GOCACHE=/tmp/.gocache -e GOMODCACHE=/tmp/.gomodcache \
+                golang:1.26-bookworm \
+                go build -buildvcs=false -o /out/schwung-manager -ldflags="-s -w" .
+            sm_built=1
+        else
+            echo "WARNING: neither 'go' nor 'docker' available — skipping schwung-manager rebuild."
+            echo "         The tarball will contain whatever stale binary is committed at"
+            echo "         schwung-manager/schwung-manager-arm64. Any new schwung-manager"
+            echo "         endpoints (e.g. per-module config UI) will not work on-device."
+        fi
+
+        if [ "$sm_built" = "1" ]; then
+            echo "Built: schwung-manager ($(wc -c < "$REPO_ROOT/build/schwung-manager" | tr -d ' ') bytes)"
+            # Inject into existing tarball (append the file with the schwung/ prefix)
+            if [ -f "$REPO_ROOT/schwung.tar.gz" ]; then
+                cd build
+                # gunzip, append, re-gzip (tar -r doesn't work on .gz)
+                gunzip -k "$REPO_ROOT/schwung.tar.gz" -f
+                if tar --version 2>/dev/null | grep -q GNU; then
+                    tar --format=posix -rf "$REPO_ROOT/schwung.tar" --transform 's,^\.,schwung,' ./schwung-manager
+                else
+                    tar -rf "$REPO_ROOT/schwung.tar" -s ',^\.,schwung,' ./schwung-manager
+                fi
+                gzip -f "$REPO_ROOT/schwung.tar"
+                cd "$REPO_ROOT"
+                echo "Injected schwung-manager into tarball"
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary

`scripts/build.sh` previously gated the `schwung-manager` rebuild behind `command -v go`. On a host without Go installed, the script would silently skip rebuilding and the tarball would carry whatever stale binary is committed at `schwung-manager/schwung-manager-arm64`. Any new schwung-manager endpoint (e.g. the per-module config UI added in 0.9.8) appeared broken on-device with no error to explain why.

This change:

- Keeps the fast local-`go` path when Go is available
- Adds a `golang:1.26-bookworm` Docker fallback that produces the same ARM64 binary when Go is missing but Docker is present (which is already the project's primary build dependency)
- Prints a loud warning, including the consequence, only when neither is available

The Docker invocation mirrors the local one: `GOOS=linux GOARCH=arm64 CGO_ENABLED=0`, `-ldflags="-s -w"`, plus `-buildvcs=false` since the container doesn't see the host's git tree. Mounted with `-u "$(id -u):$(id -g)"` so the output binary is owned by the host user, and Go caches go to `/tmp` inside the container so they don't pollute the source tree.

## Test plan

- [x] On a host with no Go installed, ran the new Docker fallback path and produced a valid ARM64 binary (`file build/schwung-manager` → `ELF 64-bit LSB executable, ARM aarch64, … statically linked`)
- [x] Bash logic for the no-Go-and-no-Docker warning path inspected by reading
- [ ] On a host with `go` installed: confirm the local fast path is unchanged (no Docker overhead). Reviewer can confirm by running `./scripts/build.sh` and verifying the "=== Building schwung-manager (Go) ===" section completes without launching a container.