### PR TITLE
launch-standalone: use bash to survive dash-based /bin/sh

### DIFF
--- a/src/launch-standalone.sh
+++ b/src/launch-standalone.sh
@@ -1,10 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 # Launch a standalone module, then restart Move when it exits.
 # Usage: launch-standalone.sh /path/to/standalone/binary
 #
 # Called via host_launch_standalone() from the host process.
 # This process inherits Move's file descriptors including /dev/ablspi0.0.
 # We MUST close them before killing Move.
+#
+# bash (not /bin/sh): some custom Move images symlink /bin/sh to dash, which
+# uses FDs 10-19 internally for builtin redirections. The "close all FDs 3+"
+# loop below silently breaks the shell mid-script on dash. Force bash to
+# avoid the issue while keeping the script behavior identical on stock Move.
 
 BINARY="$1"
 if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
@@ -12,7 +17,7 @@ if [ -z "$BINARY" ] || [ ! -x "$BINARY" ]; then
     exit 1
 fi
 
-setsid sh -c '
+setsid bash -c '
     BINARY="$1"
     LOG_HELPER=/data/UserData/schwung/unified-log
 


### PR DESCRIPTION
## Summary

`launch-standalone.sh` closes inherited FDs 3-1023 in a loop before exec'ing the standalone binary, so the new process doesn't inherit `/dev/ablspi0.0` or other Move-owned descriptors:

```sh
i=3; while [ \$i -lt 1024 ]; do eval \"exec \${i}>&-\" 2>/dev/null; i=\$((i+1)); done
```

This works fine on stock Move because its `/bin/sh` doesn't reuse FDs in that range while a script is running. But some Move-derived Linux images symlink `/bin/sh` → `dash`, and dash uses **FDs 10-19 internally** for builtin redirections (parameter expansion, command substitution backups, etc.). The instant the loop closes FD 10, dash loses an internal FD and silently breaks mid-script — the two-phase kill of `MoveOriginal`/`shadow_ui`, the SPI free, and the `\"\$BINARY\"` exec all never run.

From the user's perspective: the screen reader announces `Launching <module>`, the `TOOLS SELECT: launching standalone binary` debug entry is written, and then nothing — no log entries from `launch-standalone.sh`, no process. Reproduces deterministically:

```
$ /bin/sh -c 'i=3; while [ \$i -lt 16 ]; do echo iter-\$i; eval \"exec \${i}>&-\" 2>/dev/null; i=\$((i+1)); done; echo done'
iter-3
iter-4
…
iter-10
# (no more output, no \"done\")
```

## Fix

Switch the shebang and the inner `setsid sh -c` to bash. Bash is part of the standard Move image; no new dependency. The script body is unchanged. Stock Move behavior is identical — it was already running under bash via the `/bin/sh` indirection.

## Test plan

- [ ] Stock Move: launch a tool module marked `standalone: true`, confirm it still works.
- [ ] Move-derived image with `/bin/sh` → dash: launch a standalone tool, confirm the binary starts (was a no-op before this PR).
- [ ] Confirm the standalone binary still gets `/dev/ablspi0.0` after MoveOriginal is killed (FD-close loop still runs to completion).