### PR TITLE
Add OTTx audio FX module to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -91,6 +91,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "ottx",
+      "name": "OTTx",
+      "description": "3-band multiband upward+downward compressor (vitOTTx port)",
+      "author": "Matt Tytel (Vital DSP) · Yegor Suslin (vitOTT) · port: legsmechanical",
+      "component_type": "audio_fx",
+      "github_repo": "legsmechanical/schwung-ottx",
+      "default_branch": "main",
+      "asset_name": "ottx-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
       "id": "midiverb",
       "name": "Midiverb",
       "description": "Alesis Midiverb / Midifex / Midiverb II emulator (lo-fi 23.4 kHz reverb)",


### PR DESCRIPTION
Adds **OTTx** to the Module Store catalog — a 3-band multiband upward+downward compressor (the "OTT" sound).

- Faithful scalar-C port of [vitOTTx](https://github.com/Sakhnovkrg/vitOTTx) (Vital's OTT DSP, GPLv3)
- `component_type: audio_fx`, works as an insert or Master/Send FX
- Distributed from **[legsmechanical/schwung-ottx](https://github.com/legsmechanical/schwung-ottx)**, released as [v0.1.0](https://github.com/legsmechanical/schwung-ottx/releases/tag/v0.1.0) (`ottx-module.tar.gz`, aarch64)
- `min_host_version: 0.3.0`
- Implements `get_param("ui_hierarchy")` + `get_param("chain_params")`, so labels/ranges work on the FX bus
- Device-tested on Ableton Move

Single-entry catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)