### PR TITLE
docs: sync cable-byte semantics for midi_inject_to_move

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -186,8 +186,15 @@ host_announce_screenreader(text) // Speak text via TTS (if screen reader enabled
 // Tool module lifecycle
 host_exit_module()            // Exit current tool module, return to tools menu (tool modules only)
 
-// MIDI injection (inject MIDI into Move's firmware input path)
-move_midi_inject_to_move([type, status, d1, d2]) // Simulate hardware MIDI input
+// MIDI injection (inject MIDI into Move's firmware input path).
+// packet[0] is the USB-MIDI byte: high nibble = cable, low nibble = CIN.
+//   cable 0 (e.g. 0x09 note-on, 0x08 note-off) → Move treats as a physical
+//     pad/button press; use this to simulate the surface.
+//   cable 2 (e.g. 0x29, 0x28) → Move routes by channel to its track
+//     instruments, as if the event came from a USB-A MIDI device.
+// The cable nibble is preserved as-is (no rewrite). See
+// docs/ADDRESSING_MOVE_SYNTHS.md for the cable-2 routing flow.
+move_midi_inject_to_move([packet0, status, d1, d2])
 
 // Cable-2 (external USB) MIDI channel remap — overtake modules only.
 // Rewrites the channel byte of incoming external MIDI before Move's firmware

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -136,7 +136,10 @@ void shadow_drain_ui_midi_dsp(void);
 void shadow_drain_midi_inject(void);
 
 /* Queue a 4-byte USB-MIDI packet for MIDI_IN injection (Pre-mode MIDI FX).
- * Cable nibble is ignored by the drain (forced to 0).
+ * The cable nibble in msg[0] is preserved by the drain. Callers choose:
+ *   cable 0 → internal hardware (Move treats as pad/button input)
+ *   cable 2 → external USB MIDI (routed by channel to Move's track synths)
+ * See shadow_midi.c for the full drain semantics.
  * Returns 4 on success, 0 if SHM unavailable or ring full. */
 int shadow_chain_midi_inject(const uint8_t *msg, int len);
 


### PR DESCRIPTION
## Summary
Follow-up to #79. Two comments still claimed the JS / drain path forces cable to 0:

- \`src/host/shadow_midi.h:139\` — "Cable nibble is ignored by the drain (forced to 0)."
- \`docs/API.md:190\` — only said "Simulate hardware MIDI input", no mention of cable semantics.

The drain in \`shadow_midi.c:478\` and \`shadow_chain_midi_inject\` (\`shadow_midi.c:521\`) both already preserve \`msg[0]\`, and #79 made the JS binding match. This PR brings the two stale comments in line with the implementation and points readers at the cable 0 vs cable 2 routing.

## Test plan
- [ ] No code changes; docs/comments only.
- [ ] Confirm \`docs/API.md\` renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)