### PR TITLE
feat(co-run): addressable-view overlays — open any registered screen over a co-run target

### DIFF
--- a/docs/CORUN.md
+++ b/docs/CORUN.md
@@ -88,6 +88,62 @@ Schwung should gate the user-facing entry on the API's presence:
 const corunAvailable = typeof shadow_corun_begin === "function";
 ```
 
+## View addressing — overlays over a co-run target
+
+The two co-run targets above hand the surface to a *fixed* destination for the
+session's whole life. **View addressing** is a layer on top: while a co-run is
+active, a tool can open any **registered** Schwung screen as a temporary
+**overlay** over its current target, and return — without changing `corun.target`,
+so the tool never tears down.
+
+```js
+shadow_corun_entries()            // -> array of openable screen ids (discovery)
+shadow_corun_open(id, keep_mask, args)  // -> true if opened, false on unknown id
+shadow_corun_close()              // -> dismiss; return to the underlay
+```
+
+These three are plain globals defined by shadow_ui (tool and shadow_ui share one
+QuickJS `globalThis`). They are backed by a curated registry, `CORUN_ENTRIES`,
+mapping a stable id to an existing screen's enter-function — `slots`,
+`chain_editor`, `master_fx`, `global_settings`. The registry is curated and added
+to deliberately; it is **never** auto-derived from the `VIEWS` enum (most views
+are context-dependent sub-views that need preloaded state). A tool discovers what
+this build offers via `shadow_corun_entries()` and gates per-id, so it degrades
+gracefully across builds that register different screens.
+
+The only C addition is one SHM helper, **`shadow_corun_overlay(active, keep_mask)`**,
+which flips `shadow_display_owner` and applies the keep_mask **without touching
+`corun.target`** (JS can't write those `shadow_control` fields directly).
+
+### Overlay model
+
+An overlay **reuses the chain-edit co-run dispatch** rather than running a parallel
+router. While one is open:
+
+- The outer `view` stays `OVERTAKE_MODULE`; the addressed screen lives in
+  `coRunView` (the entry's view change is captured by `runCoRunChainEdit`).
+  Keeping `view` at `OVERTAKE_MODULE` is what keeps the tool addressable: the
+  unified dispatch (gated `view === OVERTAKE_MODULE`) keeps delegating
+  pads/steps/transport to the tool, so the tool's own gestures (its exit, its
+  LEDs) keep working — for free, exactly as in chain-edit co-run.
+- `coRunUiActive() = coRunChainEditSlot >= 0 || corunOverlayId != null` gates the
+  draw / knob / Back-guard / intercept. `coRunWants(grp)` is one uniform rule for
+  every UI-element guard: chain-edit handles the groups the tool **cedes**; an
+  overlay handles the groups the tool **keeps** (kept events reach this process;
+  ceded ones go to Move). So a tool enables, e.g., overlay knob editing simply by
+  keeping `CORUN_GRP_KNOBS` — no view-specific code in the dispatcher.
+- `corun.target` is **untouched** → `shadow_corun_state()` still reports the
+  original target, and the tool does not run its teardown.
+- **Back** pops within the addressed view; at the overlay's root it calls
+  `shadow_corun_close()` (return to the underlay). **Menu** (and the tool's own
+  exit gesture) still ends co-run; the per-frame `shadow_corun_state()` reconcile
+  clears the overlay state when co-run ends, handing the screen back to the tool
+  rather than stranding the view.
+
+Additive and backward-compatible: with no overlay open (`corunOverlayId == null`)
+`coRunWants` collapses to `coRunCedes` and the dispatch behaves exactly as the
+framework does without view addressing.
+
 ## Move-firmware coupling
 
 `CORUN_TARGET_MOVE_NATIVE` runs as a pure shim-level split: Move firmware

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -403,6 +403,31 @@ static JSValue js_shadow_corun_end(JSContext *ctx, JSValueConst this_val, int ar
     return JS_UNDEFINED;
 }
 
+/* shadow_corun_overlay(active, keep_mask) -> void
+ * Present (active=1) or dismiss (active=0) a registered shadow_ui view as a
+ * temporary overlay over the active co-run target. Sets keep_mask and flips OLED
+ * ownership WITHOUT touching corun.target, so the consumer tool's corun_state()
+ * view and its state machine stay put (no teardown). On dismiss the OLED returns
+ * to the underlay: Move firmware for a move_native underlay, shadow_ui otherwise. */
+static JSValue js_shadow_corun_overlay(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 2) return JS_UNDEFINED;
+    int active = 0, keep = 0;
+    if (JS_ToInt32(ctx, &active, argv[0])) return JS_UNDEFINED;
+    if (JS_ToInt32(ctx, &keep, argv[1])) return JS_UNDEFINED;
+    if (keep < 0 || keep > 0xFFFF) return JS_UNDEFINED;
+    shadow_control->corun.keep_mask = (uint16_t)keep;
+    if (active) {
+        shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
+    } else {
+        shadow_control->shadow_display_owner =
+            (shadow_control->corun.target == CORUN_TARGET_MOVE_NATIVE)
+                ? DISPLAY_OWNER_MOVE_FIRMWARE
+                : DISPLAY_OWNER_SCHWUNG_UI;
+    }
+    return JS_UNDEFINED;
+}
+
 /* shadow_corun_state() -> { target, id, keep_mask } | null
  * Returns null when no co-run is active, else the current state. Tools poll
  * this each frame to detect framework-driven exit (Back press) and to
@@ -3247,6 +3272,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_begin", JS_NewCFunction(ctx, js_shadow_corun_begin, "shadow_corun_begin", 3));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_end", JS_NewCFunction(ctx, js_shadow_corun_end, "shadow_corun_end", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_state", JS_NewCFunction(ctx, js_shadow_corun_state, "shadow_corun_state", 0));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_overlay", JS_NewCFunction(ctx, js_shadow_corun_overlay, "shadow_corun_overlay", 2));
     /* Co-run target enum (matches corun_target_t in shadow_constants.h). */
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_NONE",        JS_NewInt32(ctx, CORUN_TARGET_NONE));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_CHAIN_EDIT",  JS_NewInt32(ctx, CORUN_TARGET_CHAIN_EDIT));

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -245,6 +245,27 @@ function coRunCedes(grp) {
     return grp !== 0 && (m & grp) === 0;
 }
 
+/* True while shadow_ui is drawing a co-run screen over a still-running tool —
+ * either the chain editor (coRunChainEditSlot >= 0) or an addressed-view overlay
+ * (corunOverlayId != null, declared below). In BOTH, the outer `view` stays
+ * OVERTAKE_MODULE and coRunView holds the drawn screen, so the dispatcher keeps
+ * delegating pads/steps/transport + LEDs to the tool. */
+function coRunUiActive() { return coRunChainEditSlot >= 0 || corunOverlayId != null; }
+
+/* Should shadow_ui's co-run intercept handle this control group? ONE uniform rule
+ * for every UI element, with no per-element special-casing:
+ *  - chain-edit: handle it when the tool CEDES it (peer is shadow_ui, same
+ *    process, so ceded events arrive here).
+ *  - addressed-view overlay: handle it when the tool KEEPS it — the tool keeps
+ *    exactly the UI elements it wants the overlay to drive (kept events reach this
+ *    process; ceded ones go to Move firmware). So "keeps" is the overlay's
+ *    analogue of chain-edit's "cedes".
+ * A tool thus enables, e.g., overlay knob editing simply by keeping
+ * CORUN_GRP_KNOBS — no view-specific code in the dispatcher. */
+function coRunWants(grp) {
+    return corunOverlayId != null ? !coRunCedes(grp) : coRunCedes(grp);
+}
+
 /* Param-shim originals. When a chain module's UI is "loaded" (or when
  * enterHierarchyEditor / setupModuleParamShims fires), the shadow_ui
  * shims host_module_get_param / host_module_set_param so chain-editor
@@ -314,6 +335,65 @@ const VIEWS = {
     LFO_TARGET_COMPONENT: "lfotargetcomp",    // LFO target picker step 1: component
     LFO_TARGET_PARAM: "lfotargetparam"        // LFO target picker step 2: parameter
 };
+
+/* ==== CO-RUN VIEW ADDRESSING ====
+ * A curated registry of addressable Schwung screens a co-running tool may open as
+ * a temporary OVERLAY over its co-run target, then return from — generalizing
+ * co-run beyond the two hardcoded targets. Tool + shadow_ui share one QuickJS
+ * globalThis, so the three verbs are plain globals the tool calls directly:
+ *   shadow_corun_entries()              -> array of openable screen ids (discovery)
+ *   shadow_corun_open(id, keep_mask, a) -> true if opened (false on unknown id)
+ *   shadow_corun_close()                -> dismiss, return to the underlay
+ * The only C addition is shadow_corun_overlay(active, keep_mask), which flips the
+ * OLED owner + keep_mask WITHOUT touching corun.target (so the consumer tool's
+ * state machine is undisturbed). Entries are curated and added deliberately —
+ * NEVER auto-derived from VIEWS (most VIEWS are context-dependent sub-views). */
+const CORUN_ENTRIES = {
+    slots:           { enter: function() { view = VIEWS.SLOTS; } },
+    chain_editor:    { enter: function(a) { enterChainEdit((a && a.slot) | 0); } },
+    master_fx:       { enter: function() { enterMasterFxSettings(); } },
+    global_settings: { enter: function() { enterGlobalSettings(); } },
+};
+
+let corunOverlayId = null;        /* active overlay entry id, or null */
+let corunOverlayPrevMask = 0;     /* keep_mask to restore on close */
+let corunOverlayRootView = -1;    /* the entry's top-level view; Back here closes */
+
+globalThis.shadow_corun_entries = function() {
+    return Object.keys(CORUN_ENTRIES);
+};
+
+globalThis.shadow_corun_open = function(id, keep_mask, args) {
+    const entry = CORUN_ENTRIES[id];
+    if (!entry) return false;
+    const st = (typeof shadow_corun_state === 'function') ? shadow_corun_state() : null;
+    corunOverlayPrevMask = st ? (st.keep_mask | 0) : 0;
+    corunOverlayId = id;
+    /* Flip OLED to shadow_ui + apply the overlay's keep_mask; corun.target stays
+     * put so the consumer tool's state machine is undisturbed. */
+    if (typeof shadow_corun_overlay === 'function') shadow_corun_overlay(1, keep_mask | 0);
+    /* Mirror chain-edit co-run: keep the outer view at OVERTAKE_MODULE (so the
+     * dispatcher keeps delegating pads/steps/transport + LEDs to the tool) and let
+     * the entry's view change land in coRunView, which the co-run draw path
+     * renders. runCoRunChainEdit captures view -> coRunView around the enter. */
+    coRunView = VIEWS.OVERTAKE_MODULE;
+    runCoRunChainEdit(function() { entry.enter(args); });
+    corunOverlayRootView = coRunView;
+    needsRedraw = true;
+    return true;
+};
+
+globalThis.shadow_corun_close = function() {
+    if (corunOverlayId == null) return;
+    corunOverlayId = null;
+    corunOverlayRootView = -1;
+    coRunView = VIEWS.OVERTAKE_MODULE;
+    /* Restore the underlay's OLED owner + keep_mask. view never left
+     * OVERTAKE_MODULE, so the tool stayed addressable throughout the overlay. */
+    if (typeof shadow_corun_overlay === 'function') shadow_corun_overlay(0, corunOverlayPrevMask | 0);
+    needsRedraw = true;
+};
+/* ==== END CO-RUN VIEW ADDRESSING ==== */
 
 /* Special action key for swap module option */
 const SWAP_MODULE_ACTION = "__swap_module__";
@@ -2590,7 +2670,7 @@ function loadModuleUi(slot, componentKey, moduleId) {
      * (and onMidiMessageInternal), which silences the active tool. The caller
      * (enterComponentEditFallback) falls back to the simple preset browser
      * when this returns false — that path doesn't touch globals. */
-    if (coRunChainEditSlot >= 0) {
+    if (coRunUiActive()) {
         moduleUiLoadError = true;
         return false;
     }
@@ -14843,6 +14923,11 @@ function runCoRunChainEdit(fn) {
  * dispatch every reachable view explicitly. */
 function dispatchCoRunDraw() {
     switch (view) {
+        /* Addressable-view overlay roots (CORUN_ENTRIES) — the co-run draw path
+         * must render these too, not just the chain-editor subtree. */
+        case VIEWS.SLOTS:                drawSlots(); break;
+        case VIEWS.MASTER_FX:            drawMasterFx(); break;
+        case VIEWS.GLOBAL_SETTINGS:      drawGlobalSettings(); break;
         case VIEWS.CHAIN_EDIT:           drawChainEdit(); break;
         case VIEWS.PATCHES:              drawPatches(); break;
         case VIEWS.PATCH_DETAIL:         drawPatchDetail(); break;
@@ -15522,7 +15607,7 @@ globalThis.tick = function() {
      * outer view is OVERTAKE_MODULE; wrap so getKnobContext (cache keyed on
      * view) resolves against the chain editor's view and the accumulated knob
      * delta isn't silently dropped under the wrong context. */
-    if (coRunChainEditSlot >= 0) {
+    if (coRunUiActive()) {
         runCoRunChainEdit(processPendingHierKnob);
     } else {
         processPendingHierKnob();
@@ -15620,6 +15705,17 @@ globalThis.tick = function() {
      * shadow_corun_state() returns null and we tear down the editor. */
     if (typeof shadow_corun_state === "function") {
         const _st = shadow_corun_state();
+        /* Overlay teardown: if the tool ended co-run (its own exit gesture / Menu /
+         * set change) while an addressed-view overlay was open, the framework
+         * already restored the display owner + keep_mask via shadow_corun_end();
+         * clear the JS overlay state here so coRunUiActive() goes false and shadow_ui
+         * hands the screen back to the tool instead of stranding the overlay. */
+        if (corunOverlayId != null && !_st) {
+            corunOverlayId = null;
+            corunOverlayRootView = -1;
+            coRunView = VIEWS.OVERTAKE_MODULE;
+            needsRedraw = true;
+        }
         const _slot = (_st && _st.target === CORUN_TARGET_CHAIN_EDIT) ? _st.id : -1;
         coRunKeepMask = (_st && typeof _st.keep_mask === "number") ? (_st.keep_mask | 0) : 0;
         if (_slot !== coRunChainEditSlot) {
@@ -15870,7 +15966,7 @@ globalThis.tick = function() {
                      * to OLED while coRunChainEditSlot >= 0 — but even if it
                      * does, drawSlots() (and chain-edit subtree draws) start
                      * with clear_screen() so the editor's pixels win. */
-                    if (coRunChainEditSlot >= 0) {
+                    if (coRunUiActive()) {
                         runCoRunChainEdit(dispatchCoRunDraw);
                     }
                 }
@@ -16076,7 +16172,7 @@ globalThis.onMidiMessageInternal = function(data) {
          * Back alone: suspend (module parks in background, ticks continue).
          * Shift+Back: full exit (unload module).
          * Skip while co-run is active: the chain editor claims Back. */
-        if ((status & 0xF0) === 0xB0 && d1 === MoveBack && d2 > 0 && overtakeSuspendKeepsJs && coRunChainEditSlot < 0) {
+        if ((status & 0xF0) === 0xB0 && d1 === MoveBack && d2 > 0 && overtakeSuspendKeepsJs && !coRunUiActive()) {
             if (hostShiftHeld) {
                 debugLog("HOST: Shift+Back → full exit (suspend_keeps_js module)");
                 if (toolOvertakeActive) exitToolOvertake();
@@ -16095,14 +16191,14 @@ globalThis.onMidiMessageInternal = function(data) {
          * (PATCHES, COMPONENT_*, KNOB_*, etc.) Back navigates up within the
          * editor; at CHAIN_EDIT (the top level) Back is silent so the tool's
          * own exit gesture (e.g. Menu) takes over. */
-        if (coRunChainEditSlot >= 0 && (status & 0xF0) === 0xB0) {
-            if (d1 === MoveMainKnob && coRunCedes(CORUN_GRP_JOG)) {
+        if (coRunUiActive() && (status & 0xF0) === 0xB0) {
+            if (d1 === MoveMainKnob && coRunWants(CORUN_GRP_JOG)) {
                 const delta = decodeDelta(d2);
                 if (delta !== 0) runCoRunChainEdit(function() { handleJog(delta); });
                 needsRedraw = true;
                 return;
             }
-            if (d1 === MoveMainButton && d2 > 0 && coRunCedes(CORUN_GRP_JOG)) {
+            if (d1 === MoveMainButton && d2 > 0 && coRunWants(CORUN_GRP_JOG)) {
                 /* Mirror the non-overtake Shift+Click handler (line ~15259):
                  * Shift+Click in CHAIN_EDIT → handleShiftSelect (enter
                  * component edit). Plain Click → handleSelect. */
@@ -16129,16 +16225,24 @@ globalThis.onMidiMessageInternal = function(data) {
              * still rely on the tool's own exit gesture; only chain-edit gets
              * the auto-exit-at-top because only shadow_ui can see its own
              * view depth. */
-            if (d1 === MoveBack && d2 > 0 && coRunCedes(CORUN_GRP_BACK)) {
-                if (coRunView !== VIEWS.CHAIN_EDIT) {
+            if (d1 === MoveBack && d2 > 0 && coRunWants(CORUN_GRP_BACK)) {
+                if (corunOverlayId != null) {
+                    /* Addressed-view overlay: pop within the view; at the overlay's
+                     * root (corunOverlayRootView) close it to return to the underlay
+                     * — never end co-run (Menu / the tool's own gesture does that). */
+                    if (coRunView === corunOverlayRootView) {
+                        shadow_corun_close();
+                    } else {
+                        runCoRunChainEdit(function() { handleBack(); });
+                    }
+                } else if (coRunView !== VIEWS.CHAIN_EDIT) {
                     runCoRunChainEdit(function() { handleBack(); });
-                    needsRedraw = true;
                 } else {
                     if (typeof shadow_corun_end === "function") shadow_corun_end();
                     coRunChainEditSlot = -1;
                     coRunView = VIEWS.OVERTAKE_MODULE;
-                    needsRedraw = true;
                 }
+                needsRedraw = true;
                 return;
             }
             /* Shift (CC 49): give it ONLY to the chain editor. hostShiftHeld
@@ -16146,12 +16250,15 @@ globalThis.onMidiMessageInternal = function(data) {
              * the editor's isShiftHeld()-based code paths see the right state.
              * Eating it here prevents the tool from reacting (e.g. its own
              * Shift+button shortcuts while you're navigating the editor). */
-            if (d1 === 49 && coRunCedes(CORUN_GRP_SHIFT)) {
+            if (d1 === 49 && coRunWants(CORUN_GRP_SHIFT)) {
                 needsRedraw = true;
                 return;
             }
-            /* Track buttons: CC 43=Track 1 (slot 0), CC 40=Track 4 (slot 3) */
-            if (d1 >= 40 && d1 <= 43 && d2 > 0 && coRunCedes(CORUN_GRP_TRACK_BUTTONS)) {
+            /* Track buttons: CC 43=Track 1 (slot 0), CC 40=Track 4 (slot 3).
+             * Chain-edit only — an overlay has no chain slot; swallow so a stray
+             * track press can't flip it into chain-edit co-run. */
+            if (d1 >= 40 && d1 <= 43 && d2 > 0 && coRunWants(CORUN_GRP_TRACK_BUTTONS)) {
+                if (corunOverlayId != null) { needsRedraw = true; return; }
                 const _slot = 43 - d1;
                 if (_slot >= 0 && _slot < SHADOW_UI_SLOTS && _slot !== coRunChainEditSlot) {
                     coRunChainEditSlot = _slot;
@@ -16173,7 +16280,7 @@ globalThis.onMidiMessageInternal = function(data) {
              * before the tool knob-accumulation below, so the tool no longer
              * receives knob turns while co-run is active. Knob TOUCH notes still
              * forward to the tool — intentional turn-only split. */
-            if (d1 >= KNOB_CC_START && d1 <= KNOB_CC_END && coRunCedes(CORUN_GRP_KNOBS)) {
+            if (d1 >= KNOB_CC_START && d1 <= KNOB_CC_END && coRunWants(CORUN_GRP_KNOBS)) {
                 const _kIdx = d1 - KNOB_CC_START;
                 const _kDelta = decodeDelta(d2);
                 if (_kDelta !== 0) {
@@ -16211,8 +16318,8 @@ globalThis.onMidiMessageInternal = function(data) {
          * notes pre-change; keeping that avoids a stranded knobTouched on exit).
          * Release drains BOTH the hierarchy (pendingHierKnob) and slot-global
          * (pendingKnob) paths, which is what actually clears the value popup. */
-        if (coRunChainEditSlot >= 0 && (status & 0xF0) === MidiNoteOn &&
-                d1 >= MoveKnob1Touch && d1 <= MoveKnob8Touch && coRunCedes(CORUN_GRP_TOUCH)) {
+        if (coRunUiActive() && (status & 0xF0) === MidiNoteOn &&
+                d1 >= MoveKnob1Touch && d1 <= MoveKnob8Touch && coRunWants(CORUN_GRP_TOUCH)) {
             const _tk = d1 - MoveKnob1Touch;
             if (d2 > 0) {
                 runCoRunChainEdit(function() {


### PR DESCRIPTION
> **Follow-up to #94** — the co-run framework PR, merged as `81a1f838` (v0.9.18). This PR stacks the view-addressing **overlay** layer directly on top of that merged framework; it does not re-introduce any of it.

Builds on #94 (the co-run framework, now merged). Adds **view addressing**: while co-run is active, a tool can open any *registered* Schwung screen as a temporary **overlay** over its current co-run target and return — without ending co-run.

## Why

#94 lets a tool share the surface with one *fixed* destination for the session (the chain editor, or Move's native pages). But a tool often wants to dip into a Schwung screen mid-session — global settings, the chain editor, master FX — and come right back, instead of leaving co-run entirely. View addressing makes that a supported, one-call operation for any tool.

## API

Three globals (defined by shadow_ui; tool + shadow_ui share one QuickJS `globalThis`):

```js
shadow_corun_entries()                  // -> ids of openable screens (discovery)
shadow_corun_open(id, keep_mask, args)  // -> true if opened, false on unknown id
shadow_corun_close()                    // -> dismiss, return to the underlay
```

Backed by a curated `CORUN_ENTRIES` registry mapping a stable id to an existing screen's enter-function — `slots` / `chain_editor` / `master_fx` / `global_settings`. The registry is curated (added to deliberately); it is **never** auto-derived from the `VIEWS` enum, since most views are context-dependent sub-views. Discovery (`shadow_corun_entries`) lets a tool capability-gate per id, so it degrades gracefully across builds that register different screens.

The only C addition is one SHM helper, `shadow_corun_overlay(active, keep_mask)`, which flips `shadow_display_owner` + the keep_mask **without touching `corun.target`** (JS can't write those `shadow_control` fields).

## How it works

The overlay **reuses the chain-edit co-run dispatch** rather than running a parallel router. While one is open:

- The outer `view` stays `OVERTAKE_MODULE`; the addressed screen lives in `coRunView` (captured by `runCoRunChainEdit`). Keeping `view` at `OVERTAKE_MODULE` is what keeps the tool addressable — the unified dispatch keeps delegating pads/steps/transport to the tool, so the tool's own gestures and its LEDs keep working, exactly as in chain-edit co-run.
- `coRunUiActive()` generalizes the intercept gate + draw/knob/touch wraps; `coRunWants(grp)` is one uniform rule for every UI-element guard — chain-edit handles what the tool **cedes**, an overlay handles what it **keeps**. So a tool enables, e.g., overlay knob editing simply by keeping `CORUN_GRP_KNOBS`.
- `corun.target` is untouched, so `shadow_corun_state()` still reports the original target and the tool doesn't tear down.
- Back pops within the view / closes at its root (returns to the underlay); Menu and the tool's own exit still end co-run; a per-frame reconcile clears the overlay when co-run ends.

## Backward compatibility

Fully additive. With no overlay open (`corunOverlayId == null`) `coRunWants` collapses to `coRunCedes` and the dispatch behaves exactly as #94 without view addressing. No struct-layout change — the helper reuses existing `shadow_control` fields.

## Testing

Proving ground is dAVEBOx (an 8-track sequencer tool that runs co-run in production), which uses this to open its FX-bus picker from Move co-run. Verified on-device against this branch (built on the merged #94 framework): opening a registered screen as an overlay over the synth, navigating it, knob editing, Back returning to the underlay, and the tool's Step-3 exit + LED upkeep all working through the overlay.

Docs: `docs/CORUN.md` (new "View addressing" section).

## How to test with dAVEBOx

[dAVEBOx](https://github.com/legsmechanical/schwung-davebox) is a public co-running tool (8-track sequencer) that uses this overlay in production. To exercise this PR end-to-end on stock Schwung:

1. Build + deploy this branch (official `main` + this PR) to a Move.
2. Install the dAVEBOx module (from `legsmechanical/schwung-davebox` `main`) onto it.
3. In dAVEBOx, enter **Move co-run** (`Edit Synth…` on a Move-routed track) so Move's synth screen is showing.
4. Press **Note/Session** → it opens the **Master FX** screen as an overlay over the synth.
   - dAVEBOx prefers its own (fork-only) `fx_picker` where registered and **falls back to the upstream `master_fx`** on stock Schwung, so **no dAVEBOx edit is needed** to test this PR (fallback added in davebox `916f5ff`).
5. Verify: jog/click navigate it, knobs edit the FX params, **Back** returns to the synth, and **Step 3** (dAVEBOx's exit gesture) ends co-run — all while the sequencer keeps playing, proving the tool stays addressable beneath the overlay.
