### PR TITLE
fix(shim): defer inject drain on cable-2 external MIDI activity

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -425,15 +425,16 @@ void shadow_drain_midi_inject(void)
     const int DEFER_FRAMES = 2;
     static int defer_counter = 0;
     uint8_t *midi_in_scan = host_shadow_mailbox + MIDI_IN_OFFSET;
-    int cable0_active = 0;
+    int hw_cable_active = 0;
     for (int j = 0; j < MIDI_IN_MAX_BYTES; j += MIDI_IN_EVT_STRIDE) {
-        if (midi_in_scan[j] == 0) break;      /* end-of-events */
-        if ((midi_in_scan[j] >> 4) == 0) {    /* cable 0 */
-            cable0_active = 1;
+        if (midi_in_scan[j] == 0) break;
+        int cable = midi_in_scan[j] >> 4;
+        if (cable == 0 || cable == 2) {   /* cable 0 (pads/hw) or cable 2 (external MIDI) */
+            hw_cable_active = 1;
             break;
         }
     }
-    if (cable0_active) {
+    if (hw_cable_active) {
         defer_counter = 0;
         return;
     }


### PR DESCRIPTION
## Summary

- The inject drain in `shadow_drain_midi_inject` already deferred when cable-0 (pad/hardware) events were present in MIDI_IN. The same race exists for cable-2: when a real external USB MIDI event arrives in MIDI_IN in the same SPI tick as a cable-2 inject, Move's firmware processes both simultaneously and crashes (SIGABRT).
- Extend the defer gate to include `cable == 2` alongside `cable == 0`.

## Root cause

`shadow_drain_midi_inject` scans MIDI_IN for cable-0 activity and holds the SHM contents for 2 frames if any is found. Cable-2 external MIDI arriving in the same tick as a cable-2 inject creates an identical race — but had no protection.

Reproduced with SEQ8: one ROUTE_MOVE track injecting sequenced notes while a second ROUTE_MOVE track received live external keyboard MIDI. The Schwung debug log showed `MIDI inject: drained 1/1 pkts at offset 8` (external event in slot 0, inject landed in slot 8) immediately before `[CRASH] [shim] Caught SIGABRT`.

## Test plan

- [ ] ROUTE_MOVE sequencer playback + simultaneous external MIDI input: no crash
- [ ] ROUTE_MOVE sequencer playback alone: notes still reach Move instrument (defer doesn't fire spuriously)
- [ ] Cable-0 pad activity: existing defer behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)