### PR TITLE
fix(shadow): preserve cable byte in JS move_midi_inject_to_move

### DIFF
--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -875,8 +875,21 @@ static JSValue js_host_ext_midi_remap_enable(JSContext *ctx, JSValueConst this_v
 
 /* move_midi_inject_to_move([cin, status, d1, d2, ...]) -> bool
  * Injects USB-MIDI packets into Move's MIDI_IN buffer via shared memory.
- * Move processes these as if they came from physical hardware.
- * Forces cable 0 on all injected events.
+ * Move processes these as if they came from a hardware MIDI source.
+ *
+ * Cable bits in packet[0] are preserved as-is. The caller chooses how
+ * Move firmware routes the event:
+ *
+ *   cable 0 (CIN nibble 0x0X) — internal hardware. Move treats the
+ *     event as a physical pad / button / knob press. Use this to
+ *     simulate the surface (song-mode auto-playback triggers pads
+ *     this way: pkt[0] = 0x09 for note-on, 0x08 for note-off).
+ *
+ *   cable 2 (CIN nibble 0x2X) — external USB MIDI input. Move treats
+ *     the event as if it arrived from a USB-A MIDI device. Routes
+ *     through Move's track-input dispatcher and reaches the
+ *     internal track synths. Use this when JS wants to play a Move
+ *     track instrument as MIDI.
  */
 static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val,
                                            int argc, JSValueConst *argv) {
@@ -904,8 +917,9 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
             packet[j] = (uint8_t)(val & 0xFF);
         }
 
-        /* Force cable 0 (internal hardware) */
-        packet[0] = (packet[0] & 0x0F) | 0x00;
+        /* Cable bits in packet[0] preserved as-is — caller picks the
+         * route (cable 0 = pad simulation, cable 2 = external MIDI in
+         * to the track synth). See function docblock. */
 
         /* Find space in buffer and write */
         int write_offset = shadow_midi_inject->write_idx;


### PR DESCRIPTION
Hi Charles!

Mad respect for Schwung — what a platform, I've been dreaming of
something like this for a long time. And that LD_PRELOAD trick is
chef's kiss!

I'm building an alternative step sequencer for Move (as a Schwung
overtake-tool), and ran into one asymmetry between the C and JS
halves of the same host API. Wanted to share a fix.

`js_move_midi_inject_to_move` force-sets cable 0:
```c
packet[0] = (packet[0] & 0x0F) | 0x00;
```

The matching C function (shadow_chain_midi_inject + drain)
preserves the cable byte — you spell that out explicitly in a
comment in shadow_midi.c. So any JS module that wants to drive
a Move track synth via the external-USB path gets a silent rewrite
to cable 0 and ends up silent.

The C side of the sequencer emits notes via
host->midi_inject_to_move(pkt, 4) with pkt[0] = 0x29, which
plays the Move track instrument as expected. The JS side has a
live preview on the pads (just like in Move Original), and that
path is silent: the exact same pkt[0] = 0x29 goes into
move_midi_inject_to_move, gets rewritten to 0x09, and Move
treats the event as "pad pressed" — never reaches the synth.

Backward compat
The only other in-tree JS caller is song-mode/ui.js, which sends
cin = 0x09 / 0x08. Its cable bits were already 0, so its
behavior is identical before and after.