### PR TITLE
feat: absolute knob automation via CC 102-109

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -325,6 +325,7 @@ console.log(msg)              // Routed to the unified logger when enabled
 | 63  | Right arrow       |                                |
 | 71-78 | Knobs 1-8       | Relative encoder (1-63 CW, 65-127 CCW) |
 | 79  | Master volume     | Relative encoder (1-63 CW, 65-127 CCW) |
+| 102-109 | Knobs 1-8 (absolute) | Absolute value (0-127 scaled to assigned param range); targets the same user-assigned knob mappings as CC 71-78 |
 | 85  | Play              |                                |
 | 86  | Record            |                                |
 | 88  | Mute              |                                |

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1802,7 +1802,8 @@ All fields are optional and combine as a union.
 | `pads` | notes | 68-99 | 32 performance pads |
 | `steps` | notes | 16-31 | 16 step sequencer buttons |
 | `tracks` | CCs | 40-43 | 4 track buttons |
-| `knobs` | CCs | 71-78 | 8 encoders |
+| `knobs` | CCs | 71-78 | 8 encoders (relative) |
+| `knobs_abs` | CCs | 102-109 | 8 knobs (absolute 0-127, scaled to assigned param range) |
 | `jog` | CC | 14 | Main encoder |
 
 **Module-level capture (for Master FX):**

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -115,6 +115,8 @@ typedef enum {
 #define MAX_KNOB_MAPPINGS 8
 #define KNOB_CC_START 71
 #define KNOB_CC_END 78
+#define KNOB_ABS_CC_START 102
+#define KNOB_ABS_CC_END 109
 #define KNOB_STEP_FLOAT 0.0015f /* Base step for floats (~600 clicks for 0-1 at min speed) */
 #define KNOB_STEP_INT 1        /* Base step for int params */
 
@@ -2707,6 +2709,54 @@ static chain_param_info_t *find_param_info(chain_param_info_t *params, int count
         }
     }
     return NULL;
+}
+
+/* Look up param metadata from a knob mapping's target string (synth/fx1-3/midi_fx1-2). */
+static chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, const char *param) {
+    if (strcmp(target, "synth") == 0)
+        return find_param_info(inst->synth_params, inst->synth_param_count, param);
+    if (strcmp(target, "fx1") == 0 && inst->fx_count > 0)
+        return find_param_info(inst->fx_params[0], inst->fx_param_counts[0], param);
+    if (strcmp(target, "fx2") == 0 && inst->fx_count > 1)
+        return find_param_info(inst->fx_params[1], inst->fx_param_counts[1], param);
+    if (strcmp(target, "fx3") == 0 && inst->fx_count > 2)
+        return find_param_info(inst->fx_params[2], inst->fx_param_counts[2], param);
+    if (strcmp(target, "midi_fx1") == 0 && inst->midi_fx_count > 0)
+        return find_param_info(inst->midi_fx_params[0], inst->midi_fx_param_counts[0], param);
+    if (strcmp(target, "midi_fx2") == 0 && inst->midi_fx_count > 1)
+        return find_param_info(inst->midi_fx_params[1], inst->midi_fx_param_counts[1], param);
+    return NULL;
+}
+
+/* Forward a formatted value string to the plugin identified by target. */
+static void knob_forward_value(chain_instance_t *inst, const char *target, const char *param, const char *val_str) {
+    if (strcmp(target, "synth") == 0) {
+        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->set_param)
+            inst->synth_plugin_v2->set_param(inst->synth_instance, param, val_str);
+        else if (inst->synth_plugin && inst->synth_plugin->set_param)
+            inst->synth_plugin->set_param(param, val_str);
+    } else if (strcmp(target, "fx1") == 0 && inst->fx_count > 0) {
+        if (inst->fx_is_v2[0] && inst->fx_plugins_v2[0] && inst->fx_instances[0])
+            inst->fx_plugins_v2[0]->set_param(inst->fx_instances[0], param, val_str);
+        else if (inst->fx_plugins[0] && inst->fx_plugins[0]->set_param)
+            inst->fx_plugins[0]->set_param(param, val_str);
+    } else if (strcmp(target, "fx2") == 0 && inst->fx_count > 1) {
+        if (inst->fx_is_v2[1] && inst->fx_plugins_v2[1] && inst->fx_instances[1])
+            inst->fx_plugins_v2[1]->set_param(inst->fx_instances[1], param, val_str);
+        else if (inst->fx_plugins[1] && inst->fx_plugins[1]->set_param)
+            inst->fx_plugins[1]->set_param(param, val_str);
+    } else if (strcmp(target, "fx3") == 0 && inst->fx_count > 2) {
+        if (inst->fx_is_v2[2] && inst->fx_plugins_v2[2] && inst->fx_instances[2])
+            inst->fx_plugins_v2[2]->set_param(inst->fx_instances[2], param, val_str);
+        else if (inst->fx_plugins[2] && inst->fx_plugins[2]->set_param)
+            inst->fx_plugins[2]->set_param(param, val_str);
+    } else if (strcmp(target, "midi_fx1") == 0 && inst->midi_fx_count > 0) {
+        if (inst->midi_fx_plugins[0] && inst->midi_fx_instances[0] && inst->midi_fx_plugins[0]->set_param)
+            inst->midi_fx_plugins[0]->set_param(inst->midi_fx_instances[0], param, val_str);
+    } else if (strcmp(target, "midi_fx2") == 0 && inst->midi_fx_count > 1) {
+        if (inst->midi_fx_plugins[1] && inst->midi_fx_instances[1] && inst->midi_fx_plugins[1]->set_param)
+            inst->midi_fx_plugins[1]->set_param(inst->midi_fx_instances[1], param, val_str);
+    }
 }
 
 /* Parse a patch file and populate patch_info */
@@ -7052,26 +7102,10 @@ static void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) 
         if (cc >= KNOB_CC_START && cc <= KNOB_CC_END) {
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == cc) {
-                    /* Look up parameter metadata dynamically */
                     const char *target = inst->knob_mappings[i].target;
                     const char *param = inst->knob_mappings[i].param;
-                    chain_param_info_t *pinfo = NULL;
-
-                    if (strcmp(target, "synth") == 0) {
-                        pinfo = find_param_info(inst->synth_params, inst->synth_param_count, param);
-                    } else if (strcmp(target, "fx1") == 0 && inst->fx_count > 0) {
-                        pinfo = find_param_info(inst->fx_params[0], inst->fx_param_counts[0], param);
-                    } else if (strcmp(target, "fx2") == 0 && inst->fx_count > 1) {
-                        pinfo = find_param_info(inst->fx_params[1], inst->fx_param_counts[1], param);
-                    } else if (strcmp(target, "fx3") == 0 && inst->fx_count > 2) {
-                        pinfo = find_param_info(inst->fx_params[2], inst->fx_param_counts[2], param);
-                    } else if (strcmp(target, "midi_fx1") == 0 && inst->midi_fx_count > 0) {
-                        pinfo = find_param_info(inst->midi_fx_params[0], inst->midi_fx_param_counts[0], param);
-                    } else if (strcmp(target, "midi_fx2") == 0 && inst->midi_fx_count > 1) {
-                        pinfo = find_param_info(inst->midi_fx_params[1], inst->midi_fx_param_counts[1], param);
-                    }
-
-                    if (!pinfo) continue;  /* Skip if param not found */
+                    chain_param_info_t *pinfo = knob_find_param(inst, target, param);
+                    if (!pinfo) continue;
 
                     /* Calculate acceleration based on time between events */
                     uint64_t now = get_time_ms();
@@ -7125,34 +7159,40 @@ static void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) 
                         snprintf(val_str, sizeof(val_str), "%.3f", new_val);
                     }
 
-                    if (strcmp(target, "synth") == 0) {
-                        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->set_param) {
-                            inst->synth_plugin_v2->set_param(inst->synth_instance, param, val_str);
-                        } else if (inst->synth_plugin && inst->synth_plugin->set_param) {
-                            inst->synth_plugin->set_param(param, val_str);
-                        }
-                    } else if (strcmp(target, "fx1") == 0 && inst->fx_count > 0) {
-                        if (inst->fx_is_v2[0] && inst->fx_plugins_v2[0] && inst->fx_instances[0]) {
-                            inst->fx_plugins_v2[0]->set_param(inst->fx_instances[0], param, val_str);
-                        } else if (inst->fx_plugins[0] && inst->fx_plugins[0]->set_param) {
-                            inst->fx_plugins[0]->set_param(param, val_str);
-                        }
-                    } else if (strcmp(target, "fx2") == 0 && inst->fx_count > 1) {
-                        if (inst->fx_is_v2[1] && inst->fx_plugins_v2[1] && inst->fx_instances[1]) {
-                            inst->fx_plugins_v2[1]->set_param(inst->fx_instances[1], param, val_str);
-                        } else if (inst->fx_plugins[1] && inst->fx_plugins[1]->set_param) {
-                            inst->fx_plugins[1]->set_param(param, val_str);
-                        }
-                    } else if (strcmp(target, "fx3") == 0 && inst->fx_count > 2) {
-                        if (inst->fx_is_v2[2] && inst->fx_plugins_v2[2] && inst->fx_instances[2]) {
-                            inst->fx_plugins_v2[2]->set_param(inst->fx_instances[2], param, val_str);
-                        } else if (inst->fx_plugins[2] && inst->fx_plugins[2]->set_param) {
-                            inst->fx_plugins[2]->set_param(param, val_str);
-                        }
-                    }
+                    knob_forward_value(inst, target, param, val_str);
                     return;
                 }
             }
+        }
+        /* Absolute knob automation: CC 102-109 → knob 1-8 (0-127 scaled to param range).
+         * Same knob mappings as CC 71-78, but interprets the value as an absolute
+         * position rather than a relative encoder delta. Consumed here; not forwarded
+         * to synth/FX. */
+        if (cc >= KNOB_ABS_CC_START && cc <= KNOB_ABS_CC_END) {
+            int target_cc = KNOB_CC_START + (cc - KNOB_ABS_CC_START);
+            for (int i = 0; i < inst->knob_mapping_count; i++) {
+                if (inst->knob_mappings[i].cc == target_cc) {
+                    const char *target = inst->knob_mappings[i].target;
+                    const char *param = inst->knob_mappings[i].param;
+                    chain_param_info_t *pinfo = knob_find_param(inst, target, param);
+                    if (!pinfo) return;
+
+                    float abs_val = pinfo->min_val + ((float)msg[2] / 127.0f) * (pinfo->max_val - pinfo->min_val);
+                    int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
+                    if (is_int) abs_val = (float)((int)(abs_val + 0.5f));
+                    if (abs_val < pinfo->min_val) abs_val = pinfo->min_val;
+                    if (abs_val > pinfo->max_val) abs_val = pinfo->max_val;
+                    inst->knob_mappings[i].current_value = abs_val;
+
+                    char val_str[16];
+                    if (is_int) snprintf(val_str, sizeof(val_str), "%d", (int)abs_val);
+                    else        snprintf(val_str, sizeof(val_str), "%.3f", abs_val);
+
+                    knob_forward_value(inst, target, param, val_str);
+                    return;
+                }
+            }
+            return;  /* CC 102-109 consumed even if unmapped — don't forward to synth */
         }
     }
 
@@ -7704,23 +7744,8 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         /* Look up parameter metadata */
                         const char *target = inst->knob_mappings[i].target;
                         const char *param = inst->knob_mappings[i].param;
-                        chain_param_info_t *pinfo = NULL;
-
-                        if (strcmp(target, "synth") == 0) {
-                            pinfo = find_param_info(inst->synth_params, inst->synth_param_count, param);
-                        } else if (strcmp(target, "fx1") == 0 && inst->fx_count > 0) {
-                            pinfo = find_param_info(inst->fx_params[0], inst->fx_param_counts[0], param);
-                        } else if (strcmp(target, "fx2") == 0 && inst->fx_count > 1) {
-                            pinfo = find_param_info(inst->fx_params[1], inst->fx_param_counts[1], param);
-                        } else if (strcmp(target, "fx3") == 0 && inst->fx_count > 2) {
-                            pinfo = find_param_info(inst->fx_params[2], inst->fx_param_counts[2], param);
-                        } else if (strcmp(target, "midi_fx1") == 0 && inst->midi_fx_count > 0) {
-                            pinfo = find_param_info(inst->midi_fx_params[0], inst->midi_fx_param_counts[0], param);
-                        } else if (strcmp(target, "midi_fx2") == 0 && inst->midi_fx_count > 1) {
-                            pinfo = find_param_info(inst->midi_fx_params[1], inst->midi_fx_param_counts[1], param);
-                        }
-
-                        if (!pinfo) continue;  /* Skip if param not found */
+                        chain_param_info_t *pinfo = knob_find_param(inst, target, param);
+                        if (!pinfo) continue;
 
                         /* Calculate acceleration based on time between events */
                         uint64_t now = get_time_ms();
@@ -7765,25 +7790,7 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                             snprintf(val_str, sizeof(val_str), "%.3f", new_val);
                         }
 
-                        if (strcmp(target, "synth") == 0) {
-                            if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->set_param) {
-                                inst->synth_plugin_v2->set_param(inst->synth_instance, param, val_str);
-                            } else if (inst->synth_plugin && inst->synth_plugin->set_param) {
-                                inst->synth_plugin->set_param(param, val_str);
-                            }
-                        } else if (strcmp(target, "fx1") == 0 && inst->fx_count > 0) {
-                            if (inst->fx_is_v2[0] && inst->fx_plugins_v2[0] && inst->fx_instances[0]) {
-                                inst->fx_plugins_v2[0]->set_param(inst->fx_instances[0], param, val_str);
-                            } else if (inst->fx_plugins[0] && inst->fx_plugins[0]->set_param) {
-                                inst->fx_plugins[0]->set_param(param, val_str);
-                            }
-                        } else if (strcmp(target, "fx2") == 0 && inst->fx_count > 1) {
-                            if (inst->fx_is_v2[1] && inst->fx_plugins_v2[1] && inst->fx_instances[1]) {
-                                inst->fx_plugins_v2[1]->set_param(inst->fx_instances[1], param, val_str);
-                            } else if (inst->fx_plugins[1] && inst->fx_plugins[1]->set_param) {
-                                inst->fx_plugins[1]->set_param(param, val_str);
-                            }
-                        }
+                        knob_forward_value(inst, target, param, val_str);
                         inst->dirty = 1;
                         break;
                     }


### PR DESCRIPTION
## Summary

Adds absolute-value control to chain slots' user-assigned knob mappings via CC 102-109, complementing the existing relative encoder control on CC 71-78.

## What this does

Chain slots already respond to CC 71-78 as relative encoder input (hardware Move knobs) for user-assigned knob mappings — the per-chain parameter assignments users configure in the chain editor. This PR adds a parallel absolute path: CC 102-109 map to the same user-assigned knobs 1-8, with the 0-127 MIDI value scaled linearly to the assigned parameter's full range. Same knob mappings, same parameter targets — just a different input encoding.

## Why it's useful

Modules and external MIDI controllers often need to set a chain parameter to a specific value rather than nudge it by a relative delta. Use cases include:
- **Automation playback** — a sequencer module can record and replay knob movements as absolute 0-127 values (dAVEBOx current main branch uses this for its Sch automation lanes)
- **External controllers** — hardware with absolute faders/knobs (not endless encoders) can drive chain parameters directly
- **Preset recall** — a module can snap parameters to known positions without tracking relative state

## What it doesn't change

- **CC 71-78 (hardware knobs)** are untouched — same relative encoding, same acceleration, same rounding
- **Knob assignment UI** (chain editor, web UI) is unchanged — users still assign knobs to parameters the same way. This only adds a new input path to control those assignments.
- **Existing modules** see no difference — CC 102-109 were previously unhandled and passed through to the synth; now they're intercepted when a knob mapping exists
- **State/persistence** — no format changes

## Potential interference

- **CC 102-109 are consumed by the chain plugin when a user-assigned knob mapping exists for the corresponding knob.** If a synth module happened to use CC 102-109 for its own parameters, those CCs would no longer reach it on mapped knobs. CC 102-119 are unassigned in the MIDI spec, so this is unlikely in practice. Unmapped knobs pass CC 102-109 through to the synth unchanged.
- **Future knob mapping features** that expand beyond 8 knobs would need to extend the CC range (e.g., CC 110+ for knobs 9+). The constants `KNOB_ABS_CC_START` / `KNOB_ABS_CC_END` make this straightforward.

## Implementation

- `KNOB_ABS_CC_START` (102) / `KNOB_ABS_CC_END` (109) constants
- CC 102-109 handler in `v2_on_midi` — scales 0-127 to param min/max, rounds to nearest for int/enum types
- `knob_find_param` / `knob_forward_value` helpers extracted from the existing relative handler to deduplicate target dispatch (~79 lines removed, 86 added, net +7)

## Testing

Tested with dAVEBOx (Schwung tool module) on device:
- Automation playback of float params (filter cutoff sweep) — smooth, same-buffer delivery
- Automation of int/enum params (oscillator type, on/off toggle) — correct discrete stepping
- Hardware knob turns (CC 71-78 relative) — unchanged behavior, no regression
- Multiple Sch lanes active simultaneously — no coalescing or interference