### PR TITLE
fix(host): fix memory ordering problem causing prev value read after setting it

### DIFF
--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -1721,7 +1721,13 @@ int shadow_param_publish_response(uint32_t req_id) {
     }
 
     param->response_id = req_id;
-    param->response_ready = 1;
+    /* Release-store: ensure prior writes to value / error / result_len /
+     * response_id are globally visible BEFORE the reader observes
+     * response_ready = 1. Plain volatile store is not enough — on
+     * weakly-ordered ARMv8 the per-CPU store buffer is free to commit
+     * the flag write ahead of the field writes, and the reader's poll
+     * would then see response_ready = 1 with stale fields. */
+    __atomic_store_n(&param->response_ready, 1, __ATOMIC_RELEASE);
     param->request_type = 0;
     return 1;
 }

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -3686,8 +3686,11 @@ static int shim_handle_param_special(uint8_t req_type, uint32_t req_id) {
             shadow_param->error = 0;
             shadow_param->result_len = 0;
         }
-        shadow_param->response_ready = 1;
         shadow_param->response_id = shadow_param->request_id;
+        /* Release-store the flag AFTER the fields (incl. response_id), pairing
+         * with the reader's acquire-load. Matches shadow_param_publish_response;
+         * a plain store lets ARMv8 commit the flag ahead of the fields. */
+        __atomic_store_n(&shadow_param->response_ready, 1, __ATOMIC_RELEASE);
         return 1;
     }
 
@@ -3697,8 +3700,11 @@ static int shim_handle_param_special(uint8_t req_type, uint32_t req_id) {
             shadow_param->error = 0;
             shadow_param->result_len = 0;
         }
-        shadow_param->response_ready = 1;
         shadow_param->response_id = shadow_param->request_id;
+        /* Release-store the flag AFTER the fields (incl. response_id), pairing
+         * with the reader's acquire-load. Matches shadow_param_publish_response;
+         * a plain store lets ARMv8 commit the flag ahead of the fields. */
+        __atomic_store_n(&shadow_param->response_ready, 1, __ATOMIC_RELEASE);
         return 1;
     }
 
@@ -3718,8 +3724,11 @@ static int shim_handle_param_special(uint8_t req_type, uint32_t req_id) {
             shadow_param->error = 0;
             shadow_param->result_len = 0;
         }
-        shadow_param->response_ready = 1;
         shadow_param->response_id = shadow_param->request_id;
+        /* Release-store the flag AFTER the fields (incl. response_id), pairing
+         * with the reader's acquire-load. Matches shadow_param_publish_response;
+         * a plain store lets ARMv8 commit the flag ahead of the fields. */
+        __atomic_store_n(&shadow_param->response_ready, 1, __ATOMIC_RELEASE);
         return 1;
     }
 

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -594,7 +594,14 @@ static int shadow_param_wait_idle(int timeout_ms) {
 static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
     int timeout = shadow_param_timeout_to_polls(timeout_ms);
     while (timeout > 0) {
-        if (shadow_param->response_ready && shadow_param->response_id == req_id) {
+        /* Acquire-load pairs with the writer's release-store of response_ready
+         * (shadow_param_publish_response + the shim sites). It guarantees the
+         * response fields (response_id, error, value) written before the flag
+         * are visible once we observe response_ready == 1. A plain volatile
+         * load is NOT an acquire on weakly-ordered ARMv8, so without this the
+         * reader could match the flag yet read stale fields. */
+        if (__atomic_load_n(&shadow_param->response_ready, __ATOMIC_ACQUIRE)
+            && shadow_param->response_id == req_id) {
             return shadow_param->error ? -1 : 1;
         }
         usleep(SHADOW_PARAM_POLL_US);


### PR DESCRIPTION
## What happens

SET_PARAM can occasionally read back the
previous value (or an empty string) right after a successful set —
even though the set returned without error.

In normal interactive use this is rare, but it happens.

## Why

The chain / master-FX param protocol uses a shared-memory mailbox
`/dev/shm/schwung-param`. The publisher writes the response
fields and then flips a "ready" flag; the reader polls the flag
and, once it's set, reads the fields.

On Move's CM4 / Cortex-A72, the CPU is allowed to commit
those writes to shared memory in a different order than the source
code wrote them. In particular, `ready = 1` can become visible to
the reader **before** the preceding writes to `value` / `error`
have flushed out of the per-CPU store buffer. The reader sees the
flag, reads the fields, and gets stale data.
`volatile` on the field is not enough — it only constrains the
compiler. The CPU's store buffer is still free to reorder.
ARMv8 is weakly ordered and explicitly requires a release barrier here.