### PR TITLE
fix: strengthen shadow_drain_midi_inject guard against MIDI_IN race (SIGABRT)

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -409,31 +409,26 @@ void shadow_drain_midi_inject(void)
 
     if (!inject_shm) return;
 
-    /* Defer cable-2 injection when there's cable-0 hardware activity in the
-     * SAME tick. Injecting concurrently with a live pad event appears to
-     * race Move's firmware (observed: SIGABRT deep in Move's stack after
-     * ~1s of arp tick-path injections). The note-path injections (chord)
-     * escape this because they fire only AFTER Move has echoed the pad on
-     * cable-2 MIDI_OUT — at which point cable-0 MIDI_IN has been consumed.
-     * Tick-path injections (arp, generator-style FX) run every SPI cycle
-     * independently, so they need an explicit gate.
+    /* Defer inject when MIDI_IN has ANY hardware events this tick.
+     * All cables share Move's firmware MIDI read path — injecting concurrently
+     * with hardware events on ANY cable races Move's internal processing and
+     * causes SIGABRT. The original guard only checked cable-0 (pads), but
+     * empirically the crash occurs with inject at offset 24 when events on
+     * other cables occupy offsets 0/8/16 — confirming the guard must be
+     * cable-agnostic.  Move also partially consumes MIDI_IN (clearing slot 0
+     * while leaving events at higher offsets), so checking only slot 0 misses
+     * residual events; scan all slots.
      *
-     * Rule: if MIDI_IN has any cable-0 events this tick, reset the defer
-     * counter and hold the SHM contents. Otherwise, drain only once the
-     * counter has climbed to 2 (≈6ms at 2.9ms/tick). Pattern is from
-     * chord-mode-native (shadow_chord.c CHORD_DEFER_FRAMES). */
+     * Rule: if any MIDI_IN slot is non-zero this tick, reset the defer counter.
+     * Otherwise, drain once the counter has climbed to 2 (≈6ms at 2.9ms/tick).
+     * Pattern from chord-mode-native (shadow_chord.c CHORD_DEFER_FRAMES). */
     const int DEFER_FRAMES = 2;
     static int defer_counter = 0;
     uint8_t *midi_in_scan = host_shadow_mailbox + MIDI_IN_OFFSET;
-    int cable0_active = 0;
-    for (int j = 0; j < MIDI_IN_MAX_BYTES; j += MIDI_IN_EVT_STRIDE) {
-        if (midi_in_scan[j] == 0) break;      /* end-of-events */
-        if ((midi_in_scan[j] >> 4) == 0) {    /* cable 0 */
-            cable0_active = 1;
-            break;
-        }
-    }
-    if (cable0_active) {
+    int hw_cable_active = 0;
+    for (int j = 0; j < MIDI_IN_MAX_BYTES; j += MIDI_IN_EVT_STRIDE)
+        if (midi_in_scan[j] != 0) { hw_cable_active = 1; break; }
+    if (hw_cable_active) {
         defer_counter = 0;
         return;
     }
@@ -468,11 +463,20 @@ void shadow_drain_midi_inject(void)
     int consumed_bytes = 0;
     for (int i = 0; i < copy_len && injected < 16; i += 4) {
         /* Find empty 8-byte slot (byte 0 == 0 means no cable/CIN, unused) */
+        int saw_existing = 0;
         while (hw_offset < MIDI_IN_MAX_BYTES) {
             if (midi_in[hw_offset] == 0) break;
+            saw_existing = 1;
             hw_offset += MIDI_IN_EVT_STRIDE;
         }
         if (hw_offset >= MIDI_IN_MAX_BYTES) break;  /* Buffer full */
+        /* If we skipped over pre-existing events to find an empty slot, bail
+         * and carry remaining packets to the next frame.  The defer guard has
+         * a narrow race window: events can appear in MIDI_IN between the guard
+         * check and the write.  Injecting alongside hardware events (at a
+         * non-zero offset) races Move's firmware MIDI read path and causes
+         * SIGABRT — empirically the crash always fires at a non-zero offset. */
+        if (saw_existing) break;
 
         /* Write 4-byte USB-MIDI packet + zero the 4-byte timestamp.
          * Cable nibble in local_buf[i] is preserved — callers choose cable:


### PR DESCRIPTION
## Problem

\`shadow_drain_midi_inject\` writes MIDI packets into the \`MIDI_IN\` region of \`host_shadow_mailbox\` so Move's firmware sees them as hardware events. If inject writes into this buffer while Move is already processing events in it, the result is a SIGABRT deep in Move's firmware stack.

The existing guard deferred inject when cable-0 (pad) events were present in \`MIDI_IN\`, but this was insufficient in two ways:

**Gap 1 — cable-agnostic:** The crash occurs with events on cables other than 0. Empirically, the SIGABRT fires when inject writes at offset 24 while events on unrelated cables occupy offsets 0/8/16. All cables share Move's firmware MIDI read path, so the guard must be cable-agnostic — not cable-0-specific.

**Gap 2 — partial buffer consumption:** Move doesn't consume \`MIDI_IN\` atomically. It clears slot 0 before finishing higher slots. The old slot-0-only check passes in this window, allowing inject to write at offset 0 while hardware events are still present at offsets 8+.

**Gap 3 — guard race window:** Even with a correct guard, hardware events can appear in \`MIDI_IN\` between the guard check and the actual write. The slot-scan loop already skips occupied slots to find an empty one — but if it had to skip any, the resulting write offset is non-zero, placing the injected event directly alongside hardware events. The SIGABRT always fires at a non-zero offset, confirming this is the final crash path.

The scenario that triggers all three: an external MIDI controller is connected via USB-A (cable-2) while a tool module is injecting DSP-generated events into Move's MIDI_IN — for example, a sequencer or arpeggiator producing notes while the user plays an external controller simultaneously.

## Fix

Two targeted changes to \`shadow_drain_midi_inject\` in \`shadow_midi.c\`.

### 1. Cable-agnostic, all-slot defer guard

\`\`\`c
// Before: only cable-0, only slot 0
int cable0_active = 0;
for (int j = 0; j < MIDI_IN_MAX_BYTES; j += MIDI_IN_EVT_STRIDE) {
    if (midi_in_scan[j] == 0) break;
    if ((midi_in_scan[j] >> 4) == 0) { cable0_active = 1; break; }
}
if (cable0_active) { defer_counter = 0; return; }

// After: any cable, all slots
int hw_cable_active = 0;
for (int j = 0; j < MIDI_IN_MAX_BYTES; j += MIDI_IN_EVT_STRIDE)
    if (midi_in_scan[j] != 0) { hw_cable_active = 1; break; }
if (hw_cable_active) { defer_counter = 0; return; }
\`\`\`

If any MIDI_IN slot is non-zero — regardless of cable — inject is deferred and the counter resets. This handles both the cable gap and the partial-consumption gap.

### 2. \`saw_existing\` bail in the slot-scan write loop

\`\`\`c
// Before: would write at whatever non-zero offset the scan found
while (hw_offset < MIDI_IN_MAX_BYTES) {
    if (midi_in[hw_offset] == 0) break;
    hw_offset += MIDI_IN_EVT_STRIDE;
}
if (hw_offset >= MIDI_IN_MAX_BYTES) break;

// After: bail if any slots were skipped
int saw_existing = 0;
while (hw_offset < MIDI_IN_MAX_BYTES) {
    if (midi_in[hw_offset] == 0) break;
    saw_existing = 1;
    hw_offset += MIDI_IN_EVT_STRIDE;
}
if (hw_offset >= MIDI_IN_MAX_BYTES) break;
if (saw_existing) break;  // carry to next frame instead of writing at non-zero offset
\`\`\`

If the scan had to skip pre-existing events to find an empty slot, inject bails immediately. The remaining packets are carried to the next frame via the existing carryover mechanism (no events are lost). This closes the race window between the guard check and the write.

## Evidence

\`debug.log\` captured immediately before every SIGABRT:

\`\`\`
MIDI inject: drained 1/1 pkts at offset 24
[CRASH] Caught SIGABRT
\`\`\`

The offset-24 entry means three hardware events were already at offsets 0/8/16 when inject wrote. The \`saw_existing\` bail specifically prevents this — if offset-0 is occupied, the scan reaches offset 24 but \`saw_existing=1\` triggers the bail before writing.

## Scope

- No behavioral change when MIDI_IN is empty — inject proceeds identically
- Packets deferred by \`saw_existing\` are not lost — they accumulate in \`inject_shm\` and drain in the next frame with a clean buffer
- The 2-frame \`DEFER_FRAMES\` hold is unchanged
- No impact on any path other than \`shadow_drain_midi_inject\`