### PR TITLE
feat: restore cable-2 MIDI routing to native instruments and chain slots when no tool is active

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -710,6 +710,90 @@ void shadow_dispatch_direct_external_midi(void)
     }
 }
 
+/* Dispatch cable-2 (USB-A external MIDI) note/voice messages to chain slots
+ * matched by configured receive channel.  Called when no tool module is
+ * active so that Schwung chain instruments respond to external MIDI by channel
+ * just as they would via Move's normal MIDI routing when Schwung is not
+ * installed. */
+void shadow_dispatch_cable2_channeled_slots(void)
+{
+    if (!*host_shadow_inprocess_ready || !*host_global_mmap_addr) return;
+
+    const plugin_api_v2_t *pv2 = *host_plugin_v2;
+    if (!pv2 || !pv2->on_midi) return;
+
+    uint8_t *in_src = *host_global_mmap_addr + MIDI_IN_OFFSET;
+
+    for (int i = 0; i < MIDI_BUFFER_SIZE; i += 4) {
+        uint8_t header = in_src[i];
+        if (header == 0) break;
+
+        uint8_t cable = (header >> 4) & 0x0F;
+        if (cable != 0x02) continue;   /* only cable-2 (USB-A external MIDI) */
+
+        uint8_t cin    = header & 0x0F;
+        uint8_t status = in_src[i + 1];
+        uint8_t type   = status & 0xF0;
+        uint8_t d1     = in_src[i + 2];
+        uint8_t d2     = in_src[i + 3];
+
+        /* Channel voice messages only */
+        if (cin < 0x08 || cin > 0x0E) continue;
+        if (type < 0x80 || type > 0xE0) continue;
+        if (cin != (type >> 4)) continue;
+
+        /* Data bytes must be 0-127 */
+        if ((d1 & 0x80) || (d2 & 0x80)) continue;
+
+        /* Filter knob-touch notes (internal Move notes 0-9) */
+        if ((type == 0x90 || type == 0x80) && d1 < 10) continue;
+
+        uint8_t in_ch = status & 0x0F;
+
+        for (int s = 0; s < SHADOW_CHAIN_INSTANCES; s++) {
+            int slot_ch = host_chain_slots[s].channel;
+
+            /* Skip THRU slots — already handled by shadow_dispatch_direct_external_midi */
+            if (slot_ch == -1 && host_chain_slots[s].forward_channel == -2) continue;
+
+            /* Channel filter: -1 = receive all; >= 0 = specific channel */
+            if (slot_ch >= 0 && slot_ch != (int)in_ch) continue;
+
+            /* Lazy activation */
+            if (!host_chain_slots[s].active) {
+                if (host_chain_slots[s].instance) {
+                    char buf[64];
+                    int len = pv2->get_param(host_chain_slots[s].instance,
+                                              "synth_module", buf, sizeof(buf));
+                    if (len > 0) {
+                        if (len < (int)sizeof(buf)) buf[len] = '\0';
+                        else buf[sizeof(buf) - 1] = '\0';
+                        if (buf[0] != '\0') {
+                            host_chain_slots[s].active = 1;
+                            if (host_ui_state_update_slot)
+                                host_ui_state_update_slot(s);
+                        }
+                    }
+                }
+                if (!host_chain_slots[s].active) continue;
+            }
+
+            /* Wake from idle */
+            if (host_slot_idle[s] || host_slot_fx_idle[s]) {
+                host_slot_idle[s]          = 0;
+                host_slot_silence_frames[s] = 0;
+                host_slot_fx_idle[s]        = 0;
+                host_slot_fx_silence_frames[s] = 0;
+            }
+
+            uint8_t msg[3] = { status, d1, d2 };
+            if (shadow_chain_apply_transpose(s, msg))
+                pv2->on_midi(host_chain_slots[s].instance, msg, 3,
+                             MOVE_MIDI_SOURCE_EXTERNAL);
+        }
+    }
+}
+
 /* ============================================================================
  * MIDI forwarding to shadow shared memory
  * ============================================================================ */

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -118,6 +118,11 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
  * correct channels. */
 void shadow_dispatch_direct_external_midi(void);
 
+/* Dispatch cable-2 (USB-A external MIDI) note/voice messages to chain slots
+ * matched by configured receive channel.  Used when no tool module is active
+ * so that Schwung instruments respond to external MIDI by channel. */
+void shadow_dispatch_cable2_channeled_slots(void);
+
 /* Forward CC/pitch bend/aftertouch from external MIDI (cable 2) into MIDI_OUT. */
 void shadow_forward_external_cc_to_out(void);
 

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -4088,6 +4088,8 @@ static uint64_t spi_last_frame_total_us = 0;
 #define OVERRUN_THRESHOLD_US 2850  /* Start worrying at 2850µs (98% of budget) */
 #define SKIP_DSP_THRESHOLD 3       /* Skip DSP after 3 consecutive overruns */
 
+static void shim_forward_cable2_to_move(void); /* defined after shim_remap_cable2_channels */
+
 /* ============================================================================
  * SPI PRE-TRANSFER CALLBACK
  * ============================================================================
@@ -4453,6 +4455,18 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     TIME_SECTION_START();
     shadow_dispatch_direct_external_midi();
     TIME_SECTION_END(spi_direct_midi_sum, spi_direct_midi_max);
+
+    /* When no tool module is active (or a module is suspended), restore Move's
+     * native cable-2 routing.  Two cooperating operations:
+     *   1. Inject cable-2 events as cable-0 so Move's DSP routes them to
+     *      native instruments by MIDI channel (shim_forward_cable2_to_move).
+     *   2. Dispatch cable-2 events to Schwung chain slots by channel so
+     *      Schwung instruments also respond (shadow_dispatch_cable2_channeled_slots). */
+    if (shadow_control &&
+        (shadow_control->overtake_mode == 0 || shadow_control->suspend_overtake)) {
+        shim_forward_cable2_to_move();
+        shadow_dispatch_cable2_channeled_slots();
+    }
 
     TIME_SECTION_START();
     shadow_inprocess_process_midi();
@@ -5209,6 +5223,26 @@ static void shim_remap_cable2_channels(uint8_t *shadow) {
             if (mapped == EXT_MIDI_REMAP_PASSTHROUGH || mapped >= 16) continue;
             buf[j + 1] = (status & 0xF0) | (mapped & 0x0F);
         }
+    }
+}
+
+/* Inject cable-2 (USB-A external MIDI) note-on/off events into Move's MIDI_IN
+ * inject ring as cable-0 packets.  The inject drain forces cable nibble to 0,
+ * so Move's DSP receives them as cable-0 and routes them to native instruments
+ * by MIDI channel — the same path used when Schwung is not installed.
+ * Called only when no tool module is active or a module is suspended. */
+static void shim_forward_cable2_to_move(void) {
+    if (!hardware_mmap_addr) return;
+    uint8_t *hw_buf = hardware_mmap_addr + MIDI_IN_OFFSET;
+    const int MIDI_IN_MAX_BYTES = 8 * 31;   /* 31 events × 8-byte stride */
+    for (int j = 0; j < MIDI_IN_MAX_BYTES; j += 8) {
+        uint8_t header = hw_buf[j];
+        if (header == 0) break;                     /* end-of-events sentinel */
+        if (((header >> 4) & 0x0F) != 2) continue;  /* cable-2 only */
+        uint8_t cin = header & 0x0F;
+        if (cin != 0x08 && cin != 0x09) continue;   /* note-off / note-on only */
+        const uint8_t pkt[4] = { header, hw_buf[j+1], hw_buf[j+2], hw_buf[j+3] };
+        shadow_chain_midi_inject(pkt, 4);
     }
 }
 


### PR DESCRIPTION
## Problem

When Schwung is **not** installed, Move natively routes USB-A (cable-2) external MIDI to its built-in instruments using MIDI channel matching — exactly as you'd expect from a hardware MIDI router.

When Schwung **is** installed, this breaks silently:

- Move's **native instruments** stop responding to external MIDI entirely.
- Schwung **chain slots configured for a specific receive channel** stop responding.
- Only chain slots configured to receive on **all channels with THRU forwarding** still work (handled by the existing `shadow_dispatch_direct_external_midi`).

This regression is present regardless of whether a Schwung tool module is loaded. The Schwung chain is running, but external MIDI from USB-A cannot reach its instruments.

## Technical cause

Move's USB host stack normally injects cable-2 MIDI events into the MIDI_IN ring buffer **as cable-0 packets**. Move's DSP reads that ring and routes cable-0 events to native instruments by MIDI channel — this is the ordinary instrument-routing path.

When the Schwung shim takes over the SPI mailbox, it intercepts the hardware MIDI_IN buffer before Move's USB host stack can complete that injection. The `shadow_dispatch_direct_external_midi` function handles THRU-mode slots, but:

1. Nothing re-injects cable-2 events as cable-0, so **Move's DSP instrument routing path is never triggered**.
2. Nothing dispatches cable-2 events to Schwung chain slots by channel, so **channel-configured Schwung instruments are also silent**.

## Fix

Two cooperating functions, both gated on `overtake_mode == 0 || suspend_overtake` (no tool module running, or a module is suspended):

### `shim_forward_cable2_to_move()` — `schwung_shim.c`

Reads cable-2 note-on/off events from the hardware MIDI_IN buffer (8-byte stride) and re-queues them via `shadow_chain_midi_inject` as cable-0 packets. The inject drain forces the cable nibble to 0 on delivery, so Move's DSP receives them on the standard cable-0 path and routes to native instruments by MIDI channel — identical to behaviour without Schwung installed.

### `shadow_dispatch_cable2_channeled_slots()` — `shadow_midi.c`

Reads cable-2 channel-voice events from the global MIDI_IN shadow (4-byte stride, same source as `shadow_dispatch_direct_external_midi`) and dispatches to chain slots whose configured receive channel matches the event channel (or is set to receive all channels). THRU slots are skipped — they are already handled by `shadow_dispatch_direct_external_midi`.

## Scope

- **No behaviour change** while a tool module is running (`overtake_mode != 0 && !suspend_overtake`). The gate is a strict no-op in that case.
- Independent of PRs #76 and #77 — requires only the `shadow_chain_midi_inject` infrastructure and the `overtake_mode`/`suspend_overtake` fields already present in `shadow_control`.
- Verified on device: native Move instruments respond by channel with no tool loaded; Schwung chain slots respond by their configured channel; existing tool-module behaviour is unchanged.