### PR TITLE
feat: add Alpha Juno 2 controller module to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -924,6 +924,17 @@
       "default_branch": "master",
       "asset_name": "dronage-tool-module.tar.gz",
       "min_host_version": "0.9.8"
+    },
+    {
+      "id": "juno_control",
+      "name": "Alpha Juno 2 Ctrl",
+      "description": "SysEx patch editor and controller for Roland Alpha Juno 1/2 and MKS-50",
+      "author": "madeinspace",
+      "component_type": "overtake",
+      "github_repo": "madeinspace/move-juno-controller",
+      "default_branch": "main",
+      "asset_name": "juno_control-module.tar.gz",
+      "min_host_version": "0.3.6"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the **Alpha Juno 2 Ctrl** module to the Schwung Module Store catalog.

- **Module ID:** `juno_control`
- **Type:** Overtake
- **Repo:** [madeinspace/move-juno-controller](https://github.com/madeinspace/move-juno-controller)
- **Release:** [v1.0.0](https://github.com/madeinspace/move-juno-controller/releases/tag/v1.0.0)

### What it does

SysEx patch editor and controller for Roland Alpha Juno 1/2 and MKS-50 synthesisers over USB-MIDI:

- **5 parameter pages** — Main (Cutoff/Reso/ADSR/LFO), DCO, VCF, VCA/FX, ENV
- **64 preset browser** — bank+number pad grid matching the Juno's front panel layout
- **Chromatic keyboard** — play the Juno from Move's pads
- **Real-time SysEx control** — all 36 tone parameters via IPR messages
- **ADSR coupling** — Main page envelope knobs auto-set intermediate levels for standard ADSR behaviour

### Connections

Juno MIDI DIN → USB-MIDI adapter → Move USB-C port