### PR TITLE
Store: pin installed module.json version to release.json on install

### DIFF
--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -1084,13 +1084,14 @@ func (app *App) installModule(mod *CatalogModule) error {
 		app.logger.Warn("release.json not found, using fallback URL", "status", resp.StatusCode)
 	}
 
-	var downloadURL string
+	var downloadURL, releaseVersion string
 	if resp.StatusCode == http.StatusOK {
 		var rel ReleaseJSON
 		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
 			return fmt.Errorf("decoding release.json: %w", err)
 		}
 		downloadURL = rel.DownloadURL
+		releaseVersion = rel.Version
 	}
 	if downloadURL == "" {
 		// Fallback: use GitHub releases latest download.
@@ -1157,6 +1158,15 @@ func (app *App) installModule(mod *CatalogModule) error {
 		}
 	}
 
+	// Pin module.json's version field to the release.json version we
+	// installed from. Without this, a publisher tarball whose bundled
+	// module.json is one bump behind release.json traps the user in an
+	// endless update loop: compare installed (old) vs release (new) →
+	// "update available" → re-download same tarball → repeat.
+	if err := pinInstalledModuleVersion(modDir, releaseVersion, app.logger); err != nil {
+		app.logger.Warn("failed to pin module.json version", "id", mod.ID, "err", err)
+	}
+
 	// Fix ownership — schwung-manager runs as root but modules should be owned by ableton.
 	chown := exec.Command("chown", "-R", "ableton:users", modDir)
 	if out, err := chown.CombinedOutput(); err != nil {
@@ -1165,6 +1175,45 @@ func (app *App) installModule(mod *CatalogModule) error {
 
 	app.logger.Info("module installed", "id", mod.ID, "path", categoryDir)
 	return nil
+}
+
+// pinInstalledModuleVersion rewrites the installed module.json's "version"
+// field to match expectedVersion (the release.json version that drove the
+// install). No-ops if expectedVersion is empty, module.json is missing or
+// unparseable, or the version already matches.
+func pinInstalledModuleVersion(modDir, expectedVersion string, logger *slog.Logger) error {
+	if expectedVersion == "" {
+		return nil
+	}
+	modJsonPath := filepath.Join(modDir, "module.json")
+	raw, err := os.ReadFile(modJsonPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading module.json: %w", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		logger.Warn("module.json parse failed during version pin",
+			"path", modJsonPath, "err", err)
+		return nil
+	}
+	currentVersion, _ := parsed["version"].(string)
+	if currentVersion == expectedVersion {
+		return nil
+	}
+	logger.Info("pinning module.json version",
+		"id", filepath.Base(modDir),
+		"tarball_version", currentVersion,
+		"release_version", expectedVersion)
+	parsed["version"] = expectedVersion
+	out, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling module.json: %w", err)
+	}
+	out = append(out, '\n')
+	return os.WriteFile(modJsonPath, out, 0644)
 }
 
 // uninstallModule removes a module from disk.

--- a/src/shared/store_utils.mjs
+++ b/src/shared/store_utils.mjs
@@ -316,6 +316,40 @@ function isValidModuleId(id) {
     return true;
 }
 
+/* Pin the installed module.json's version to match the release.json version
+ * we just installed from. Some publishers ship tarballs whose bundled
+ * module.json reports an older version than the release.json that drove
+ * the install — Module Store would then compare installed (old) against
+ * release.json (new), conclude an update is available, download the same
+ * tarball, and loop forever. Rewriting the version field on disk breaks
+ * the loop regardless of which side of the publish flow regressed. */
+function pinInstalledModuleVersion(mod, expectedVersion) {
+    if (!expectedVersion) return;
+    if (!globalThis.host_read_file || !globalThis.host_write_file) return;
+
+    const subdir = getInstallSubdir(mod.component_type);
+    const moduleJsonPath = subdir
+        ? `${MODULES_DIR}/${subdir}/${mod.id}/module.json`
+        : `${MODULES_DIR}/${mod.id}/module.json`;
+
+    const jsonStr = globalThis.host_read_file(moduleJsonPath);
+    if (!jsonStr) return;
+
+    let data;
+    try {
+        data = JSON.parse(jsonStr);
+    } catch (e) {
+        console.log(`pinInstalledModuleVersion: parse failed for ${moduleJsonPath}: ${e}`);
+        return;
+    }
+
+    if (data.version === expectedVersion) return;
+
+    console.log(`pinInstalledModuleVersion: ${mod.id} tarball reports ${data.version}, release.json says ${expectedVersion}; rewriting to ${expectedVersion}`);
+    data.version = expectedVersion;
+    globalThis.host_write_file(moduleJsonPath, JSON.stringify(data, null, 2) + '\n');
+}
+
 /* Install a module, returns { success, error } */
 export function installModule(mod, hostVersion, onProgress) {
     if (!isValidModuleId(mod.id)) {
@@ -365,6 +399,11 @@ export function installModule(mod, hostVersion, onProgress) {
     if (!extractOk) {
         return { success: false, error: 'Extract failed' };
     }
+
+    /* Pin module.json version to match the release.json we installed
+     * from, so publisher tarball/release.json mismatches don't trap the
+     * user in an endless update loop. */
+    pinInstalledModuleVersion(mod, mod.latest_version);
 
     /* Rescan modules */
     globalThis.host_rescan_modules();


### PR DESCRIPTION
## Summary

Module Store decides "update available?" by comparing each installed module's bundled `module.json` `version` against the version in the upstream `release.json`. If a publisher ships a tarball whose `module.json` still reports an older version than the `release.json` that drove the install, the comparison loops:

```
release.json: 0.3.6
installed module.json (from tarball): 0.1.0
→ update available → download → install → installed version still 0.1.0
→ update available → download → install → …
```

This is what happened to users updating **davebox** (`release.json` 0.3.6 / tarball 0.1.0), **dissolver** (0.2.3 / 0.2.2), and **bbgen** (0.3.2 / 0.3.1) over the past week.

## Root cause analysis

The root cause is on the publisher side — their `release.json` and their tarball's `module.json` drifted out of sync because nothing in their build flow stamps the version from the git tag. PRs are open against the four affected module repos to fix that at the source:

| Repo | PR |
|---|---|
| `legsmechanical/schwung-davebox` | legsmechanical/schwung-davebox#1 |
| `filliformes/dissolver-move` | filliformes/dissolver-move#1 |
| `mestela/schwung-breakbeat` | mestela/schwung-breakbeat#1 |
| `filliformes/euclidrum-move` | filliformes/euclidrum-move#1 |

But Schwung shouldn't trap users in a loop just because a publisher's tarball happens to be one bump behind. This PR is the defense-in-depth fix on our side.

## What this PR does

After a successful tarball extract in `installModule`, call a new `pinInstalledModuleVersion(mod, mod.latest_version)` which:

1. Reads the installed `module.json` from disk
2. If its `version` field doesn't match the `release.json` version we just installed from, rewrites it to match
3. Logs the rewrite so it's visible in `debug.log`

The loop terminates after one install regardless of which side of the publish flow regressed.

### Defensive guards

- Skip if `expectedVersion` is falsy (no `latest_version` populated)
- Skip if `host_read_file` / `host_write_file` aren't available
- Skip if the installed `module.json` doesn't exist or can't be parsed
- Skip the write if the version already matches (no-op for the common case)

### Self-healing for existing stuck installs

Users currently stuck in the loop will see the update offer once more after this lands; the next install will pin and the loop terminates.

## Test plan

- [ ] Smoke: install a healthy module (e.g. `sf2`) and confirm no behavior change (`pinInstalledModuleVersion` log line should not appear since `data.version === expectedVersion`).
- [ ] Install one of the four publisher-stuck modules (e.g. `dissolver` while filliformes/dissolver-move#1 hasn't merged yet) and confirm:
  - The log line `pinInstalledModuleVersion: dissolver tarball reports 0.2.2, release.json says 0.2.3; rewriting to 0.2.3` appears in `debug.log`
  - The installed `module.json` on disk shows `0.2.3`
  - Module Store no longer offers v0.2.3 as an update on the next sync
- [ ] Re-install the same module again — `pinInstalledModuleVersion` should now be a no-op (version already matches).