### PR TITLE
ext_midi_remap: add EXT_MIDI_REMAP_BLOCK to suppress cable-2 note-ons from Move

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -246,6 +246,7 @@ typedef struct schwung_ext_midi_remap_t {
 } schwung_ext_midi_remap_t;          /* 64 bytes total */
 
 #define EXT_MIDI_REMAP_PASSTHROUGH 0xFF
+#define EXT_MIDI_REMAP_BLOCK       0xFE  /* block note-ons from Move; shadow_ui still sees original */
 #define EXT_MIDI_REMAP_VERSION     1
 
 /*

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -5178,37 +5178,69 @@ static int any_thru_slot_active(void) {
 static void shim_remap_cable2_channels(uint8_t *shadow) {
     if (!ext_midi_remap_feature_enabled) return;  /* Feature flag kill switch */
     if (!ext_midi_remap_shm || !ext_midi_remap_shm->enabled) return;
-    if (any_thru_slot_active()) return;  /* MPE escape hatch */
     if (!hardware_mmap_addr) return;
 
-    /* Mutate both hw (so Move sees remapped channels on this frame) and
-     * shadow (so next frame's pre-transfer readers — cable-2 echo filter,
-     * shadow_forward_external_cc_to_out — see consistent data). */
-    uint8_t *targets[2] = { hardware_mmap_addr, shadow };
-    for (int t = 0; t < 2; t++) {
-        uint8_t *buf = targets[t];
-        if (!buf) continue;
-        buf += MIDI_IN_OFFSET;
-        /* MIDI_IN events are 8 bytes (4 USB-MIDI + 4 timestamp). 4-byte
-         * stride visits timestamps and rewrites their bytes when a
-         * timestamp byte happens to look like cable-2 + a non-system
-         * status — corrupts the contiguous event run that Move's MIDI_IN
-         * parser scans (it terminates at the first zero slot). Sparse
-         * buffer hides this; transport-running + external MIDI fills the
-         * buffer and produces SIGABRT deep in Move's stack. */
-        const int MIDI_IN_MAX_BYTES = 8 * 31;     /* 31 events × 8 bytes */
-        for (int j = 0; j < MIDI_IN_MAX_BYTES; j += 8) {
-            uint8_t header = buf[j];
-            if (header == 0) break;               /* end-of-events */
-            uint8_t cable = (header >> 4) & 0x0F;
-            if (cable != 2) continue;             /* only cable-2 (external USB) */
-            uint8_t status = buf[j + 1];
-            if ((status & 0xF0) == 0xF0) continue; /* system messages — channelless */
-            uint8_t in_ch = status & 0x0F;
-            uint8_t mapped = ext_midi_remap_shm->remap[in_ch];
-            if (mapped == EXT_MIDI_REMAP_PASSTHROUGH || mapped >= 16) continue;
-            buf[j + 1] = (status & 0xF0) | (mapped & 0x0F);
+    /* MIDI_IN events are 8 bytes (4 USB-MIDI + 4 timestamp); stride at 8.
+     * 4-byte stride would hit timestamp bytes, corrupt the contiguous event
+     * run, and produce SIGABRT deep in Move's stack. */
+    uint8_t *hw_buf = hardware_mmap_addr + MIDI_IN_OFFSET;
+    uint8_t *sh_buf = shadow ? (shadow + MIDI_IN_OFFSET) : NULL;
+    const int MIDI_IN_MAX_BYTES = 8 * 31;     /* 31 events × 8 bytes */
+
+    for (int j = 0; j < MIDI_IN_MAX_BYTES; j += 8) {
+        uint8_t header = hw_buf[j];
+        if (header == 0) break;               /* end-of-events */
+        uint8_t cable = (header >> 4) & 0x0F;
+        if (cable != 2) continue;             /* only cable-2 (external USB) */
+        uint8_t status = hw_buf[j + 1];
+        if ((status & 0xF0) == 0xF0) continue; /* system messages — channelless */
+        uint8_t in_ch = status & 0x0F;
+        uint8_t mapped = ext_midi_remap_shm->remap[in_ch];
+
+        if (mapped == EXT_MIDI_REMAP_PASSTHROUGH) continue;
+
+        if (mapped == EXT_MIDI_REMAP_BLOCK) {
+            /* Leave hardware_mmap_addr untouched — writing the MIDI_IN region
+             * of the hardware SPI mmap crashes Move's process.  The shadow
+             * buffer (sh_midi) is patched to a proper note-off after the
+             * sh_midi copy loop via shim_block_cable2_in_sh_midi(). */
+            continue;
         }
+
+        /* Normal channel remap: rewrite channel byte in both hw and shadow so
+         * Move firmware and next-frame internal readers see consistent data. */
+        if (mapped >= 16) continue;  /* guard: treat unknown values as passthrough */
+        hw_buf[j + 1] = (status & 0xF0) | (mapped & 0x0F);
+        if (sh_buf) sh_buf[j + 1] = (status & 0xF0) | (mapped & 0x0F);
+    }
+}
+
+/* Patch sh_midi (shadow buffer, 4-byte stride) to suppress BLOCK channels from
+ * reaching Move's firmware.  Called AFTER the sh_midi copy loop so the patch
+ * survives the overwrite.  Converts note-ons on BLOCK channels to proper
+ * note-offs (CIN 8 / status 0x80) rather than zeroing velocity, avoiding any
+ * firmware edge-case on velocity=0 note-ons.  hardware_mmap_addr is left
+ * untouched — writing MIDI_IN there crashes Move's process. */
+static void shim_block_cable2_in_sh_midi(uint8_t *sh_midi) {
+    if (!ext_midi_remap_feature_enabled) return;
+    if (!ext_midi_remap_shm || !ext_midi_remap_shm->enabled) return;
+    /* MIDI_IN events are 8 bytes (4 USB-MIDI + 4 timestamp). Must stride by 8
+     * so we only inspect the USB-MIDI header bytes and never accidentally
+     * interpret or corrupt timestamp bytes. */
+    const int MIDI_IN_MAX_BYTES = 8 * 31;
+    for (int j = 0; j < MIDI_IN_MAX_BYTES; j += 8) {
+        if (sh_midi[j] == 0) break;                    /* end of events */
+        uint8_t cable = (sh_midi[j] >> 4) & 0x0F;
+        if (cable != 2) continue;
+        uint8_t status = sh_midi[j + 1];
+        if ((status & 0xF0) != 0x90) continue;         /* note-on only */
+        if (sh_midi[j + 3] == 0) continue;             /* already velocity=0 */
+        uint8_t in_ch = status & 0x0F;
+        if (ext_midi_remap_shm->remap[in_ch] != EXT_MIDI_REMAP_BLOCK) continue;
+        /* Convert to proper note-off so Move ignores it cleanly */
+        sh_midi[j]     = (sh_midi[j] & 0xF0) | 0x08;  /* CIN 8 = note-off */
+        sh_midi[j + 1] = 0x80 | in_ch;                 /* note-off status */
+        sh_midi[j + 3] = 0x40;                         /* standard note-off vel */
     }
 }
 
@@ -5543,6 +5575,11 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         /* Not in shadow mode - copy MIDI_IN directly */
         memcpy(sh_midi, hw_midi, MIDI_BUFFER_SIZE);
     }
+
+    /* Convert BLOCK-channel cable-2 note-ons to note-offs in shadow so Move
+     * ignores them.  Must run AFTER the sh_midi loop (which overwrites shadow
+     * from hw_midi) and only touches shadow — never hardware_mmap_addr. */
+    shim_block_cable2_in_sh_midi(sh_midi);
 
     /* === SHIFT+MENU SHORTCUT DETECTION AND BLOCKING (POST-IOCTL) ===
      * Scan hardware MIDI_IN for Shift+Menu, perform action, and block from reaching Move.
@@ -6449,6 +6486,11 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                                        (d1 >= 40 && d1 <= 43)));           /* track buttons */
                     if (!is_ui_event) continue;  /* Skip non-UI events in menu mode */
                 }
+
+                /* BLOCK channels: hardware_mmap_addr is NOT modified (writing
+                 * MIDI_IN hardware crashes Move), so src here has the original
+                 * velocity.  Forward the note-on normally so SEQ8 can route it.
+                 * Move won't play it because sh_midi has the patched note-off. */
 
                 /* Queue cable 2 note-on messages (external LED commands like M8)
                  * for rate-limited forwarding to prevent buffer overflow */

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -839,7 +839,9 @@ static JSValue js_host_ext_midi_remap_set(JSContext *ctx, JSValueConst this_val,
     if (JS_ToInt32(ctx, &in_ch, argv[0]) < 0) return JS_FALSE;
     if (JS_ToInt32(ctx, &out_ch, argv[1]) < 0) return JS_FALSE;
     if (in_ch < 0 || in_ch > 15) return JS_FALSE;
-    uint8_t mapped = (out_ch < 0 || out_ch > 15) ? EXT_MIDI_REMAP_PASSTHROUGH : (uint8_t)out_ch;
+    uint8_t mapped = (out_ch == (int32_t)EXT_MIDI_REMAP_BLOCK) ? EXT_MIDI_REMAP_BLOCK :
+                     (out_ch < 0 || out_ch > 15) ? EXT_MIDI_REMAP_PASSTHROUGH :
+                     (uint8_t)out_ch;
     ext_midi_remap->remap[in_ch] = mapped;
     __sync_synchronize();
     return JS_TRUE;


### PR DESCRIPTION
## Problem

The existing `ext_midi_remap` mechanism lets tool modules remap cable-2 (USB-A external controller) MIDI channels before they reach Move's firmware. It supports channel rewriting and passthrough, but has no way to *suppress* a cable-2 note from triggering a Move instrument entirely.

This matters for tools that handle external MIDI themselves — routing it through a DSP chain, a sequencer, or out a different port — and don't want Move's instrument layer playing the note at all. Previously, the only option was to set the active track to a non-Move route and accept that Move would still play whatever instrument was listening on that channel.

## Solution

Add an `EXT_MIDI_REMAP_BLOCK` sentinel value (`0xFE`) to the remap table. When a channel entry is set to BLOCK, cable-2 note-ons for that channel are suppressed from reaching Move's firmware while still being forwarded to the module's `onMidiMessageExternal` handler with their original data intact.

Tool modules opt in by calling `host_ext_midi_remap_set(channel, 254)` for any channels they want to capture exclusively.

## JS usage example

```js
// Called whenever the active track or route changes.
function applyExtMidiRemap() {
    if (typeof host_ext_midi_remap_enable !== 'function') return;

    const isMove = activeTrackRoute === ROUTE_MOVE;

    if (!isMove) {
        // Non-Move route: block all cable-2 channels from Move so the
        // module can handle them exclusively via onMidiMessageExternal.
        host_ext_midi_remap_clear();
        for (var ch = 0; ch < 16; ch++) {
            host_ext_midi_remap_set(ch, 254);  // EXT_MIDI_REMAP_BLOCK
        }
        host_ext_midi_remap_enable(1);
        return;
    }

    // ROUTE_MOVE: rechannelize incoming notes to the track's target channel
    // so Move's instrument plays on the correct channel. No blocking needed.
    const outCh = activeTrackChannel - 1;  // 0-indexed
    host_ext_midi_remap_clear();
    for (var ch = 0; ch < 16; ch++) {
        if (ch !== outCh) host_ext_midi_remap_set(ch, outCh);
    }
    host_ext_midi_remap_enable(1);
}

function onMidiMessageExternal(status, d1, d2) {
    // This fires for cable-2 events regardless of BLOCK state.
    // On non-Move routes, Move is silent — only this handler plays the note.
    var type = status & 0xF0;
    if (type === 0x90 && d2 > 0) {
        routeNoteToSequencer(d1, d2);
    }
}
```

The key point: `onMidiMessageExternal` always receives the original event — BLOCK only affects what Move's firmware sees. The two handlers are independent.

## Implementation

### Why this can't be done by writing `hardware_mmap_addr`

The obvious approach — zeroing the velocity in `hardware_mmap_addr` inline in `shim_remap_cable2_channels`, as normal remap does — crashes Move's process. The MIDI_IN region of the hardware SPI mmap is written by the XMOS side; writing it from ARM produces a fault.

### Two-phase approach

**Phase 1 — `shim_remap_cable2_channels`** (pre-transfer): when a cable-2 event is on a BLOCK channel, skip it — leave both `hardware_mmap_addr` and shadow untouched.

**Phase 2 — `shim_block_cable2_in_sh_midi`** (new function, post-transfer, *after* the `memcpy(sh_midi, hw_midi, ...)` copy): scan `sh_midi` for cable-2 note-ons on BLOCK channels and rewrite them to proper note-offs (CIN 8 / status `0x80`, velocity `0x40`). Must run after the copy loop or the patch would be overwritten.

Result:
- Move's firmware reads shadow, which has note-offs for BLOCK channels → no instrument triggered
- The post-transfer `onMidiMessageExternal` forwarding loop reads from `hardware_mmap_addr` (untouched) → module receives the original note-on with correct velocity
- Note-offs, CCs, aftertouch, and pitch bend on BLOCK channels pass through unmodified — they can't trigger new voices and are harmless without a preceding note-on

### `shadow_ui.c` change

`js_host_ext_midi_remap_set` previously clamped any value outside 0–15 to `EXT_MIDI_REMAP_PASSTHROUGH`. The change adds an explicit check for `254` before the range clamp, storing it as `EXT_MIDI_REMAP_BLOCK` instead of silently treating it as passthrough.

### Incidental refactor in `shim_remap_cable2_channels`

The original code used a `targets[2]` array to loop over both `hardware_mmap_addr` and `shadow` with the same write. With BLOCK needing to treat the two buffers differently, the loop is refactored to use explicit `hw_buf` / `sh_buf` pointers. Behavior for non-BLOCK channels is identical — both buffers still receive the channel rewrite.

## Scope and compatibility

- Fully opt-in. Modules that don't call `host_ext_midi_remap_set(..., 254)` are completely unaffected.
- When `ext_midi_remap_shm->enabled` is 0 or no channels are set to BLOCK, `shim_block_cable2_in_sh_midi` exits after the guard check — no per-frame overhead.
- The `any_thru_slot_active()` escape hatch is preserved in all paths.
- No changes to the public JS API surface beyond accepting `254` as a valid argument to the existing `host_ext_midi_remap_set`.

## Files changed

| File | Change |
|------|--------|
| `src/host/shadow_constants.h` | Add `EXT_MIDI_REMAP_BLOCK = 0xFE` |
| `src/schwung_shim.c` | BLOCK branch in `shim_remap_cable2_channels`; new `shim_block_cable2_in_sh_midi`; call site in `shim_post_transfer` |
| `src/shadow/shadow_ui.c` | Accept `254` as `EXT_MIDI_REMAP_BLOCK` in `js_host_ext_midi_remap_set` |