### PR TITLE
Add KrautDrums to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -813,6 +813,17 @@
       "default_branch": "main",
       "asset_name": "breakbeat-module.tar.gz",
       "min_host_version": "0.9.0"
+    },
+    {
+      "id": "krautdrums",
+      "name": "KrautDrums",
+      "description": "16-voice tonal drum machine modeled on the 1969 Elka Drummer One, with V72/A80/Synthi pre-FX, EP-3/Echorec/RE-201 delay, EMT 140/BX20/chamber reverb, and EMT 156-style bus comp",
+      "author": "Vincent Filliforme",
+      "component_type": "sound_generator",
+      "github_repo": "filliformes/krautdrums-move",
+      "default_branch": "main",
+      "asset_name": "krautdrums-module.tar.gz",
+      "min_host_version": "0.9.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds **KrautDrums** to the Schwung module catalog
- 16-voice tonal drum machine for Ableton Move, modeled on the **1969 Elka Drummer One**
- Hand-tuned voices, multi-mode FX chain, period-correct Krautrock studio coloration

## About the module

KrautDrums brings the bridged-T resonator sound of Italy's 1969 Elka Drummer One (the preset-rhythm box behind Cluster, Kraftwerk, Harmonia, Roedelius, Tangerine Dream, Popol Vuh) to the Move, with the studio chain those records were printed through.

**Voices (16):**
- 9 original Drummer One voices (Bass-drum, Conga, Tom 1/2, Claves, Snare, Short/Long cymbal, Cow bell) + 7 hand-tuned variations
- Voice frequencies derived from schematic + SPICE analysis of the bridged-T notch formula
- Plaits-style shaped trigger excitation (1 ms diode-clipped pulse + 6 ms FM pulse)
- Diode-starve frequency drift — pitch decays with the envelope, like the real circuit
- 3-layer analog drift simulation

**Pre-FX studio chain (Attitude page):**
- V72/V76 preamp (transformer + tube stages)
- Studer A80 tape (cubic clip + head-bump biquad + HF rolloff)
- HPF, body shelf, air shelf
- EMS Synthi-style diode-ladder resonant LPF (period-correct for the Krautrock VCS3 era)
- MXR Phase 90 (single knob controls rate + depth + wet)

**Master FX:**
- Multi-mode delay: Echoplex EP-3 / Binson Echorec (dual-sine wow) / Roland RE-201 (self-oscillates ≥ 95% feedback for the *Phaedra* sound)
- Multi-mode reverb: Dattorro figure-8 EMT 140 plate / Parker dispersive BX20 spring / Conny Plank-style live chamber
- EMT 156 / Neumann broadcast-limiter style bus compressor
- Delay tempo sync (12 divisions)

**UX:**
- Left 16 pads = voice triggers, right 16 pads = rhythm pattern toggles (8 simultaneous, OR-merged with density × 1/√N gating)
- 5 menu pages: Kraut / FX / Attitude / General / Rhythms
- 10 ms knob smoothing on all 19 audio-rate float params
- All Decay knob scales BPF Q (1× → 16×) for sustained drone/wash textures

## Links
- Repo: https://github.com/filliformes/krautdrums-move
- Release: https://github.com/filliformes/krautdrums-move/releases/tag/v0.1.0
- Asset: `krautdrums-module.tar.gz` (~73 KB)

## Test plan
- [x] Builds cleanly (ARM64 cross-compile via Docker, zero warnings)
- [x] Loads on Move via SCP install, no SIGSEGV / SIGBUS
- [x] Module picker shows "KrautDrums"; knob-popup prefix shows "KD"
- [x] All 32 pads route correctly (Drum Kit template: notes 36-51 → voices, 52-67 → rhythms)
- [x] All 5 menu pages navigate; all knobs respond to encoder edits
- [x] Delay Sync menu switch toggles delay_time knob between ms and tempo-division display
- [x] State persists across slot remove/re-add via get_param/set_param("state") round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)