### PR TITLE
fix(co-run): serialize discrete multi-field set_param commits (LFO target, MPE)

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2819,6 +2819,24 @@ function getSlotParam(slot, key) {
     }
 }
 
+/* Blocking set_param for DISCRETE multi-field commits (e.g. LFO target+param,
+ * MPE recv/fwd/enable). In co-run (overtake mode) shadow_set_param is
+ * fire-and-forget and shares ONE shadow_param SHM slot, so two back-to-back
+ * writes race — the 2nd clobbers the 1st before the host drains it, losing the
+ * earlier write (e.g. LFO target reverts to "none"). The blocking variant
+ * (shadow_set_param_timeout, force_blocking) waits for each write to be consumed,
+ * serializing the pair. Knob streams keep the non-blocking path. */
+const SHADOW_SET_BLOCKING_TIMEOUT_MS = 200;
+function shadowSetParamBlocking(slot, key, value) {
+    if (typeof shadow_set_param_timeout === "function") {
+        return shadow_set_param_timeout(slot, key, String(value), SHADOW_SET_BLOCKING_TIMEOUT_MS);
+    }
+    if (typeof shadow_set_param === "function") {
+        return shadow_set_param(slot, key, String(value));
+    }
+    return false;
+}
+
 function setSlotParam(slot, key, value) {
     if (typeof shadow_set_param !== "function") return false;
     try {
@@ -7491,14 +7509,14 @@ function adjustChainSetting(slot, setting, delta) {
                 recv: getSlotParam(slot, "slot:receive_channel"),
                 fwd: getSlotParam(slot, "slot:forward_channel"),
             };
-            setSlotParam(slot, "slot:receive_channel", "0");    /* All */
-            setSlotParam(slot, "slot:forward_channel", "-2");   /* THRU */
-            setSlotParam(slot, "synth:mpe_enabled", "1");
+            shadowSetParamBlocking(slot, "slot:receive_channel", "0");    /* All */
+            shadowSetParamBlocking(slot, "slot:forward_channel", "-2");   /* THRU */
+            shadowSetParamBlocking(slot, "synth:mpe_enabled", "1");
         } else if (delta < 0 && mpeOn) {
             const prev = chainMpePreState[slot];
-            setSlotParam(slot, "slot:receive_channel", prev?.recv || String(slot + 1));
-            setSlotParam(slot, "slot:forward_channel", prev?.fwd || "-1");
-            setSlotParam(slot, "synth:mpe_enabled", "0");
+            shadowSetParamBlocking(slot, "slot:receive_channel", prev?.recv || String(slot + 1));
+            shadowSetParamBlocking(slot, "slot:forward_channel", prev?.fwd || "-1");
+            shadowSetParamBlocking(slot, "synth:mpe_enabled", "0");
             chainMpePreState[slot] = null;
         }
         return;
@@ -12767,8 +12785,8 @@ function handleSelect() {
             if (lfoTargetComponents.length > 0 && lfoCtx) {
                 const comp = lfoTargetComponents[selectedLfoTargetComp];
                 if (comp.key === "__clear__") {
-                    lfoCtx.setParam("target", "");
-                    lfoCtx.setParam("target_param", "");
+                    lfoCtx.setParamBlocking("target", "");
+                    lfoCtx.setParamBlocking("target_param", "");
                     setView(VIEWS.LFO_EDIT);
                     announce("Target cleared");
                     needsRedraw = true;
@@ -12782,8 +12800,8 @@ function handleSelect() {
             if (lfoTargetParams.length > 0 && lfoCtx) {
                 const comp = lfoTargetComponents[selectedLfoTargetComp];
                 const param = lfoTargetParams[selectedLfoTargetParam];
-                lfoCtx.setParam("target", comp.key);
-                lfoCtx.setParam("target_param", param.key);
+                lfoCtx.setParamBlocking("target", comp.key);
+                lfoCtx.setParamBlocking("target_param", param.key);
                 setView(VIEWS.LFO_EDIT);
                 announce("Target set: " + comp.label + " " + param.label);
                 needsRedraw = true;
@@ -14332,6 +14350,7 @@ function makeSlotLfoCtx(slot, lfoIdx) {
         lfoIdx: lfoIdx,
         getParam: function(key) { return getSlotParam(slot, prefix + key); },
         setParam: function(key, val) { setSlotParam(slot, prefix + key, val); },
+        setParamBlocking: function(key, val) { return shadowSetParamBlocking(slot, prefix + key, val); },
         getTargetComponents: function() {
             const comps = [];
             const synthModule = getSlotParam(slot, "synth_module");
@@ -14407,6 +14426,7 @@ function makeMfxLfoCtx(lfoIdx) {
         lfoIdx: lfoIdx,
         getParam: function(key) { return shadow_get_param(0, prefix + key); },
         setParam: function(key, val) { shadow_set_param(0, prefix + key, val); },
+        setParamBlocking: function(key, val) { return shadowSetParamBlocking(0, prefix + key, val); },
         getTargetComponents: function() {
             const comps = [];
             for (let i = 0; i < 4; i++) {


### PR DESCRIPTION
> **Follow-up to #94** — the co-run framework PR (merged as `81a1f838`, v0.9.18). A small, self-contained co-run bug fix on top of that merged framework.

In co-run, `shadow_set_param` is fire-and-forget (overtake mode, `shadow_set_param_common`) and shares a **single** `shadow_param` SHM request slot. So two `set_param` writes issued **back-to-back in one handler** race: the 2nd stamps the slot before the host drains the 1st, and the earlier write is silently dropped.

This bites **discrete multi-field commits** — operations that must write several params atomically in a single user action:

- **LFO target picker** — writes `target` then `target_param`. In co-run the `target` write is lost → the assignment reverts to **"none"**.
- **Chain Settings MPE toggle** — writes `receive_channel` + `forward_channel` + `synth:mpe_enabled`. In co-run it applies partially.

Standalone is unaffected: there `set_param` blocks (`wait_idle` + `wait_response`) between writes, so each lands before the next.

**Fix:** add `shadowSetParamBlocking`, which routes through the existing always-blocking `shadow_set_param_timeout` (it already bypasses the overtake fire-and-forget path), and use it for those discrete multi-field commits so the writes serialize even in co-run. Rapid knob streams keep the non-blocking fast path — the reason fire-and-forget exists — untouched.

**Scope:** only the co-run-reachable discrete multi-field commits. The Slot Settings MPE toggle is standalone-only (its view is never set as a `coRunView`), so it can't race and is left unchanged. No SHM/layout change.

**Verified on-device:** the identical change ships in our dAVEBOx fork — in co-run, LFO targets now persist (master + per-slot) and the MPE toggle applies fully; standalone behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)