### PR TITLE
Add Signal to module catalog (sound_generator)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -813,6 +813,17 @@
       "default_branch": "main",
       "asset_name": "breakbeat-module.tar.gz",
       "min_host_version": "0.9.0"
+    },
+    {
+      "id": "signal",
+      "name": "Signal",
+      "description": "Polymetric microsound rhythm generator with breakbeat engine and Scene A/B morph — Ikeda/Bernier/Holzman aesthetic",
+      "author": "filliformes",
+      "component_type": "sound_generator",
+      "github_repo": "filliformes/signal-move",
+      "default_branch": "master",
+      "asset_name": "signal-module.tar.gz",
+      "min_host_version": "0.9.0"
     }
   ]
 }


### PR DESCRIPTION
Adds [Signal](https://github.com/filliformes/signal-move) — a polymetric microsound rhythm generator (sound_generator) — to the module catalog. v0.2.0 is live on GitHub Releases, `release.json` and `src/module.json` are version-consistent, and the module has been tested on-device.

### What is Signal?

Four self-sequencing microsound voices combining a rhythm engine with a micro-synth, plus a v0.2.0 breakbeat engine and Scene A/B morph that lets the user crossfade between two complete configurations on a single knob.

- 25 deterministic rhythm patterns (Morse, mathcore odd-meters, Ikeda grids, Bernier sparse, glitch/CA) + 10 stochastic breakbeat presets (Amen kit, Think, Funky Drummer, Jungle Roll, Liquid DnB, Holzman Improv...)
- 40 microsound synth presets + 10 kit synths (Kick, Kick Sub, Snare Body, Piccolo Snare, Rim Click, Closed/Open Hat, Ride Ping, Tom, Ghost Snare) — adds three new layered waveforms (Kick/Snare/Hat) to the voice engine
- Scene A/B + Morph on a single knob: linear interpolation on continuous params, hard switch on discrete enums at 0.5, three morph curves (Linear/Exp/Stepped) with 0–200ms smoothing
- Holzman live-drummer layer: per-voice Improv (per-bar curve mutation seeded by voice+bar), Push/Pull micro-timing on odd steps, multi-pitch Snare Bank (Off/Rule/Random with 5 pitches), Ghost Crescendo, cross-voice Drummer Brain (Off/Light/Heavy)
- Phrase tracking (Off / 2 / 4 / 8 / 16 bars) + 6 fill shapes (Snare Roll, Tom Run, Kick Fill, Hat Splatter, Crash Drop, Random) overlaid on the last bar of each phrase
- 50 named patches including 4 hybrid breakbeat-x-microsound configurations (Microsound Jungle, Bernier Jungle, Mathcore Break, Bretschneider Roll)

Inspired by Ryoji Ikeda (data sonification, frequencies), Nicolas Bernier (sparse pings, tuning forks), Dillinger Escape Plan / Converge (mathcore polyrhythms), Frank Bretschneider (spectral click variation), Russell Holzman (live jazz breakbeat), and the breakbeat decision algorithm documented in `mestela/schwung-breakbeat` (re-implemented from the README description — no code copied).

### Catalog entry

```json
{
  "id": "signal",
  "name": "Signal",
  "description": "Polymetric microsound rhythm generator with breakbeat engine and Scene A/B morph — Ikeda/Bernier/Holzman aesthetic",
  "author": "filliformes",
  "component_type": "sound_generator",
  "github_repo": "filliformes/signal-move",
  "default_branch": "master",
  "asset_name": "signal-module.tar.gz",
  "min_host_version": "0.9.0"
}
```

### Release & verification

- **Release tarball:** https://github.com/filliformes/signal-move/releases/download/v0.2.0/signal-module.tar.gz
- **release.json:** https://github.com/filliformes/signal-move/blob/master/release.json (v0.2.0, URL matches the catalog `asset_name`)
- **src/module.json version:** `0.2.0` (matches tag, CI verified)
- **api_version:** 2, **component_type** at root level
- **CI workflow:** `.github/workflows/release.yml` — builds via Docker ARM64, publishes release, updates `release.json` on master
- Shell scripts executable (100755), `src/module.json` fetchable for desktop installer
- Tested on-device (Schwung v0.9.11) — module loads cleanly, all 10 pages navigable, all 50 patches play

### License

GPL-3.0