### PR TITLE
feat: add dAVEBOx to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -846,6 +846,17 @@
       "default_branch": "master",
       "asset_name": "forge-module.tar.gz",
       "min_host_version": "0.9.0"
+    },
+    {
+      "id": "davebox",
+      "name": "dAVEBOx",
+      "description": "8-track creative MIDI sequencer with per-clip effects chains, polyrhythmic drum lanes, live recording, and a 24-mod performance mode",
+      "author": "legsmechanical",
+      "component_type": "tool",
+      "github_repo": "legsmechanical/schwung-davebox",
+      "default_branch": "main",
+      "asset_name": "davebox-module.tar.gz",
+      "min_host_version": "0.9.13"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **dAVEBOx** to the Schwung module catalog. dAVEBOx is a creative 8-track MIDI sequencer for Move designed to replace the native sequencer with per-clip effects chains, polyrhythmic drum lanes, live recording, and a performance mode.

## Highlights

- 8 tracks (melodic + drum), 16 clips per track, up to 256 steps per clip
- Per-clip effects chain (ARP IN, NOTE FX, HARMZ, MIDI DLY, SEQ ARP) with bake-to-notes
- 32-lane polyrhythmic drum tracks — per-lane loop length, effects, note repeat
- Scale-aware pitch random / harmonizer / delay transposition
- Performance Mode: 24 mods × 16 snapshot slots, hold/lock/latch interaction
- 8 CC automation lanes per track, per-clip at 1/32 resolution
- Per-track routing: Move · Schwung · External
- Live recording with count-in pre-roll
- Set state inheritance — duplicate a Move set, inherit dAVEBOx state by name

## Compatibility

- `min_host_version: "0.9.13"` — earlier Schwung versions had upstream crashes around ROUTE_MOVE external MIDI input and suspend-during-drum-playback. Both addressed by PRs #76 / #77 / #78 + follow-up `62a04135` in v0.9.13.
- Installs and runs cleanly on stock Schwung v0.9.13. Two optional co-run features (`Edit Slot...` / `Edit Synth...`) require a patched shim from `legsmechanical/schwung`; they're capability-gated and silently hidden on stock Schwung.

## Release artifact

Latest release **v0.3.6**: https://github.com/legsmechanical/schwung-davebox/releases/tag/v0.3.6 — asset `davebox-module.tar.gz`.

## Repo

https://github.com/legsmechanical/schwung-davebox
