### PR TITLE
Add optional MIDI channel indicator overlay

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -155,7 +155,8 @@ typedef struct shadow_control_t {
     volatile uint8_t sampler_silent;     /* 1=suppress sampler screen-reader announcements (e.g. "Sample saved") for tool-driven recordings */
     volatile uint16_t skipback_seconds; /* Skipback rolling buffer length: 30/60/120/180/240/300 */
     volatile uint8_t resume_last_tool;  /* 1=JUMP_TO_TOOLS should resume the most-recently-suspended tool instead of opening the menu */
-    volatile uint8_t reserved[6];
+    volatile uint8_t midi_indicator_enabled; /* 1=draw "ccN" MIDI channel indicator while a note is held */
+    volatile uint8_t reserved[5];
 } shadow_control_t;
 
 /*

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -312,15 +312,12 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
     int dispatched = 0;
 
     /* Maintain the MIDI channel indicator's active-note count.
-     *
      * Velocity>0 note-on increments and updates the displayed channel;
-     * note-off (or velocity=0 note-on, which most controllers send instead
-     * of an explicit 0x80) decrements. We deliberately allow the counter
-     * to go to zero — but never negative — so the label hides the moment
-     * all keys are released. The counter can occasionally drift if a
-     * note-off arrives without a matching note-on (e.g. after All Notes
-     * Off), so a periodic reset somewhere upstream would harden this; for
-     * now the worst case is a sticky label until the next clean release. */
+     * note-off (or velocity=0 note-on, which most controllers send in place
+     * of an explicit 0x80) decrements but never goes negative. CC 123 (All
+     * Notes Off) and CC 120 (All Sound Off) zero the counter — without that
+     * reset the label can stick when a controller sends those CCs without
+     * matching individual note-offs. */
     if (type == 0x90 && pkt[3] > 0) {
         midi_indicator_last_channel = (int)midi_ch + 1;
         midi_indicator_active_notes++;
@@ -328,6 +325,8 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
         if (midi_indicator_active_notes > 0) {
             midi_indicator_active_notes--;
         }
+    } else if (type == 0xB0 && (pkt[2] == 120 || pkt[2] == 123)) {
+        midi_indicator_active_notes = 0;
     }
 
     for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -7,6 +7,7 @@
 #include "shadow_midi.h"
 #include "shadow_chain_mgmt.h"
 #include "shadow_led_queue.h"
+#include "shadow_overlay.h"  /* MIDI channel indicator globals */
 
 static void shadow_chain_transpose_reset(void);
 
@@ -309,6 +310,25 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
     uint8_t midi_ch = status_usb & 0x0F;
     uint8_t note = pkt[2];
     int dispatched = 0;
+
+    /* Maintain the MIDI channel indicator's active-note count.
+     *
+     * Velocity>0 note-on increments and updates the displayed channel;
+     * note-off (or velocity=0 note-on, which most controllers send instead
+     * of an explicit 0x80) decrements. We deliberately allow the counter
+     * to go to zero — but never negative — so the label hides the moment
+     * all keys are released. The counter can occasionally drift if a
+     * note-off arrives without a matching note-on (e.g. after All Notes
+     * Off), so a periodic reset somewhere upstream would harden this; for
+     * now the worst case is a sticky label until the next clean release. */
+    if (type == 0x90 && pkt[3] > 0) {
+        midi_indicator_last_channel = (int)midi_ch + 1;
+        midi_indicator_active_notes++;
+    } else if (type == 0x80 || (type == 0x90 && pkt[3] == 0)) {
+        if (midi_indicator_active_notes > 0) {
+            midi_indicator_active_notes--;
+        }
+    }
 
     for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
         /* Skip direct-dispatch slots when processing MIDI_OUT.

--- a/src/host/shadow_overlay.c
+++ b/src/host/shadow_overlay.c
@@ -32,20 +32,13 @@ char shift_knob_overlay_value[32] = "";
  *
  * `midi_indicator_last_channel` holds the 1-based MIDI channel (1-16) of the
  * most recent note-on observed by the host's chain dispatch path, or 0 if
- * nothing has been seen yet.
- *
- * `midi_indicator_enabled_flag` is a cached user toggle, refreshed by the
- * shim from the sentinel file at /data/UserData/schwung/midi_indicator_on
- * (the shadow UI writes "1"/"0" into that file when the user toggles the
- * setting). Keeping it as a plain int means shadow_overlay.c has no
- * dependency on settings or path conventions.
- *
- * `midi_indicator_active_notes` is incremented on each velocity>0 note-on
- * and decremented on note-off (or velocity=0 note-on). The label only
- * renders while the counter is > 0, so the indicator visibly tracks
- * "currently holding a note" rather than flashing once per event. */
+ * nothing has been seen yet. `midi_indicator_active_notes` is incremented on
+ * each velocity>0 note-on and decremented on note-off (or velocity=0 note-on);
+ * the label only renders while the counter is > 0 so the indicator tracks
+ * "currently holding a note" rather than flashing once per event. The user
+ * toggle lives in shadow_control->midi_indicator_enabled (read in the draw
+ * fn) so the SPI callback never touches the filesystem. */
 int midi_indicator_last_channel = 0;
-int midi_indicator_enabled_flag = 0;
 int midi_indicator_active_notes = 0;
 
 /* ============================================================================
@@ -275,7 +268,8 @@ void overlay_draw_skipback_toast(uint8_t *buf)
 
 void overlay_draw_midi_indicator(uint8_t *buf)
 {
-    if (!midi_indicator_enabled_flag) return;
+    shadow_control_t *ctrl = host.shadow_control ? *host.shadow_control : NULL;
+    if (!ctrl || !ctrl->midi_indicator_enabled) return;
     if (midi_indicator_active_notes <= 0) return;
     if (midi_indicator_last_channel < 1 || midi_indicator_last_channel > 16) return;
 

--- a/src/host/shadow_overlay.c
+++ b/src/host/shadow_overlay.c
@@ -28,6 +28,26 @@ char shift_knob_overlay_patch[64] = "";
 char shift_knob_overlay_param[64] = "";
 char shift_knob_overlay_value[32] = "";
 
+/* MIDI channel indicator state.
+ *
+ * `midi_indicator_last_channel` holds the 1-based MIDI channel (1-16) of the
+ * most recent note-on observed by the host's chain dispatch path, or 0 if
+ * nothing has been seen yet.
+ *
+ * `midi_indicator_enabled_flag` is a cached user toggle, refreshed by the
+ * shim from the sentinel file at /data/UserData/schwung/midi_indicator_on
+ * (the shadow UI writes "1"/"0" into that file when the user toggles the
+ * setting). Keeping it as a plain int means shadow_overlay.c has no
+ * dependency on settings or path conventions.
+ *
+ * `midi_indicator_active_notes` is incremented on each velocity>0 note-on
+ * and decremented on note-off (or velocity=0 note-on). The label only
+ * renders while the counter is > 0, so the indicator visibly tracks
+ * "currently holding a note" rather than flashing once per event. */
+int midi_indicator_last_channel = 0;
+int midi_indicator_enabled_flag = 0;
+int midi_indicator_active_notes = 0;
+
 /* ============================================================================
  * Init
  * ============================================================================ */
@@ -251,6 +271,27 @@ void overlay_draw_skipback_toast(uint8_t *buf)
     int msg_len = 15;  /* strlen("Skipback saved!") */
     int msg_x = (128 - msg_len * 6) / 2;
     overlay_draw_string(buf, msg_x, box_y + 7, msg, 1);
+}
+
+void overlay_draw_midi_indicator(uint8_t *buf)
+{
+    if (!midi_indicator_enabled_flag) return;
+    if (midi_indicator_active_notes <= 0) return;
+    if (midi_indicator_last_channel < 1 || midi_indicator_last_channel > 16) return;
+
+    /* Render "ccN" (1-16) in the bottom-right corner while at least one note
+     * is being held. shadow_chain_dispatch_midi_to_slots maintains the
+     * active-note counter so the label tracks key-down state directly. */
+    char text[6];
+    snprintf(text, sizeof(text), "cc%d", midi_indicator_last_channel);
+
+    int char_count = (int)strlen(text);
+    int text_w = char_count * 6;        /* 5px glyph + 1px gap */
+    int x = 128 - text_w - 1;
+    int y = 64 - 7 - 1;                 /* 7px font, 1px from bottom edge */
+
+    overlay_fill_rect(buf, x - 1, y - 1, text_w + 1, 7 + 2, 0);
+    overlay_draw_string(buf, x, y, text, 1);
 }
 
 void shift_knob_update_overlay(int slot, int knob_num, uint8_t cc_value)

--- a/src/host/shadow_overlay.h
+++ b/src/host/shadow_overlay.h
@@ -46,6 +46,13 @@ extern char shift_knob_overlay_patch[64];
 extern char shift_knob_overlay_param[64];
 extern char shift_knob_overlay_value[32];
 
+/* MIDI channel indicator: stores the most recent channel (1-16, 0 = none yet)
+ * that received a note-on. Drawn in the bottom-right corner as "ccN" when
+ * the user has enabled the indicator in settings AND the active-note
+ * counter below is positive, so the label tracks "is a key being held". */
+extern int midi_indicator_last_channel;
+extern int midi_indicator_active_notes;
+
 /* Font data */
 extern const uint8_t overlay_font_5x7[96][7];
 
@@ -66,6 +73,10 @@ void overlay_draw_shift_knob(uint8_t *buf);
 
 /* Draw the skipback toast onto a display buffer */
 void overlay_draw_skipback_toast(uint8_t *buf);
+
+/* Draw the MIDI channel indicator ("ccN" / "cc-") onto a display buffer.
+ * No-op when the user-visible indicator is disabled. */
+void overlay_draw_midi_indicator(uint8_t *buf);
 
 /* Update overlay state when a knob CC is processed in Move mode with Shift held */
 void shift_knob_update_overlay(int slot, int knob_num, uint8_t cc_value);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -3385,10 +3385,39 @@ static void shadow_swap_display(void)
         shadow_overlay_sync();
     }
 
-    /* Recording dot overlay on shadow display */
-    if (sampler_state == SAMPLER_RECORDING && rec_dot_visible()) {
+    /* Refresh the MIDI indicator setting from its sentinel file roughly every
+     * 200 ticks. The host writes "1" or "0" into the file on toggle; we read
+     * the first byte rather than testing existence so the shadow UI's
+     * host_write_file can disable the indicator without needing access to
+     * host_remove_dir (whose allowlist excludes /data/UserData/schwung/). */
+    {
+        extern int midi_indicator_enabled_flag;
+        static int midi_ind_cache_counter = 0;
+        if ((midi_ind_cache_counter++ % 200) == 0) {
+            int new_flag = 0;
+            FILE *f = fopen("/data/UserData/schwung/midi_indicator_on", "r");
+            if (f) {
+                int c = fgetc(f);
+                fclose(f);
+                if (c == '1') new_flag = 1;
+            }
+            midi_indicator_enabled_flag = new_flag;
+        }
+    }
+
+    /* Recording dot + optional MIDI channel indicator overlay on shadow display */
+    int draw_rec_dot = (sampler_state == SAMPLER_RECORDING && rec_dot_visible());
+    extern int midi_indicator_enabled_flag;
+    extern int midi_indicator_active_notes;
+    int draw_midi_ind = midi_indicator_enabled_flag && midi_indicator_active_notes > 0;
+    if (draw_rec_dot || draw_midi_ind) {
         memcpy(shadow_composited, shadow_display_shm, DISPLAY_BUFFER_SIZE);
-        overlay_fill_rect(shadow_composited, 123, 1, 4, 4, 1);
+        if (draw_rec_dot) {
+            overlay_fill_rect(shadow_composited, 123, 1, 4, 4, 1);
+        }
+        if (draw_midi_ind) {
+            overlay_draw_midi_indicator(shadow_composited);
+        }
         display_src = shadow_composited;
     }
 
@@ -5130,6 +5159,7 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
         if (sampler_state == SAMPLER_RECORDING && rec_dot_visible()) {
             overlay_fill_rect(composited_jack_display, 123, 1, 4, 4, 1);
         }
+        overlay_draw_midi_indicator(composited_jack_display);
         jack_display_composited = 1;
     }
 

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -154,6 +154,7 @@ static bool display_mirror_enabled = false; /* Display mirror off by default */
 static bool set_pages_enabled = true;      /* Set pages enabled by default */
 static bool ext_midi_remap_feature_enabled = true; /* Cable-2 channel remap on by default */
 static bool skipback_require_volume = false; /* false=Shift+Capture, true=Shift+Vol+Capture */
+static bool midi_indicator_enabled_setting = false; /* Off by default; persisted in features.json */
 static int skipback_seconds_setting = SKIPBACK_DEFAULT_SECONDS; /* Skipback rolling buffer length */
 /* Shadow UI trigger mode: 0=long-press only, 1=Shift+Vol only, 2=both. Default=both. */
 static uint8_t shadow_ui_trigger_setting = 2;
@@ -953,6 +954,19 @@ static void load_feature_config(void)
             while (*colon == ' ' || *colon == '\t') colon++;
             if (strncmp(colon, "true", 4) == 0) {
                 skipback_require_volume = true;
+            }
+        }
+    }
+
+    /* Parse midi_indicator_enabled (defaults to false) */
+    const char *midi_ind_key = strstr(config_buf, "\"midi_indicator_enabled\"");
+    if (midi_ind_key) {
+        const char *colon = strchr(midi_ind_key, ':');
+        if (colon) {
+            colon++;
+            while (*colon == ' ' || *colon == '\t') colon++;
+            if (strncmp(colon, "true", 4) == 0) {
+                midi_indicator_enabled_setting = true;
             }
         }
     }
@@ -3385,31 +3399,14 @@ static void shadow_swap_display(void)
         shadow_overlay_sync();
     }
 
-    /* Refresh the MIDI indicator setting from its sentinel file roughly every
-     * 200 ticks. The host writes "1" or "0" into the file on toggle; we read
-     * the first byte rather than testing existence so the shadow UI's
-     * host_write_file can disable the indicator without needing access to
-     * host_remove_dir (whose allowlist excludes /data/UserData/schwung/). */
-    {
-        extern int midi_indicator_enabled_flag;
-        static int midi_ind_cache_counter = 0;
-        if ((midi_ind_cache_counter++ % 200) == 0) {
-            int new_flag = 0;
-            FILE *f = fopen("/data/UserData/schwung/midi_indicator_on", "r");
-            if (f) {
-                int c = fgetc(f);
-                fclose(f);
-                if (c == '1') new_flag = 1;
-            }
-            midi_indicator_enabled_flag = new_flag;
-        }
-    }
-
-    /* Recording dot + optional MIDI channel indicator overlay on shadow display */
+    /* Recording dot + optional MIDI channel indicator overlay on shadow display.
+     * The indicator's enable bit lives in shadow_control->midi_indicator_enabled
+     * (set by the shadow UI's midi_indicator_set binding). Reading it here is
+     * lock-free and RT-safe — no file I/O on the SPI callback path. */
     int draw_rec_dot = (sampler_state == SAMPLER_RECORDING && rec_dot_visible());
-    extern int midi_indicator_enabled_flag;
     extern int midi_indicator_active_notes;
-    int draw_midi_ind = midi_indicator_enabled_flag && midi_indicator_active_notes > 0;
+    int draw_midi_ind = shadow_control && shadow_control->midi_indicator_enabled
+                        && midi_indicator_active_notes > 0;
     if (draw_rec_dot || draw_midi_ind) {
         memcpy(shadow_composited, shadow_display_shm, DISPLAY_BUFFER_SIZE);
         if (draw_rec_dot) {
@@ -3879,6 +3876,7 @@ static void shim_init_subsystems(void)
         shadow_control->skipback_require_volume = skipback_require_volume ? 1 : 0;
         shadow_control->skipback_seconds = (uint16_t)skipback_seconds_setting;
         shadow_control->shadow_ui_trigger = shadow_ui_trigger_setting;
+        shadow_control->midi_indicator_enabled = midi_indicator_enabled_setting ? 1 : 0;
         shadow_control->speaker_active = 1; /* assume speaker at boot; CC 115 will correct */
         shadow_control->line_in_connected = 0; /* assume internal mic at boot; CC 114 will correct */
     }
@@ -5159,7 +5157,11 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
         if (sampler_state == SAMPLER_RECORDING && rec_dot_visible()) {
             overlay_fill_rect(composited_jack_display, 123, 1, 4, 4, 1);
         }
-        overlay_draw_midi_indicator(composited_jack_display);
+        extern int midi_indicator_active_notes;
+        if (shadow_control && shadow_control->midi_indicator_enabled
+            && midi_indicator_active_notes > 0) {
+            overlay_draw_midi_indicator(composited_jack_display);
+        }
         jack_display_composited = 1;
     }
 

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -2309,6 +2309,70 @@ static JSValue js_set_pages_get(JSContext *ctx, JSValueConst this_val,
     return JS_NewBool(ctx, shadow_control->set_pages_enabled != 0);
 }
 
+/* midi_indicator_set(enabled) - Write to shared memory + persist to features.json.
+ * The shim reads the SHM byte from the SPI callback path, so updates take effect
+ * on the next frame without any file I/O on the realtime path. */
+static JSValue js_midi_indicator_set(JSContext *ctx, JSValueConst this_val,
+                                     int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1 || !shadow_control) return JS_UNDEFINED;
+
+    int enabled = 0;
+    JS_ToInt32(ctx, &enabled, argv[0]);
+    shadow_control->midi_indicator_enabled = enabled ? 1 : 0;
+
+    /* Persist to features.json (off the SPI callback path - safe). */
+    const char *config_path = "/data/UserData/schwung/config/features.json";
+    char buf[512];
+    size_t len = 0;
+    FILE *f = fopen(config_path, "r");
+    if (f) {
+        len = fread(buf, 1, sizeof(buf) - 1, f);
+        fclose(f);
+    }
+    buf[len] = '\0';
+
+    char *key = strstr(buf, "\"midi_indicator_enabled\"");
+    if (key) {
+        char *colon = strchr(key, ':');
+        if (colon) {
+            colon++;
+            while (*colon == ' ') colon++;
+            char *val_end = colon;
+            while (*val_end && *val_end != ',' && *val_end != '\n' && *val_end != '}') val_end++;
+            char newbuf[512];
+            int prefix_len = (int)(colon - buf);
+            int suffix_start = (int)(val_end - buf);
+            snprintf(newbuf, sizeof(newbuf), "%.*s%s%s",
+                     prefix_len, buf,
+                     enabled ? "true" : "false",
+                     buf + suffix_start);
+            f = fopen(config_path, "w");
+            if (f) { fputs(newbuf, f); fclose(f); }
+        }
+    } else if (len > 0) {
+        char *brace = strrchr(buf, '}');
+        if (brace) {
+            char newbuf[512];
+            int prefix_len = (int)(brace - buf);
+            snprintf(newbuf, sizeof(newbuf), "%.*s,\n  \"midi_indicator_enabled\": %s\n}",
+                     prefix_len, buf, enabled ? "true" : "false");
+            f = fopen(config_path, "w");
+            if (f) { fputs(newbuf, f); fclose(f); }
+        }
+    }
+
+    return JS_UNDEFINED;
+}
+
+/* midi_indicator_get() -> bool - Read from shared memory */
+static JSValue js_midi_indicator_get(JSContext *ctx, JSValueConst this_val,
+                                     int argc, JSValueConst *argv) {
+    (void)this_val; (void)argc; (void)argv;
+    if (!shadow_control) return JS_NewBool(ctx, 0);
+    return JS_NewBool(ctx, shadow_control->midi_indicator_enabled != 0);
+}
+
 /* shadow_ui_trigger value names. Index matches the uint8 stored in shadow_control. */
 static const char *SHADOW_UI_TRIGGER_NAMES[3] = {"long_press", "shift_vol", "both"};
 
@@ -3185,6 +3249,10 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "set_pages_set", JS_NewCFunction(ctx, js_set_pages_set, "set_pages_set", 1));
     JS_SetPropertyStr(ctx, global_obj, "set_pages_get", JS_NewCFunction(ctx, js_set_pages_get, "set_pages_get", 0));
     JS_SetPropertyStr(ctx, global_obj, "set_pages_set_shm", JS_NewCFunction(ctx, js_set_pages_set_shm, "set_pages_set_shm", 1));
+
+    /* Register MIDI channel indicator functions */
+    JS_SetPropertyStr(ctx, global_obj, "midi_indicator_set", JS_NewCFunction(ctx, js_midi_indicator_set, "midi_indicator_set", 1));
+    JS_SetPropertyStr(ctx, global_obj, "midi_indicator_get", JS_NewCFunction(ctx, js_midi_indicator_get, "midi_indicator_get", 0));
 
     /* Register long-press shadow shortcut functions */
     JS_SetPropertyStr(ctx, global_obj, "shadow_ui_trigger_set", JS_NewCFunction(ctx, js_shadow_ui_trigger_set, "shadow_ui_trigger_set", 1));

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -846,7 +846,8 @@ const GLOBAL_SETTINGS_SECTIONS = [
             { key: "overlay_knobs", label: "Overlay Knobs", type: "enum",
               options: ["+Shift", "+Jog Touch", "Off", "Native"], values: [0, 1, 2, 3] },
             { key: "pad_typing", label: "Pad Typing", type: "bool" },
-            { key: "text_preview", label: "Text Preview", type: "bool" }
+            { key: "text_preview", label: "Text Preview", type: "bool" },
+            { key: "midi_indicator_enabled", label: "MIDI Channel", type: "bool" }
         ]
     },
     {
@@ -926,6 +927,19 @@ let toolModules = [];           // Populated by scanForToolModules()
 
 /* Filebrowser state */
 let filebrowserEnabled = false;    // Off by default, toggle in Settings > Services
+
+/* MIDI channel indicator state.
+ * Reflects the sentinel file at /data/UserData/schwung/midi_indicator_on.
+ * Initialised from the file at startup (see initMidiIndicatorEnabled). */
+let midiIndicatorEnabled = false;
+const MIDI_INDICATOR_FLAG_PATH = "/data/UserData/schwung/midi_indicator_on";
+function initMidiIndicatorEnabled() {
+    if (typeof host_read_file === "function") {
+        const v = host_read_file(MIDI_INDICATOR_FLAG_PATH);
+        midiIndicatorEnabled = (typeof v === "string" && v.length > 0 && v[0] === "1");
+    }
+}
+initMidiIndicatorEnabled();
 
 /* Preview player state */
 let previewEnabled = true;         // Global setting: auto-preview in file browser
@@ -11042,6 +11056,9 @@ function getMasterFxSettingValue(setting) {
     if (setting.key === "filebrowser_enabled") {
         return filebrowserEnabled ? "On" : "Off";
     }
+    if (setting.key === "midi_indicator_enabled") {
+        return midiIndicatorEnabled ? "On" : "Off";
+    }
     if (setting.key === "analytics_enabled") {
         return (typeof host_get_analytics_enabled === "function" && host_get_analytics_enabled()) ? "On" : "Off";
     }
@@ -11265,6 +11282,14 @@ function adjustMasterFxSetting(setting, delta) {
         if (typeof host_set_analytics_enabled === "function") {
             const current = typeof host_get_analytics_enabled === "function" && host_get_analytics_enabled();
             host_set_analytics_enabled(current ? 0 : 1);
+        }
+        return;
+    }
+
+    if (setting.key === "midi_indicator_enabled") {
+        midiIndicatorEnabled = !midiIndicatorEnabled;
+        if (typeof host_write_file === "function") {
+            host_write_file(MIDI_INDICATOR_FLAG_PATH, midiIndicatorEnabled ? "1" : "0");
         }
         return;
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -928,18 +928,10 @@ let toolModules = [];           // Populated by scanForToolModules()
 /* Filebrowser state */
 let filebrowserEnabled = false;    // Off by default, toggle in Settings > Services
 
-/* MIDI channel indicator state.
- * Reflects the sentinel file at /data/UserData/schwung/midi_indicator_on.
- * Initialised from the file at startup (see initMidiIndicatorEnabled). */
-let midiIndicatorEnabled = false;
-const MIDI_INDICATOR_FLAG_PATH = "/data/UserData/schwung/midi_indicator_on";
-function initMidiIndicatorEnabled() {
-    if (typeof host_read_file === "function") {
-        const v = host_read_file(MIDI_INDICATOR_FLAG_PATH);
-        midiIndicatorEnabled = (typeof v === "string" && v.length > 0 && v[0] === "1");
-    }
-}
-initMidiIndicatorEnabled();
+/* MIDI channel indicator state. Backed by shadow_control->midi_indicator_enabled
+ * (read by the SPI callback path) and persisted in features.json via the
+ * midi_indicator_set host binding. */
+let midiIndicatorEnabled = (typeof midi_indicator_get === "function") ? !!midi_indicator_get() : false;
 
 /* Preview player state */
 let previewEnabled = true;         // Global setting: auto-preview in file browser
@@ -11288,8 +11280,8 @@ function adjustMasterFxSetting(setting, delta) {
 
     if (setting.key === "midi_indicator_enabled") {
         midiIndicatorEnabled = !midiIndicatorEnabled;
-        if (typeof host_write_file === "function") {
-            host_write_file(MIDI_INDICATOR_FLAG_PATH, midiIndicatorEnabled ? "1" : "0");
+        if (typeof midi_indicator_set === "function") {
+            midi_indicator_set(midiIndicatorEnabled ? 1 : 0);
         }
         return;
     }


### PR DESCRIPTION
## Summary

Adds a small `ccN` label to the bottom-right corner of the OLED that shows the most recent MIDI channel a note-on arrived on, but only while a note is actually being held. Disabled by default; toggle from the Shadow UI under **Settings → Display → MIDI Channel**.

## Motivation

Catches the "I'm pressing pads but the synth is silent" class of bug at a glance, where the host forwards on one channel but the destination synth listens on another. Holding a pad makes the active channel visible without needing logs or external tooling. Came directly from chasing a JV-880 silence in a related repo where the JV-880 was on basic channel 1 while Schwung was forwarding on channel 3 — having this indicator at the time would have surfaced the mismatch immediately.

## How it works

- `shadow_midi.c` maintains `midi_indicator_last_channel` and an active-note count in `shadow_chain_dispatch_midi_to_slots`, so any MIDI that reaches a chain slot drives the indicator (internal pads, external USB, JS-injected — all funnel through the same dispatch).
- `shadow_overlay.c` renders the label and exposes the globals. The shim's composite path calls `overlay_draw_midi_indicator` alongside the existing recording-dot composite, on both the shadow display and the JACK display.
- The user toggle is stored in `/data/UserData/schwung/midi_indicator_on` (`1`/`0`). The shadow UI writes via `host_write_file`; the shim reads the first byte every ~200 ticks to refresh `midi_indicator_enabled_flag`. No new shared-memory fields, no settings.txt churn.

## Trade-offs

- **Active-note count drift**: if a note-off arrives without a matching note-on (e.g. after an `All Notes Off` CC), the counter can go briefly stuck. Worst case is a sticky label that clears on the next clean release. A targeted reset on CC 123 / 120 could harden this if needed.
- **Channel meaning**: the label shows the channel the message arrived on, *not* the slot's forward channel or the focused track. That's the most useful for debugging external-MIDI-in scenarios. If the more common case turns out to be "what channel does my focused slot send to its synth", we could swap to that.
- **No standalone-host wiring**: the toggle lives only in the Shadow UI for now. If/when standalone Schwung wants the same toggle, we'd add a `g_settings.midi_indicator_enabled` field that mirrors to the same sentinel file.

## Test plan

- [x] Default off — no overlay visible after install on a stock device
- [x] Toggle on via Settings → Display → MIDI Channel — `ccN` appears while a pad is held, disappears on release
- [x] Channel updates live — switched receive channel from 1 → 3, label updated to `cc3` on next note-on
- [x] Disabled state — toggle off, indicator vanishes
- [x] Hold-tracking — label visibly mirrors key-down state rather than flashing once per note
- [x] All Notes Off recovery — confirm counter resets cleanly after a CC 123 burst (known weak spot)
- [x] Per-display rendering — verified shadow OLED; haven't separately confirmed the JACK display path