### PR TITLE
catalog: add Forge (filliformes/forge-move)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -813,6 +813,17 @@
       "default_branch": "main",
       "asset_name": "breakbeat-module.tar.gz",
       "min_host_version": "0.9.0"
+    },
+    {
+      "id": "forge",
+      "name": "Forge",
+      "description": "8-voice FM/subtractive hybrid drum synthesiser with Kit A↔B morph across 16 pads, 5 voice algorithms, per-voice resonator, dual filter with Comb modes, three concurrent FX buses, 64 factory kits",
+      "author": "Vincent Fillion",
+      "component_type": "sound_generator",
+      "github_repo": "filliformes/forge-move",
+      "default_branch": "master",
+      "asset_name": "forge-module.tar.gz",
+      "min_host_version": "0.9.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Forge** to the Schwung Module Store catalog.

## What it is

**Forge** is an 8-voice FM/subtractive hybrid drum synthesiser for Ableton Move, inspired by Erica Synths LXR-02, 1010music Razzmatazz, Elektron Digitone II, and the classic drum machine roster (TR-808/909/707, CR-78, LinnDrum, DMX, SP-12, Simmons).

- 5 voice algorithms — Drum / Snare / Cymbal / Hat / Wild
- **Kit A↔B morph** across the 16-pad Drum Kit template (lower row plays morphed state, upper row plays the untouched B reference)
- 64 factory kits spanning LXR-02 / Razzmatazz / Digitone-II / classic drum machines / genre / experimental
- Per-voice resonator (feedback-comb + tanh saturation)
- Dual filter with Base-Width pre-stage and Comb+/Comb− modes alongside the SVF
- Curved AD envelopes with repeat (LXR-style)
- Cross-voice LFO routing
- 3 concurrent FX buses (Delay with BPF feedback / Dattorro plate Reverb / Panoramic Chorus)
- EMT-156 bus compressor, 3-band EQ, master saturation/bit/rate/limiter
- Phasma-style binary Save Kit persistence

## Repo + release

- Repo: https://github.com/filliformes/forge-move
- Current release: v0.1.2
- Tarball: forge-module.tar.gz (auto-built by CI)
- License: MIT

## Verified before submission

- Repo public, not archived
- `src/module.json` reachable on `master` (required for desktop installer)
- `release.json` matches latest tag (v0.1.2)
- `api_version: 2` and `component_type: "sound_generator"` at root level
- Tarball asset attached, version inside matches tag
- Shell scripts executable (100755), CI pinned to ubuntu-22.04
- `/dsp-review` clean — buffer safety / denormals / feedback / filter stability all OK, ~5% CPU, ~500KB memory per instance
- Diff against `origin/main` shows only the new entry
