### PR TITLE
feat(overtake): deliver internal pad MIDI to overtake DSP's on_midi hook

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1252,6 +1252,7 @@ static void shadow_inprocess_process_midi(void) {
 
         }
     }
+
 }
 
 /* === OVERTAKE DSP LOAD/UNLOAD ===
@@ -6752,6 +6753,22 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
             uint8_t type = status & 0xF0;
             uint8_t d1 = src[j + 2];
             uint8_t d2 = src[j + 3];
+
+            /* Deliver internal cable-0 note events (d1 >= 10, excludes
+             * knob-touch reserved range 0–9) to the loaded overtake DSP
+             * via its audio-thread on_midi hook.  Enables overtake tools
+             * like dAVEBOx to handle pad input on the audio thread
+             * instead of through the JS round-trip below. */
+            if (overtake_mode == 2 && cable == 0x00 &&
+                (type == 0x90 || type == 0x80) && d1 >= 10) {
+                if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->on_midi) {
+                    uint8_t msg[3] = { status, d1, d2 };
+                    overtake_dsp_gen->on_midi(overtake_dsp_gen_inst, msg, 3, MOVE_MIDI_SOURCE_INTERNAL);
+                } else if (overtake_dsp_fx && overtake_dsp_fx_inst && overtake_dsp_fx->on_midi) {
+                    uint8_t msg[3] = { status, d1, d2 };
+                    overtake_dsp_fx->on_midi(overtake_dsp_fx_inst, msg, 3, MOVE_MIDI_SOURCE_INTERNAL);
+                }
+            }
 
             /* In overtake mode, forward events to shadow UI.
              * overtake_mode=1 (menu): only forward UI events (jog, click, back)

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -323,6 +323,18 @@ static JSValue js_shadow_clear_ui_flags(JSContext *ctx, JSValueConst this_val, i
     return JS_UNDEFINED;
 }
 
+/* shadow_inbound_pad_midi_active() -> int
+ * Returns 1 if this build of the shim delivers internal pad MIDI to the
+ * overtake tool's DSP on_midi on the audio thread. Capability sentinel
+ * for tools that want audio-thread input: check
+ * `typeof shadow_inbound_pad_midi_active === 'function'` to gate the
+ * DSP-owned input path. The function's mere existence is the signal;
+ * the return value is reserved for future use. */
+static JSValue js_shadow_inbound_pad_midi_active(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val; (void)argc; (void)argv;
+    return JS_NewInt32(ctx, 1);
+}
+
 /* shadow_get_selected_slot() -> int
  * Returns the track-selected slot (0-3) for playback/knobs.
  */
@@ -3089,6 +3101,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_focused_slot", JS_NewCFunction(ctx, js_shadow_set_focused_slot, "shadow_set_focused_slot", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_ui_flags", JS_NewCFunction(ctx, js_shadow_get_ui_flags, "shadow_get_ui_flags", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_clear_ui_flags", JS_NewCFunction(ctx, js_shadow_clear_ui_flags, "shadow_clear_ui_flags", 1));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_inbound_pad_midi_active", JS_NewCFunction(ctx, js_shadow_inbound_pad_midi_active, "shadow_inbound_pad_midi_active", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_open_tool_cmd",
         JS_NewCFunction(ctx, js_shadow_get_open_tool_cmd, "shadow_get_open_tool_cmd", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_selected_slot", JS_NewCFunction(ctx, js_shadow_get_selected_slot, "shadow_get_selected_slot", 0));


### PR DESCRIPTION
### What this PR does

Adds an opt-in path for overtake tool modules to receive internal pad MIDI on the **audio thread** instead of through the JS round-trip.

Today, when an overtake tool module is loaded (`overtake_mode == 2`), internal cable-0 note events from the pad grid are forwarded to the shadow UI's JS context, where the tool's `onMidiMessage` handler can react. The DSP `on_midi` hook on the overtake module is already invoked for external (cable-2) MIDI but not for internal pads — so pad input is locked to JS-tick cadence.

This PR closes that gap. With the change, internal cable-0 note events (notes ≥ 10, excluding the knob-touch reserved range 0–9) are delivered to the loaded overtake DSP's `on_midi` callback **in addition to** the existing JS forward. A tiny capability sentinel lets tools detect this build at runtime so they can opt into the audio-thread path on hosts that support it and continue to use the JS path on hosts that don't.

### Two commits

1. **`feat(overtake): deliver internal pad MIDI to overtake DSP on_midi`** — 17 lines in `src/schwung_shim.c`. Inside `shim_post_transfer`'s existing event loop, immediately before the JS forward block, dispatches qualifying notes to `overtake_dsp_gen->on_midi` (or `overtake_dsp_fx->on_midi`) with source flag `MOVE_MIDI_SOURCE_INTERNAL`.

2. **`feat(overtake): add shadow_inbound_pad_midi_active() capability sentinel`** — 13 lines in `src/shadow/shadow_ui.c`. Zero-arg `shadow_*` function that exists on this build and is undefined on stock. Tools check `typeof shadow_inbound_pad_midi_active === 'function'` to gate the audio-thread path.

### Why this matters

**Symmetry.** Overtake DSP modules already have an `on_midi` hook that fires for external (cable-2) MIDI. This PR makes the hook fire for the *other* obvious input source — the device's own pads — bringing internal MIDI into parity with external MIDI for overtake tools that opt in.

**Removes an invisible latency floor.** JS-tick cadence on Move is ~94 Hz (one tick per 512-sample audio buffer at 48 kHz). Any tool that responds to a pad press in JS — sound previews, repeat engines, chord arpeggiators, gate latches — adds up to one tick of jitter between the physical press and the audible response. On the audio thread that floor disappears; events land at sample-accuracy and the tool's DSP can react in the same buffer the event arrived in. For sequencer-style tools this is the difference between "feels MIDI" and "feels native."

**Zero impact on existing tools.** The dispatch is additive: the event reaches both `on_midi` AND the JS forward. Tools that don't opt in are completely unaffected. Tools that do opt in can choose, per event, whether to handle it on the audio thread, in JS, or both (e.g. audio-thread for the audible response, JS for UI redraws).

**Opt-in via a capability sentinel keeps modules forward- and backward-compatible.** The pattern matches the existing `shadow_set_corun_chain_edit` / `shadow_set_corun_move_native` exposure shape. Useful for any overtake tool whose response to input is currently bottlenecked by `pollDSP` / JS-tick polling — performance samplers, live-looping tools, gate/repeat engines — gain a faster path without giving up the JS path.

### Implementation notes for tool authors adopting this

`on_midi` runs on the audio thread — treat it like `render` (no allocations, no file I/O, no non-audio-safe host APIs). The dispatch passes notes with `d1 >= 10`; the 0–9 range remains reserved for knob-touch events and continues to reach JS only. Events reach both `on_midi` AND JS, so the tool can split work (audio-thread for the audible response, JS for UI). The sentinel returns `1` today; the return value is intentionally not parsed as a bitmask yet — "non-zero means active" leaves room to grow into capability flags (e.g. CC delivery) without breaking the contract.

### Compatibility

- **Stock builds**: `shadow_inbound_pad_midi_active` is undefined. Tools that check `typeof ... === 'function'` see `false` and use their pre-existing JS-side input path. Zero behavior change.
- **This build, tool doesn't opt in**: The new dispatch fires but the tool's `on_midi` ignores internal-source notes (the standard pattern is `if (source != MOVE_MIDI_SOURCE_EXTERNAL) return;`). Zero behavior change.
- **This build, tool opts in**: The tool's DSP receives the event on the audio thread. The JS path also fires; the tool decides per-event how to split work between them.
- **Non-overtake mode**: Guard is `overtake_mode == 2 && cable == 0x00 && (type == 0x90 || type == 0x80) && d1 >= 10`. Dispatch never fires when no overtake tool is loaded or for non-note / non-internal events.

### Risk

Additive only — no existing code path is modified or removed; no struct layouts change; no host API signatures change. 3 bytes copied + one function-pointer call per qualifying event; pad-grid traffic is bounded by hardware. Audio-thread safety inherits from the existing JS-forward block in the same loop.

### Verification

Built and run on Move (Schwung v0.9.13 base). dAVEBOx Phase 1 development tree exercises the hook across:
- 16-step chord-press cohesion
- Count-in pre-roll capture window
- Drum velocity-zone preview routing
- Rpt1 / Rpt2 repeat-engine triggering (incl. multi-lane simultaneous press/release, latch via Loop-held gesture, re-tap-to-unlatch at fastest rate)
- Recording armed across `ROUTE_MOVE` and `ROUTE_SCHWUNG`
- Set-switch / state-load instance recreate
- Modal-pad gating during Delete-held gestures

No regressions observed on tools that don't opt in (stock dAVEBOx, other tested module).
