### PR TITLE
Add Libpo32 drum synthesizer to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -859,6 +859,17 @@
       "min_host_version": "0.9.0"
     },
     {
+      "id": "po32-drum",
+      "name": "Libpo32",
+      "description": "16-voice drum synthesizer based on the libpo32/Tonic engine, with GM drum layout, three bundled kits, per-voice noise filter and envelope controls, and role-aware randomizer",
+      "author": "mestela",
+      "component_type": "sound_generator",
+      "github_repo": "mestela/schwung-libpo32",
+      "default_branch": "main",
+      "asset_name": "po32-drum-module.tar.gz",
+      "min_host_version": "0.9.13"
+    },
+    {
       "id": "signal",
       "name": "Signal",
       "description": "Polymetric microsound rhythm generator with breakbeat engine & Scene A/B morph",


### PR DESCRIPTION
Adds **Libpo32** to the module catalog — a 16-voice drum synthesizer based on the libpo32/Tonic engine (Teenage Engineering / Sonic Charge).

**Repo:** https://github.com/mestela/schwung-libpo32  
**Latest release:** https://github.com/mestela/schwung-libpo32/releases/tag/v1.0.5

**Highlights:**
- 16 voices mapped to the GM drum layout (Kick, Snare, Closed HH, etc.)
- Per-voice: Wave, Pitch, Decay, Mod, Noise mix, Dist, Level, Noise Filter (LP/BP/HP), Noise Envelope (Exp/Lin/Clap)
- Role-aware randomizer — each pad stays true to its sound type
- Three bundled kits: tonic, tape, acid
- Full state save/restore with Schwung sets

Setting `min_host_version` to `0.9.13` as that's what it was developed and tested against.