### PR TITLE
Add optional realtime-safe OpenTelemetry span tracing to the shim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ ssh ableton@move.local "tail -f /data/UserData/schwung/debug.log"
 
 JS: `console.log()` (auto-routed) or import `shared/logger.mjs`. C: `LOG_DEBUG("source", "msg")` from `host/unified_log.h`. See `docs/LOGGING.md`.
 
+**OTLP span tracing** (perf profiling, off by default): `touch /data/UserData/schwung/otlp_trace_on` makes the shim emit realtime-safe spans (`spi.pre`/`spi.post` roots + `param.serve`, `shadow.mix_audio`, `midi.process` children) as OTLP/JSONL to `/data/UserData/schwung/traces/` for replay into Tempo/Jaeger. `rm` the file to stop. Zero hot-path cost when off. See `docs/tracing.md`.
+
 ## Device Constraints
 
 **Never write to `/tmp` on the Move device.** Root FS (`/`) is ~463MB and usually 100% full; `/tmp` lives there. **Always** use `/data/UserData/` (~49GB free) for logs, recordings, temp files, everything. The unified logger already writes to `/data/UserData/schwung/debug.log`.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -65,14 +65,17 @@ JS modules (overtake/chain, e.g. ion) add their own spans under `js.tick` — se
 
 `TRACE_SCOPE("name")` (or manual `TRACE_BEGIN`/`TRACE_END`) opens a span. When
 tracing is off it is a single atomic-load + branch; when on it stamps
-`CLOCK_MONOTONIC_RAW` and pushes a fixed 48-byte record into a lock-free ring.
+`CLOCK_MONOTONIC` and pushes a fixed 48-byte record into a lock-free ring.
 The emission path is realtime-safe — usable from the SPI callback (SCHED_FIFO
 90, core 3, ~900 µs budget):
 
 - no allocation (ring, name table, and per-thread span stack are preallocated/fixed);
 - no locks (atomics only);
-- no syscalls except the vDSO clock read;
-- O(1) per begin/end; drop-on-full, never blocks.
+- no syscalls in steady state except the vDSO clock read; the one exception
+  is a single `gettid()` per thread on its first traced span (cached
+  thereafter), and only while tracing is enabled;
+- O(1) per begin; end is O(1) for the normal LIFO case (one comparison),
+  O(depth) only when unwinding a mismatched/forgotten end; drop-on-full, never blocks.
 
 **Ring** — one SPSC ring per producer thread (`g_rings[]`, claimed lazily on
 first push and cached in a thread-local). The producer owns `w` (release on
@@ -88,8 +91,11 @@ stores only the id. Static C literals are stored by pointer
 **Parent linkage** — a per-thread span stack. A `begin` at depth 0 mints a new
 `trace_id` (a root); nested `begin`s inherit the trace and parent to the stack
 top. So `spi.pre` is the root of one trace per frame and its phases are
-children — a clean per-frame flamegraph. `end` unwinds to the matching
-`span_id`, so a forgotten `end()` (e.g. from JS) cannot corrupt the stack.
+children — a clean per-frame flamegraph. `end` matches the handle's
+`span_id` against the stack top (the normal LIFO case) and, if they differ,
+unwinds down to the matching span — so a forgotten or out-of-order `end()`
+(e.g. from the JS bridge) re-parents subsequent spans correctly instead of
+corrupting the stack. Spans left open by such a mismatch are dropped.
 
 ### Export (off the hot path)
 
@@ -115,9 +121,11 @@ rings/exporters/files — yet their spans stitch into **one** trace
    (`trace_id` / `parent_span_id`, released before `request_type`); the shim
    emits `param.serve` as that span's child via `schwung_trace_span_explicit`.
 
-The per-process UnixNano stamps line up to <1 ms because `CLOCK_MONOTONIC_RAW`
+The per-process UnixNano stamps line up to <1 ms because `CLOCK_MONOTONIC`
 is system-wide and each process samples the same MONOTONIC↔REALTIME offset at
-init. Tempo/Jaeger merge the two files by `trace_id`.
+init. (`CLOCK_MONOTONIC` rather than `_RAW`: it shares REALTIME's NTP slew, so
+the fixed offset doesn't drift the exported UnixNano over a long session.)
+Tempo/Jaeger merge the two files by `trace_id`.
 
 ## Adding spans
 
@@ -168,6 +176,8 @@ only the file exporter is wired today (replay from file, or `curl` it yourself).
 
 - 256-entry name table per process (shared by C + JS spans).
 - 8 producer rings per process; 32 levels of span nesting per thread.
+  More than 8 producer threads → the extras' spans drop, logged once by the
+  exporter (`thread-ring table exhausted`).
 - 16 JS spans open simultaneously per tick (`host_trace_begin` returns 0 past
   that, logged once).
 - Trace files: 8 MB rotation, newest 16 per service retained.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,173 @@
+# Schwung tracing
+
+Realtime-safe span tracing for the Schwung shim and the `shadow_ui` process,
+exported as OTLP/JSON for Grafana Tempo / Jaeger. It answers "where does the
+time go" perf questions — a slow JS tick, an over-long SPI frame — with
+parent/child spans and cross-process correlation, instead of ad-hoc
+`Date.now()` / `clock_gettime` instrumentation.
+
+**Off by default, zero hot-path cost when off**, and enabled live on a shipped
+device via a touch-file (no rebuild, no restart). Source:
+`src/host/schwung_trace.{c,h}`.
+
+> **Scope — part 1 of 2.** This PR adds the **shim** tracing core (the ring,
+> exporter, OTLP/JSON writer, macros, and the shim's own spans). The
+> `shadow_ui` / JavaScript-bridge / cross-process pieces described below
+> (marked **⏳ Part 2**) are implemented and validated on a fork but are **not
+> in this PR** — they follow as a second PR if this one is approved, to keep
+> the review focused. In this PR the shim writes a single
+> `schwung-<ts>.otlp.jsonl` and `param.serve` is a plain child of `spi.pre`.
+
+## Using it (on device)
+
+```bash
+# enable
+ssh ableton@move.local "touch /data/UserData/schwung/otlp_trace_on"
+# ... reproduce the scenario you want to profile ...
+# disable
+ssh ableton@move.local "rm /data/UserData/schwung/otlp_trace_on"
+# pull the traces
+scp 'ableton@move.local:/data/UserData/schwung/traces/*.otlp.jsonl' .
+```
+
+The touch-file gates every process (polled within ~5 s, so toggling is live).
+Output lands in `/data/UserData/schwung/traces/`, one file per service:
+
+- `schwung-shim-<ts>.otlp.jsonl` — the LD_PRELOAD shim (SPI callback path)
+- `schwung-shadow-ui-<ts>.otlp.jsonl` — the QuickJS UI process
+
+Each line is one OTLP `ExportTraceServiceRequest` (JSONL) — replay it to a
+collector or import directly into Tempo/Jaeger.
+
+## What gets traced
+
+**Shim** (`schwung-shim`), per SPI frame:
+
+- `spi.pre` / `spi.post` — roots (one trace each per frame); the two halves of
+  the SPI callback around the hardware ioctl.
+- `shadow.mix_audio`, `midi.process` — children of `spi.pre`.
+- `param.serve` — the shim servicing a `shadow_param` request (a child of
+  `spi.pre`). **⏳ Part 2** re-parents it cross-process to the JS `param.get`
+  span (see [Cross-process correlation](#cross-process-correlation)).
+
+**shadow_ui** (`schwung-shadow-ui`), per UI tick — **⏳ Part 2** (not in this PR):
+
+- `js.tick` — root around the JS `tick()` call.
+- `param.get` — child around the synchronous `shadow_get_param` round-trip (the
+  JS side busy-waits for the shim to service it once per SPI frame).
+
+JS modules (overtake/chain, e.g. ion) add their own spans under `js.tick` — see
+[Adding spans](#adding-spans).
+
+## How it works
+
+### Emission (hot path, RT-safe)
+
+`TRACE_SCOPE("name")` (or manual `TRACE_BEGIN`/`TRACE_END`) opens a span. When
+tracing is off it is a single atomic-load + branch; when on it stamps
+`CLOCK_MONOTONIC_RAW` and pushes a fixed 48-byte record into a lock-free ring.
+The emission path is realtime-safe — usable from the SPI callback (SCHED_FIFO
+90, core 3, ~900 µs budget):
+
+- no allocation (ring, name table, and per-thread span stack are preallocated/fixed);
+- no locks (atomics only);
+- no syscalls except the vDSO clock read;
+- O(1) per begin/end; drop-on-full, never blocks.
+
+**Ring** — one SPSC ring per producer thread (`g_rings[]`, claimed lazily on
+first push and cached in a thread-local). The producer owns `w` (release on
+publish), the exporter owns `r`; single-producer-per-ring keeps it tear-free
+via `w` release/acquire with no locks. On overrun the oldest spans are dropped
+and counted.
+
+**Name interning** — span names become an int once per call site; the hot path
+stores only the id. Static C literals are stored by pointer
+(`schwung_trace_intern`); JS-supplied names are copied + deduped
+(`schwung_trace_intern_copy`, capped at 255 chars).
+
+**Parent linkage** — a per-thread span stack. A `begin` at depth 0 mints a new
+`trace_id` (a root); nested `begin`s inherit the trace and parent to the stack
+top. So `spi.pre` is the root of one trace per frame and its phases are
+children — a clean per-frame flamegraph. `end` unwinds to the matching
+`span_id`, so a forgotten `end()` (e.g. from JS) cannot corrupt the stack.
+
+### Export (off the hot path)
+
+A dedicated exporter thread (SCHED_OTHER, pinned to cores 0–2, never core 3)
+drains the rings, builds OTLP/JSON, and appends a JSONL line per batch to the
+current trace file. It starts lazily when the touch-file appears. Files rotate
+at 8 MB and are pruned to the newest 16 per service (≤128 MB/service), so a
+left-on session cannot fill the disk.
+
+### Cross-process correlation — ⏳ Part 2 (not in this PR)
+
+The shim and `shadow_ui` are separate processes with separate
+rings/exporters/files — yet their spans stitch into **one** trace
+(`js.tick → param.get → param.serve`). Two mechanisms:
+
+1. **Globally-unique ids.** Span/trace ids are `per-process-random-base +
+   counter` (a `splitmix64` of pid + clocks, seeded at init). Without the
+   per-process base the two processes' counters would collide — two spans
+   sharing an id in one trace, or two unrelated traces sharing a `trace_id` and
+   getting merged.
+2. **Context propagation through IPC.** `shadow_ui` stamps the open `param.get`
+   span's `trace_id`/`span_id` into the `shadow_param_t` request
+   (`trace_id` / `parent_span_id`, released before `request_type`); the shim
+   emits `param.serve` as that span's child via `schwung_trace_span_explicit`.
+
+The per-process UnixNano stamps line up to <1 ms because `CLOCK_MONOTONIC_RAW`
+is system-wide and each process samples the same MONOTONIC↔REALTIME offset at
+init. Tempo/Jaeger merge the two files by `trace_id`.
+
+## Adding spans
+
+**C** (anywhere, including the RT path):
+
+```c
+#include "host/schwung_trace.h"
+
+void f(void) {
+    TRACE_SCOPE("my.phase");                 // closes at end of the C block
+    ...
+    { TRACE_SCOPE("my.subphase"); work(); }  // nested child
+}
+```
+
+`TRACE_BEGIN("name")` / `TRACE_END(h)` cover spans that don't match a lexical
+block. Build with `-DSCHWUNG_TRACE_DISABLED` to compile every macro to zero.
+
+**JavaScript** (in a `shadow_ui` module — overtake/chain) — **⏳ Part 2** (not in this PR):
+
+```js
+const h = host_trace_begin("ion.computeFrame");  // 0 when tracing is off
+...
+host_trace_end(h);
+```
+
+JS spans nest under the C `js.tick` root for that tick. Use a fixed set of
+names — each distinct name takes a table slot (256 per process).
+
+## OTLP/JSON output
+
+One `ExportTraceServiceRequest` per drained batch, newline-delimited:
+
+```json
+{"resourceSpans":[{"resource":{"attributes":[
+  {"key":"service.name","value":{"stringValue":"schwung-shim"}}]},
+  "scopeSpans":[{"scope":{"name":"shim"},"spans":[
+    {"traceId":"<32hex>","spanId":"<16hex>","parentSpanId":"<16hex>",
+     "name":"spi.pre","kind":1,
+     "startTimeUnixNano":"...","endTimeUnixNano":"..."}]}]}]}
+```
+
+Span times are converted to UnixNano using the MONOTONIC↔REALTIME offset
+sampled at exporter start. The same bytes are what an HTTP OTLP push would POST;
+only the file exporter is wired today (replay from file, or `curl` it yourself).
+
+## Limits
+
+- 256-entry name table per process (shared by C + JS spans).
+- 8 producer rings per process; 32 levels of span nesting per thread.
+- 16 JS spans open simultaneously per tick (`host_trace_begin` returns 0 past
+  that, logged once).
+- Trace files: 8 MB rotation, newest 16 per service retained.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -234,7 +234,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_resample.c src/host/shadow_overlay.c src/host/shadow_pin_scanner.c \
     src/host/shadow_led_queue.c src/host/shadow_state.c \
     src/host/shadow_midi.c src/host/unified_log.c src/host/shim_worker.c \
-    src/host/shadow_shm_util.c \
+    src/host/shadow_shm_util.c src/host/schwung_trace.c \
     $SHIM_TTS_SRC \
     src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
     src/host/shim_worker.h \
@@ -243,6 +243,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_resample.h src/host/shadow_overlay.h src/host/shadow_pin_scanner.h \
     src/host/shadow_led_queue.h src/host/shadow_state.h \
     src/host/plugin_api_v1.h src/host/unified_log.h src/host/tts_engine.h \
+    src/host/schwung_trace.h \
     src/host/link_audio.h src/host/shadow_shm_util.h; then
     echo "Building shim..."
     "${CROSS_PREFIX}gcc" -g3 -shared -fPIC \
@@ -265,6 +266,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/unified_log.c \
         src/host/shim_worker.c \
         src/host/shadow_shm_util.c \
+        src/host/schwung_trace.c \
         $SHIM_TTS_SRC \
         $SHIM_DEFINES \
         $SHIM_INCLUDES \

--- a/src/host/schwung_trace.c
+++ b/src/host/schwung_trace.c
@@ -1,0 +1,389 @@
+/*
+ * schwung_trace.c — realtime-safe span tracing, OTLP/JSON file exporter.
+ * See schwung_trace.h and docs/tracing.md.
+ *
+ * Emission (hot path, incl. SPI core 3): per-thread SPSC ring, no alloc /
+ * lock / I/O. Export: one SCHED_OTHER thread drains every thread's ring,
+ * builds OTLP/JSON, appends a JSONL line to a rotating file. OFF by
+ * default; enabled by the touch-file (see schwung_trace_poll_enable).
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE        /* pthread affinity + CPU_SET (RT: keep core 3 free) */
+#endif
+#include "schwung_trace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sched.h>
+#include <dirent.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "unified_log.h"   /* exporter thread is non-RT → logging is safe here */
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+static inline uint32_t os_tid(void) { return (uint32_t)syscall(SYS_gettid); }
+#else
+static inline uint32_t os_tid(void) { return (uint32_t)(uintptr_t)pthread_self(); }
+#endif
+
+/* ---- Tunables ------------------------------------------------------- */
+#define TRACE_MAX_THREADS  8
+#define TRACE_RING_CAP     4096            /* per thread; power of two */
+#define TRACE_RING_MASK    (TRACE_RING_CAP - 1)
+#define TRACE_MAX_DEPTH    32              /* per-thread span nesting */
+#define TRACE_MAX_NAMES    256
+#define TRACE_NAME_LIT     1               /* names are static literals */
+
+#define TRACE_TOUCH_FILE   "/data/UserData/schwung/otlp_trace_on"
+#define TRACE_DIR          "/data/UserData/schwung/traces"
+#define TRACE_FILE_FMT     TRACE_DIR "/schwung-%s.otlp.jsonl"
+#define TRACE_ROTATE_BYTES (8 * 1024 * 1024)
+#define TRACE_MAX_FILES    16              /* keep at most this many trace files */
+#define TRACE_EXPORT_SLEEP_US 50000        /* 50 ms drain cadence */
+
+/* ---- Span record (internal; .h keeps trace_handle_t opaque) --------- */
+typedef struct {
+    uint32_t name_id;
+    uint32_t tid;
+    uint64_t t0_ns, t1_ns;
+    uint64_t trace_id;
+    uint64_t span_id;
+    uint64_t parent_id;
+} trace_rec_t;
+
+/* ---- Per-thread SPSC ring ------------------------------------------- */
+typedef struct {
+    _Atomic uint64_t w;                    /* producer-only writes (RELEASE) */
+    _Atomic uint64_t r;                    /* exporter-only writes; producer reads */
+    _Atomic uint64_t dropped;
+    trace_rec_t      buf[TRACE_RING_CAP];
+} trace_ring_t;
+
+static trace_ring_t   g_rings[TRACE_MAX_THREADS];
+static _Atomic int    g_ring_count = 0;
+static __thread trace_ring_t *t_ring = NULL;   /* this thread's claimed ring */
+
+/* ---- Per-thread span stack (parent linkage + trace id) -------------- */
+static __thread trace_rec_t t_stack[TRACE_MAX_DEPTH];
+static __thread int          t_depth   = 0;
+static __thread uint64_t      t_traceid = 0;
+static __thread uint32_t      t_tid     = 0;
+
+/* ---- Global state --------------------------------------------------- */
+_Atomic int schwung_trace_on = 0;
+
+static _Atomic(const char *) g_names[TRACE_MAX_NAMES];
+static _Atomic uint32_t g_name_count = 0;
+
+static _Atomic uint64_t g_span_seq  = 0;
+static _Atomic uint64_t g_trace_seq = 0;
+
+static char        g_service[64] = "schwung";
+static int         g_inited = 0;        /* set in constructor before any RT thread */
+static pthread_t   g_exporter;
+static _Atomic int g_exporter_running = 0;
+static _Atomic int g_exporter_stop = 0;
+
+/* MONOTONIC_RAW ↔ REALTIME offset, sampled at init (ns). */
+static uint64_t g_mono0_ns = 0;
+static uint64_t g_real0_ns = 0;
+
+/* ---- Clock ---------------------------------------------------------- */
+static inline uint64_t mono_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+static inline uint64_t real_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+/* ---- Name interning: store the literal pointer, lock-free ----------- */
+uint32_t schwung_trace_intern(const char *name) {
+    uint32_t idx = atomic_fetch_add_explicit(&g_name_count, 1, memory_order_relaxed);
+    if (idx >= TRACE_MAX_NAMES) return 1;          /* table full → bucket 1 */
+    /* Release-store the literal so the exporter, which acquire-loads the slot,
+     * never sees the id published with a stale/NULL pointer (ARM64 reorders). */
+    atomic_store_explicit(&g_names[idx], name, memory_order_release);
+    return idx + 1;                                /* ids are 1-based */
+}
+
+/* ---- Ring push (hot path; SPSC, this thread only) ------------------- */
+static inline void ring_push(const trace_rec_t *rec) {
+    trace_ring_t *ring = t_ring;
+    if (!ring) {
+        int i = atomic_fetch_add_explicit(&g_ring_count, 1, memory_order_relaxed);
+        if (i >= TRACE_MAX_THREADS) return;        /* too many threads → drop */
+        ring = t_ring = &g_rings[i];
+    }
+    uint64_t w = atomic_load_explicit(&ring->w, memory_order_relaxed);
+    uint64_t r = atomic_load_explicit(&ring->r, memory_order_relaxed);  /* stale ok, not torn */
+    if (w - r >= TRACE_RING_CAP) {                 /* full → drop, count it */
+        atomic_fetch_add_explicit(&ring->dropped, 1, memory_order_relaxed);
+        return;
+    }
+    ring->buf[w & TRACE_RING_MASK] = *rec;
+    atomic_store_explicit(&ring->w, w + 1, memory_order_release);
+}
+
+/* ---- begin / end ---------------------------------------------------- */
+trace_handle_t schwung_trace_begin(uint32_t name_id) {
+    if (!atomic_load_explicit(&schwung_trace_on, memory_order_relaxed))
+        return (trace_handle_t){0};
+    if (t_depth >= TRACE_MAX_DEPTH || t_depth < 0)
+        return (trace_handle_t){0};                /* nesting overflow → skip */
+    uint64_t sid = atomic_fetch_add_explicit(&g_span_seq, 1, memory_order_relaxed) + 1;
+    if (t_depth == 0)
+        t_traceid = atomic_fetch_add_explicit(&g_trace_seq, 1, memory_order_relaxed) + 1;
+    trace_rec_t *r = &t_stack[t_depth];
+    r->name_id   = name_id;
+    r->span_id   = sid;
+    r->parent_id = (t_depth > 0) ? t_stack[t_depth - 1].span_id : 0;
+    r->trace_id  = t_traceid;
+    r->t0_ns     = mono_ns();
+    t_depth++;
+    return (trace_handle_t){ sid };
+}
+
+void schwung_trace_end(trace_handle_t *h) {
+    if (!h || h->span_id == 0) return;             /* was off at begin */
+    if (t_depth <= 0) return;
+    trace_rec_t *r = &t_stack[--t_depth];
+    r->t1_ns = mono_ns();
+    if (t_tid == 0) t_tid = os_tid();
+    r->tid   = t_tid;
+    ring_push(r);
+}
+
+void schwung_trace_span_explicit(uint32_t name_id,
+                                 uint64_t t0_ns, uint64_t t1_ns,
+                                 uint64_t trace_id, uint64_t parent_id) {
+    if (!atomic_load_explicit(&schwung_trace_on, memory_order_relaxed)) return;
+    if (t_tid == 0) t_tid = os_tid();
+    trace_rec_t rec = {
+        .name_id = name_id, .tid = t_tid,
+        .t0_ns = t0_ns, .t1_ns = t1_ns,
+        .trace_id = trace_id ? trace_id
+                  : (atomic_fetch_add_explicit(&g_trace_seq, 1, memory_order_relaxed) + 1),
+        .span_id  = atomic_fetch_add_explicit(&g_span_seq, 1, memory_order_relaxed) + 1,
+        .parent_id = parent_id,
+    };
+    ring_push(&rec);
+}
+
+/* ---- Exporter: drain rings → OTLP/JSON → rotating JSONL file -------- */
+static void hex16(uint64_t v, char *out) {           /* 16 hex chars */
+    static const char *H = "0123456789abcdef";
+    for (int i = 15; i >= 0; i--) { out[i] = H[v & 0xF]; v >>= 4; }
+}
+static uint64_t to_unix_ns(uint64_t mono) {
+    /* real0 + (mono - mono0); guard mono < mono0 (shouldn't happen). */
+    return (mono >= g_mono0_ns) ? g_real0_ns + (mono - g_mono0_ns)
+                                : g_real0_ns;
+}
+
+static FILE  *g_out = NULL;
+static long   g_out_bytes = 0;
+
+/* Keep at most TRACE_MAX_FILES trace files: unlink the oldest before opening a
+ * new one. Filenames are schwung-YYYYMMDD-HHMMSS.otlp.jsonl, so lexicographic
+ * order == chronological order. Bounds disk use even if the touch-file is left
+ * on for days (/data is ~49 GB but not infinite). */
+static void prune_old_files(void) {
+    DIR *d = opendir(TRACE_DIR);
+    if (!d) return;
+    char names[64][48];
+    int count = 0;
+    struct dirent *de;
+    while ((de = readdir(d)) != NULL && count < 64) {
+        if (strncmp(de->d_name, "schwung-", 8) == 0 &&
+            strstr(de->d_name, ".otlp.jsonl") != NULL) {
+            snprintf(names[count], sizeof(names[count]), "%s", de->d_name);
+            count++;
+        }
+    }
+    closedir(d);
+    /* insertion sort ascending (oldest first) */
+    for (int i = 1; i < count; i++) {
+        char key[48];
+        snprintf(key, sizeof(key), "%s", names[i]);
+        int j = i - 1;
+        while (j >= 0 && strcmp(names[j], key) > 0) {
+            snprintf(names[j + 1], sizeof(names[j + 1]), "%s", names[j]);
+            j--;
+        }
+        snprintf(names[j + 1], sizeof(names[j + 1]), "%s", key);
+    }
+    int to_delete = count - (TRACE_MAX_FILES - 1);   /* leave room for the new file */
+    for (int i = 0; i < to_delete && i < count; i++) {
+        char p[320];
+        snprintf(p, sizeof(p), "%s/%s", TRACE_DIR, names[i]);
+        unlink(p);
+    }
+}
+
+static void open_outfile(void) {
+    if (mkdir(TRACE_DIR, 0755) != 0 && errno != EEXIST)
+        unified_log("trace", LOG_LEVEL_ERROR, "mkdir %s failed: errno %d", TRACE_DIR, errno);
+    prune_old_files();
+    char path[256], stamp[32];
+    time_t now = time(NULL);
+    struct tm tmv; localtime_r(&now, &tmv);
+    strftime(stamp, sizeof(stamp), "%Y%m%d-%H%M%S", &tmv);
+    snprintf(path, sizeof(path), TRACE_FILE_FMT, stamp);
+    g_out = fopen(path, "w");
+    if (!g_out)
+        unified_log("trace", LOG_LEVEL_ERROR, "fopen %s failed: errno %d", path, errno);
+    g_out_bytes = 0;
+}
+
+/* Build + write one ExportTraceServiceRequest (JSONL) for `spans`. */
+static void write_batch(const trace_rec_t *spans, int n) {
+    if (!g_out || n <= 0) return;
+    char sid[17] = {0}, pid[17] = {0};
+    fprintf(g_out,
+        "{\"resourceSpans\":[{\"resource\":{\"attributes\":["
+        "{\"key\":\"service.name\",\"value\":{\"stringValue\":\"%s\"}}]},"
+        "\"scopeSpans\":[{\"scope\":{\"name\":\"shim\"},\"spans\":[",
+        g_service);
+    for (int i = 0; i < n; i++) {
+        const trace_rec_t *s = &spans[i];
+        uint32_t nc = atomic_load_explicit(&g_name_count, memory_order_acquire);
+        const char *nm_p = (s->name_id >= 1 && s->name_id <= nc)
+            ? atomic_load_explicit(&g_names[s->name_id - 1], memory_order_acquire) : NULL;
+        const char *nm = nm_p ? nm_p : "?";
+        /* 128-bit OTLP traceId: high 64 bits zero, low 64 = our trace_id. */
+        char traceid32[33];
+        memset(traceid32, '0', 16);
+        hex16(s->trace_id, traceid32 + 16);
+        traceid32[32] = 0;
+        hex16(s->span_id, sid);
+        hex16(s->parent_id, pid);
+        fprintf(g_out,
+            "%s{\"traceId\":\"%s\",\"spanId\":\"%s\",%s%s%s"
+            "\"name\":\"%s\",\"kind\":1,"
+            "\"startTimeUnixNano\":\"%llu\",\"endTimeUnixNano\":\"%llu\","
+            "\"attributes\":[{\"key\":\"tid\",\"value\":{\"intValue\":\"%u\"}}]}",
+            (i ? "," : ""), traceid32, sid,
+            (s->parent_id ? "\"parentSpanId\":\"" : ""),
+            (s->parent_id ? pid : ""),
+            (s->parent_id ? "\"," : ""),
+            nm,
+            (unsigned long long)to_unix_ns(s->t0_ns),
+            (unsigned long long)to_unix_ns(s->t1_ns),
+            s->tid);
+    }
+    fputs("]}]}]}\n", g_out);
+    fflush(g_out);
+    long pos = ftell(g_out);              /* true file size incl. JSON envelope */
+    if (pos >= 0) g_out_bytes = pos;
+    if (g_out_bytes >= TRACE_ROTATE_BYTES) {
+        fclose(g_out); g_out = NULL; open_outfile();
+    }
+}
+
+static void *exporter_main(void *arg) {
+    (void)arg;
+    open_outfile();
+    /* small staging buffer drained from the rings each pass */
+    static trace_rec_t batch[1024];
+    while (!atomic_load_explicit(&g_exporter_stop, memory_order_relaxed)) {
+        int n = 0;
+        int rc = atomic_load_explicit(&g_ring_count, memory_order_relaxed);
+        if (rc > TRACE_MAX_THREADS) rc = TRACE_MAX_THREADS;
+        for (int i = 0; i < rc; i++) {
+            trace_ring_t *ring = &g_rings[i];
+            uint64_t w = atomic_load_explicit(&ring->w, memory_order_acquire);
+            uint64_t r = atomic_load_explicit(&ring->r, memory_order_relaxed);
+            if (w - r > TRACE_RING_CAP) {            /* producer lapped us */
+                uint64_t skipped = (w - TRACE_RING_CAP) - r;
+                atomic_fetch_add_explicit(&ring->dropped, skipped, memory_order_relaxed);
+                r = w - TRACE_RING_CAP;             /* skip the overwritten span(s) */
+            }
+            while (r < w && n < (int)(sizeof(batch)/sizeof(batch[0]))) {
+                batch[n++] = ring->buf[r & TRACE_RING_MASK];
+                r++;
+            }
+            atomic_store_explicit(&ring->r, r, memory_order_relaxed);
+        }
+        if (n > 0) write_batch(batch, n);
+        /* Always sleep — cap exporter I/O to one burst per cadence even when
+         * the ring keeps producing (otherwise this spins on cores 0-2). */
+        usleep(TRACE_EXPORT_SLEEP_US);
+    }
+    if (g_out) { fclose(g_out); g_out = NULL; }
+    return NULL;
+}
+
+/* ---- Lifecycle ------------------------------------------------------ */
+void schwung_trace_init(const char *service_name) {
+    if (g_inited) return;
+    if (service_name && *service_name) {
+        snprintf(g_service, sizeof(g_service), "%s", service_name);
+    }
+    g_mono0_ns = mono_ns();
+    g_real0_ns = real_ns();
+    g_inited = 1;
+    schwung_trace_poll_enable();
+}
+
+static int touch_file_present(void) {
+    struct stat st;
+    return stat(TRACE_TOUCH_FILE, &st) == 0;
+}
+
+/* Spawn the exporter with an EXPLICIT non-RT schedule. The shim runs inside
+ * MoveOriginal's SCHED_FIFO-70 threads, and the poll that triggers this may
+ * itself be on such a thread; the default PTHREAD_INHERIT_SCHED would hand the
+ * exporter FIFO priority and possibly core 3 (the SPI callback's core). Force
+ * SCHED_OTHER and pin to cores 0-2 so it never preempts the RT path. */
+static int start_exporter(void) {
+    pthread_attr_t attr;
+    if (pthread_attr_init(&attr) != 0) return -1;
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    struct sched_param sp = { .sched_priority = 0 };
+    pthread_attr_setschedparam(&attr, &sp);
+    cpu_set_t cpus;
+    CPU_ZERO(&cpus);
+    CPU_SET(0, &cpus); CPU_SET(1, &cpus); CPU_SET(2, &cpus);
+    pthread_attr_setaffinity_np(&attr, sizeof(cpus), &cpus);  /* best-effort */
+    int rc = pthread_create(&g_exporter, &attr, exporter_main, NULL);
+    pthread_attr_destroy(&attr);
+    return rc;
+}
+
+void schwung_trace_poll_enable(void) {
+    if (!g_inited) return;
+    int want = touch_file_present();
+    int have = atomic_load_explicit(&schwung_trace_on, memory_order_relaxed);
+    if (want && !have) {
+        if (!g_exporter_running) {
+            atomic_store_explicit(&g_exporter_stop, 0, memory_order_relaxed);
+            if (start_exporter() == 0)
+                g_exporter_running = 1;
+        }
+        atomic_store_explicit(&schwung_trace_on, 1, memory_order_release);
+    } else if (!want && have) {
+        atomic_store_explicit(&schwung_trace_on, 0, memory_order_release);
+        /* leave the exporter running to flush residual; it idles. */
+    }
+}
+
+void schwung_trace_shutdown(void) {
+    atomic_store_explicit(&schwung_trace_on, 0, memory_order_release);
+    if (g_exporter_running) {
+        atomic_store_explicit(&g_exporter_stop, 1, memory_order_release);
+        pthread_join(g_exporter, NULL);
+        g_exporter_running = 0;
+    }
+}

--- a/src/host/schwung_trace.c
+++ b/src/host/schwung_trace.c
@@ -91,14 +91,19 @@ static pthread_t   g_exporter;
 static _Atomic int g_exporter_running = 0;
 static _Atomic int g_exporter_stop = 0;
 
-/* MONOTONIC_RAW ↔ REALTIME offset, sampled at init (ns). */
+/* MONOTONIC ↔ REALTIME offset, sampled at init (ns). */
 static uint64_t g_mono0_ns = 0;
 static uint64_t g_real0_ns = 0;
 
-/* ---- Clock ---------------------------------------------------------- */
+/* ---- Clock ---------------------------------------------------------- *
+ * CLOCK_MONOTONIC (not _RAW): same vDSO read, no syscall, but it shares
+ * REALTIME's NTP slewing so the fixed MONOTONIC↔REALTIME offset sampled at
+ * init stays accurate over long sessions (RAW is unslewed and would drift
+ * the exported UnixNano). It also matches the clock the rest of the shim
+ * uses for its [spi_timing] boundaries. */
 static inline uint64_t mono_ns(void) {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
 }
 static inline uint64_t real_ns(void) {
@@ -157,10 +162,25 @@ trace_handle_t schwung_trace_begin(uint32_t name_id) {
 void schwung_trace_end(trace_handle_t *h) {
     if (!h || h->span_id == 0) return;             /* was off at begin */
     if (t_depth <= 0) return;
-    trace_rec_t *r = &t_stack[--t_depth];
+    /* Normal LIFO fast path: the span being ended is the stack top — one
+     * comparison, no scan. */
+    int idx = t_depth - 1;
+    if (__builtin_expect(t_stack[idx].span_id != h->span_id, 0)) {
+        /* Out-of-order / forgotten end (e.g. a mis-paired JS-bridge span):
+         * find the matching span deeper in the stack and unwind to it, so
+         * subsequent spans re-parent correctly instead of inheriting a stale
+         * top. Inner spans left open by the mismatch are dropped (they were
+         * never properly ended). Bounded by TRACE_MAX_DEPTH; no syscall/alloc.
+         * Unknown handle (already ended / never pushed) → no-op. */
+        idx--;
+        while (idx >= 0 && t_stack[idx].span_id != h->span_id) idx--;
+        if (idx < 0) return;
+    }
+    trace_rec_t *r = &t_stack[idx];
     r->t1_ns = mono_ns();
     if (t_tid == 0) t_tid = os_tid();
     r->tid   = t_tid;
+    t_depth  = idx;                                /* unwind to / pop the match */
     ring_push(r);
 }
 
@@ -186,7 +206,9 @@ static void hex16(uint64_t v, char *out) {           /* 16 hex chars */
     for (int i = 15; i >= 0; i--) { out[i] = H[v & 0xF]; v >>= 4; }
 }
 static uint64_t to_unix_ns(uint64_t mono) {
-    /* real0 + (mono - mono0); guard mono < mono0 (shouldn't happen). */
+    /* real0 + (mono - mono0); guard mono < mono0 (shouldn't happen).
+     * mono0/real0 are sampled together at init; CLOCK_MONOTONIC tracks
+     * REALTIME's slew so this fixed offset doesn't drift. */
     return (mono >= g_mono0_ns) ? g_real0_ns + (mono - g_mono0_ns)
                                 : g_real0_ns;
 }
@@ -294,11 +316,21 @@ static void write_batch(const trace_rec_t *spans, int n) {
 static void *exporter_main(void *arg) {
     (void)arg;
     open_outfile();
+    int overflow_logged = 0;
     /* small staging buffer drained from the rings each pass */
     static trace_rec_t batch[1024];
     while (!atomic_load_explicit(&g_exporter_stop, memory_order_relaxed)) {
         int n = 0;
         int rc = atomic_load_explicit(&g_ring_count, memory_order_relaxed);
+        /* More producer threads than rings → the extras drop silently on the
+         * RT path (can't log there). Surface it once from here (non-RT). */
+        if (rc > TRACE_MAX_THREADS && !overflow_logged) {
+            unified_log("trace", LOG_LEVEL_WARN,
+                "thread-ring table exhausted (%d producers > %d rings); "
+                "spans from extra threads dropped — raise TRACE_MAX_THREADS",
+                rc, TRACE_MAX_THREADS);
+            overflow_logged = 1;
+        }
         if (rc > TRACE_MAX_THREADS) rc = TRACE_MAX_THREADS;
         for (int i = 0; i < rc; i++) {
             trace_ring_t *ring = &g_rings[i];
@@ -333,6 +365,10 @@ void schwung_trace_init(const char *service_name) {
     g_mono0_ns = mono_ns();
     g_real0_ns = real_ns();
     g_inited = 1;
+    /* Flush + join the exporter on normal process exit. No-op when tracing
+     * was never enabled (exporter not running). Best-effort: skipped on
+     * SIGKILL, but then /data is reclaimed by the OS anyway. */
+    atexit(schwung_trace_shutdown);
     schwung_trace_poll_enable();
 }
 

--- a/src/host/schwung_trace.h
+++ b/src/host/schwung_trace.h
@@ -23,9 +23,11 @@
  * -DSCHWUNG_TRACE_DISABLED to compile every macro to absolute zero.
  *
  * REALTIME SAFETY (emission): no alloc, no locks, no I/O. Begin/end only
- * read CLOCK_MONOTONIC_RAW and append a fixed record to a preallocated
- * lock-free ring; full ring drops (never blocks). Export (serialize +
- * file/HTTP) runs on a separate SCHED_OTHER thread, never core 3.
+ * read CLOCK_MONOTONIC (vDSO, no syscall) and append a fixed record to a
+ * preallocated lock-free ring; full ring drops (never blocks). The sole
+ * syscall is one cached gettid() per thread on its first traced span (only
+ * when tracing is enabled); steady state is syscall-free. Export (serialize
+ * + file/HTTP) runs on a separate SCHED_OTHER thread, never core 3.
  */
 #ifndef SCHWUNG_TRACE_H
 #define SCHWUNG_TRACE_H

--- a/src/host/schwung_trace.h
+++ b/src/host/schwung_trace.h
@@ -1,0 +1,118 @@
+/*
+ * schwung_trace.h — realtime-safe span tracing with OTLP export.
+ *
+ * Design + rationale: docs/tracing.md
+ *
+ * One-line instrumentation, no begin/end boilerplate:
+ *
+ *     void shim_post_transfer(...) {
+ *         TRACE_SCOPE("spi.callback");           // root span for this frame
+ *         ...
+ *         { TRACE_SCOPE("spi.mix_audio"); mix_audio(); }   // child span
+ *         ...
+ *     }                                          // span auto-closes here
+ *
+ * For spans that don't match a lexical block:
+ *
+ *     trace_handle_t h = TRACE_BEGIN("param.serve");
+ *     ...
+ *     TRACE_END(h);
+ *
+ * COST WHEN DISABLED: tracing is OFF BY DEFAULT (no touch-file). Begin
+ * is then a single atomic-load + branch; end is a no-op. Build with
+ * -DSCHWUNG_TRACE_DISABLED to compile every macro to absolute zero.
+ *
+ * REALTIME SAFETY (emission): no alloc, no locks, no I/O. Begin/end only
+ * read CLOCK_MONOTONIC_RAW and append a fixed record to a preallocated
+ * lock-free ring; full ring drops (never blocks). Export (serialize +
+ * file/HTTP) runs on a separate SCHED_OTHER thread, never core 3.
+ */
+#ifndef SCHWUNG_TRACE_H
+#define SCHWUNG_TRACE_H
+
+#include <stdint.h>
+#include <stdatomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Returned by begin, consumed by end. Opaque-ish; treat as a token. */
+typedef struct {
+    uint64_t span_id;   /* 0 when tracing was off at begin → end no-ops */
+} trace_handle_t;
+
+/* ---- Lifecycle (call from the owning process, e.g. the shim) -------- *
+ *
+ * init: allocate the ring + name table, record the MONOTONIC↔REALTIME
+ *       offset, and (if the touch-file is present) start the exporter
+ *       thread. Safe to call once at startup.
+ * poll_enable: re-check the touch-file; flips tracing on/off and
+ *       lazily starts/parks the exporter. Call from a slow timer.
+ * shutdown: flush + stop the exporter (best-effort; optional).
+ */
+void schwung_trace_init(const char *service_name);
+void schwung_trace_poll_enable(void);
+void schwung_trace_shutdown(void);
+
+/* Runtime gate. 0 = off (the default). Read by the macros. */
+extern _Atomic int schwung_trace_on;
+
+/* Intern a span-name string literal → stable id (>= 1). Called once per
+ * call site via the macros; not on the hot path after the first hit. */
+uint32_t schwung_trace_intern(const char *name);
+
+/* Hot-path primitives. begin returns {0} immediately when off. */
+trace_handle_t schwung_trace_begin(uint32_t name_id);
+void           schwung_trace_end(trace_handle_t *h);
+
+/* ---- Phase 2: cross-process / JS bridge (declared, not yet wired) --- *
+ * A JS (QuickJS) binding will push a pre-timed span into the shared ring
+ * so shadow_ui / ion spans correlate with the shim's. */
+void schwung_trace_span_explicit(uint32_t name_id,
+                                 uint64_t t0_ns, uint64_t t1_ns,
+                                 uint64_t trace_id, uint64_t parent_id);
+
+/* ===================================================================== */
+/*  Macros — the only thing call sites should use.                       */
+/* ===================================================================== */
+
+#ifdef SCHWUNG_TRACE_DISABLED
+
+#define TRACE_SCOPE(name_lit)   ((void)0)
+#define TRACE_BEGIN(name_lit)   ((trace_handle_t){0})
+#define TRACE_END(h)            ((void)(h))
+
+#else  /* tracing compiled in, runtime-gated */
+
+/* Cache the interned id per call site in a static; first hit interns. */
+#define SCHWUNG_TRACE__NID(name_lit)                                       \
+    ({ static uint32_t _schw_nid = 0;                                      \
+       if (__builtin_expect(_schw_nid == 0, 0))                            \
+           _schw_nid = schwung_trace_intern(name_lit);                     \
+       _schw_nid; })
+
+#define SCHWUNG_TRACE__CAT2(a, b) a##b
+#define SCHWUNG_TRACE__CAT(a, b)  SCHWUNG_TRACE__CAT2(a, b)
+
+static inline void schwung_trace__cleanup(trace_handle_t *h) {
+    schwung_trace_end(h);
+}
+
+/* Scoped span: closes automatically at end of the enclosing block. */
+#define TRACE_SCOPE(name_lit)                                              \
+    trace_handle_t SCHWUNG_TRACE__CAT(_schw_span_, __LINE__)               \
+        __attribute__((cleanup(schwung_trace__cleanup))) =                 \
+        schwung_trace_begin(SCHWUNG_TRACE__NID(name_lit))
+
+/* Manual begin/end for non-lexical spans. */
+#define TRACE_BEGIN(name_lit) schwung_trace_begin(SCHWUNG_TRACE__NID(name_lit))
+#define TRACE_END(h)          schwung_trace_end(&(h))
+
+#endif /* SCHWUNG_TRACE_DISABLED */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCHWUNG_TRACE_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -42,6 +42,7 @@
 #include "host/shadow_midi_inject_writer.h"
 #include "host/shadow_chain_types.h"
 #include "host/unified_log.h"
+#include "host/schwung_trace.h"
 #include "host/tts_engine.h"
 #include "host/link_audio.h"
 #include "host/shadow_sampler.h"
@@ -4252,6 +4253,11 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     (void)ctx;
     (void)size;
 
+    /* Root span for the pre-ioctl half of the SPI frame. No-op when tracing
+     * is off (default). Closes on function return (incl. the goto pre_done
+     * baseline path — the handle stays in scope). */
+    TRACE_SCOPE("spi.pre");
+
     /* Flush-to-zero denormals on the SPI thread so IIR filters (speaker EQ,
      * subsonic HP, etc.) don't grind through gradual-underflow range during
      * long silent tails. FPCR is per-thread — set once on first callback.
@@ -4575,7 +4581,7 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
 
     /* Mix shadow audio into mailbox BEFORE hardware transaction */
     TIME_SECTION_START();
-    shadow_mix_audio();
+    { TRACE_SCOPE("shadow.mix_audio"); shadow_mix_audio(); }
     TIME_SECTION_END(spi_mix_audio_sum, spi_mix_audio_max);
 
     TIME_SECTION_START();
@@ -4584,8 +4590,10 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     TIME_SECTION_END(spi_ui_req_sum, spi_ui_req_max);
 
     TIME_SECTION_START();
-    shadow_inprocess_handle_param_request();
-    shadow_drain_web_param_set();  /* Web UI fire-and-forget param sets */
+    { TRACE_SCOPE("param.serve");
+      shadow_inprocess_handle_param_request();
+      shadow_drain_web_param_set();  /* Web UI fire-and-forget param sets */
+    }
     TIME_SECTION_END(spi_param_req_sum, spi_param_req_max);
 
     /* Forward CC/pitch bend/aftertouch from external MIDI to MIDI_OUT so DSP
@@ -4674,7 +4682,7 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     }
 
     TIME_SECTION_START();
-    shadow_inprocess_process_midi();
+    { TRACE_SCOPE("midi.process"); shadow_inprocess_process_midi(); }
     TIME_SECTION_END(spi_proc_midi_sum, spi_proc_midi_max);
 
     /* Stash MIDI_OUT cable-2 sequencer notes before SPI ioctl consumes them.
@@ -5495,6 +5503,9 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
 {
     (void)ctx;
     (void)size;
+
+    /* Root span for the post-ioctl half of the SPI frame. */
+    TRACE_SCOPE("spi.post");
 
     /* Timing: reuse statics from pre-transfer (same translation unit) */
     /* spi_post_start is at file scope */
@@ -7333,6 +7344,11 @@ static void *spi_timing_logger_thread(void *arg)
     while (1) {
         usleep(5000000);  /* 5 seconds */
 
+        /* Toggle span tracing live from the touch-file (independent of the
+         * unified-log gate below). Non-RT thread → safe to start the
+         * exporter / flip the atomic here. */
+        schwung_trace_poll_enable();
+
         if (!unified_log_enabled()) continue;
         if (spi_snap.seq == last_seq) continue;  /* No new data */
         last_seq = spi_snap.seq;
@@ -7521,6 +7537,12 @@ static void shim_spi_init(void)
     if (!real_ioctl) {
         real_ioctl = dlsym(RTLD_NEXT, "ioctl");
     }
+
+    /* Initialize OTLP span tracing (OFF unless the touch-file is present;
+     * see docs/tracing.md). Cheap: just samples the
+     * clock offset and polls the gate once. The exporter thread is started
+     * lazily by poll_enable, on its own SCHED_OTHER schedule off core 3. */
+    schwung_trace_init("schwung-shim");
 
     /* Initialize SPI library and register callbacks */
     g_spi_handle = schwung_spi_init();


### PR DESCRIPTION
## What

Realtime-safe **OpenTelemetry (OTLP) span tracing** for the shim, exported as OTLP/JSON for Grafana Tempo / Jaeger — for answering "where does the time go" perf questions (a long SPI frame, a slow path) with proper parent/child spans instead of ad-hoc `Date.now()` / `clock_gettime`. **Off by default, zero hot-path cost when off**, toggled live on-device via a touch-file (no rebuild).

This is **part 1 of 2 — the shim tracing core** (`src/host/schwung_trace.{c,h}` + shim wiring). The `shadow_ui` (QuickJS) spans, the JS `host_trace_begin/end` bridge, and cross-process correlation are implemented and validated on a fork and **follow as a second PR if this one is approved** — kept separate to keep the review focused. `docs/tracing.md` describes the full design with the part-2 sections marked ⏳.

## How it works

- `TRACE_SCOPE("name")` (and manual `TRACE_BEGIN`/`TRACE_END`) open spans. Off = one atomic-load + branch; on = stamp `CLOCK_MONOTONIC_RAW` + push a fixed 48-byte record into a lock-free per-thread SPSC ring — no alloc / locks / syscalls beyond the vDSO clock, safe from the SPI callback (SCHED_FIFO 90, core 3, ~900 µs budget). Drop-on-full, never blocks. `-DSCHWUNG_TRACE_DISABLED` compiles it out entirely.
- A dedicated exporter thread (SCHED_OTHER, pinned off core 3) drains the rings to rotating OTLP/JSONL under `/data/UserData/schwung/traces/` (8 MB rotation, newest 16 kept). Each line is one OTLP `ExportTraceServiceRequest` — replayable to a collector or importable into Tempo/Jaeger.
- Wired into the shim: `spi.pre`/`spi.post` roots + `shadow.mix_audio`, `midi.process`, `param.serve` children, on the existing `[spi_timing]` boundaries.

## Using it

```bash
touch /data/UserData/schwung/otlp_trace_on   # on
# ... reproduce the scenario you want to profile ...
rm /data/UserData/schwung/otlp_trace_on      # off
# import /data/UserData/schwung/traces/*.otlp.jsonl into Tempo/Jaeger
```

Full reference: `docs/tracing.md`.

## Testing

Builds clean (shim, no new warnings); validated on a real Move — traces produced, RT-path emission within the SPI frame budget.