### PR TITLE
feat(fx): Send FX — two post-fader send buses (A/B) + generic FX-bus picker

### DIFF
--- a/docs/SEND_FX.md
+++ b/docs/SEND_FX.md
@@ -1,0 +1,146 @@
+# Send FX
+
+Send FX adds two **post-fader send buses** (Send A and Send B) to Schwung,
+each with its own effects chain, alongside a generic **FX-bus picker** that
+also hosts the existing Master FX. It's the classic mixer *aux/return* model:
+every track can feed a portion of its signal to a shared effect (a reverb, a
+delay, …) instead of putting a separate copy of that effect on each track.
+
+---
+
+## What it does (plain terms)
+
+- **Two send buses, A and B.** Each is a small FX chain of up to **4 effects**.
+- **Per-track send amounts.** Every chain slot (track) has a **Send A** and
+  **Send B** level (0–100%) in its settings — how much of that track is sent
+  to each bus. The sends are **post-fader**: they follow the track's own
+  volume, so turning a track down also pulls it out of the sends (like a
+  console's post-fader aux).
+- **Per-bus return level.** Each bus has a **return level** that sets how much
+  of the (effected) bus comes back into the main mix.
+- **Send A → Send B.** Send A can additionally feed **Send B** (the "**→ Send
+  B**" amount in Send A's settings), so you can chain effects in parallel —
+  e.g. a delay (A) whose repeats are then washed through a reverb (B). It's
+  post-fader on A's return, and feedback-safe (B can't bleed back into A).
+- **Presets, shared between A and B.** You can save/recall a whole send chain
+  as a preset; the preset list is shared, so a preset saved from A can be
+  loaded onto B and vice-versa.
+- **Per-set persistence.** Send chains, return levels, the A→B amount, and the
+  per-track send levels all save and restore with the Move Set.
+
+### Using it
+
+1. Open the **FX-bus picker** and choose **Send A**, **Send B**, or **Master
+   FX**. (Master FX behaves exactly as before — it's now just one of the
+   buses the picker can open.)
+2. In the bus editor, load effects into the slots, tweak params, set the
+   **return level**, and **save/load presets**. Sends have no LFOs (those
+   menu items are hidden for sends; Master keeps them).
+3. On a **track** (chain slot), open its settings and raise **Send A** /
+   **Send B** to feed that track into a bus.
+4. For parallel chaining, raise **→ Send B** in **Send A**'s settings.
+
+---
+
+## How it works (technical)
+
+### Topology
+
+```
+track 0 ──(slot:send_a)──┐                       ┌── return_level[A] ──┐
+track 1 ──(slot:send_a)──┼─► send_accum[A] ─► [A FX1..4] ─► send_buf ──┤
+track N ──(slot:send_a)──┘                  │                          ├─► ME bus ─► Master FX ─► out
+                                            └─(a:to_b · return_level[A])┐         │
+track k ──(slot:send_b)──┐                                             ▼         │
+              ...        ┼─► send_accum[B] ─► [B FX1..4] ─► return_level[B] ──────┘
+                         ┘
+```
+
+Buses are **2** (`SEND_BUS_COUNT`), each with **4** FX slots (`SEND_FX_SLOTS`).
+Each send bus is hosted exactly like Master FX — an array of
+`master_fx_slot_t` (`shadow_send_fx_slots[SEND_BUS_COUNT][SEND_FX_SLOTS]`) —
+so all the Master-FX module hosting, presets, and bypass machinery is reused
+rather than duplicated.
+
+### Mix path (`src/schwung_shim.c`)
+
+Per audio block, after the per-slot chains run:
+
+1. Each chain slot's **post-fader** output is multiplied by its `slot:send_a` /
+   `slot:send_b` level and summed into the bus accumulator `send_accum[bus]`.
+2. For each active bus, the accumulator is clamped to `int16`, run through the
+   bus's FX slots (`process_block`), then scaled by `shadow_send_return_level[bus]`
+   and summed into the **ME bus** (pre–Master FX), so the returns are colored
+   by Master FX like everything else.
+3. **A→B:** if `shadow_send_a_to_b_level > 0`, Send A's *return-scaled* output
+   (`send_buf · return_level[A] · a_to_b`) is added into `send_accum[B]` **before**
+   B is processed. Because buses run in order (A=0 then B=1) and A is already
+   finished, B can never feed back into A — feedback-safe by construction. A
+   still returns to the master independently (parallel, not a re-route).
+
+### Parameters
+
+| Key | Where | Meaning |
+| --- | --- | --- |
+| `slot:send_a`, `slot:send_b` | per chain slot | post-fader send level 0–1 to bus A/B |
+| `send_fx:<a\|b>:fx<1-4>:<param>` | host | param on a send-bus FX slot (`module`, `bypassed`, plugin params, `state`, `chain_params`, `ui_hierarchy`) |
+| `send_fx:<a\|b>:return_level` | host | per-bus return level 0–1 (default 1.0) |
+| `send_fx:a:to_b` | host | Send A → Send B amount 0–1 (default 0) |
+| `save_send_preset` / `update_send_preset` / `delete_send_preset` | DSP | shared send-preset writes |
+| `send_preset_count` / `send_preset_name_<i>` / `send_preset_json_<i>` | DSP | shared send-preset reads |
+
+`send_fx:` SET/GET is handled in **both** host param paths
+(`shadow_direct_set_param` and `shadow_inprocess_handle_param_request` in
+`src/host/shadow_chain_mgmt.c`).
+
+### UI — one editor, many buses
+
+The former Master-FX editor is **genericized** into a single
+**bus-descriptor-driven** editor (`src/shadow/shadow_ui_master_fx.mjs`). A
+descriptor (`FX_BUS.master` / `sendA` / `sendB`) carries the bus's `id`,
+`paramPrefix` (`master_fx:` vs `send_fx:a:` …), `slotCount`, `hasLfo`,
+component list, and preset config. The **FX-bus picker**
+(`VIEWS.FX_BUS_PICKER` / `enterFxBusPicker` in `src/shadow/shadow_ui.js`)
+selects the active bus before entry; only one editor is open at a time, so the
+editor's transient state is repopulated per bus on entry.
+
+- Sends set `hasLfo:false`, so the LFO settings items (`mfx_lfo1`/`mfx_lfo2`)
+  are filtered out of their settings menu; Master (`hasLfo:true`) keeps them.
+- The **home-screen knob-context cache** is keyed on `activeFxBus.id` so knob
+  param mappings don't leak across buses once more than one bus exists.
+
+### Persistence
+
+Two layers:
+
+- **Per-set** (mirrors Master-FX per-set files): each send slot's chain is
+  written to `send_fx_<bus>_<slot>.json` in the set's state dir, and bus-level
+  values (`return_level` for A/B, plus `send_a_to_b`) to `send_fx_meta.json`.
+  `send_a_to_b` is always written (default 0) so it can't leak across sets.
+  Per-track `slot:send_a/b` save with the chain config; `shadow_state.c` also
+  mirrors `send_return_level` + `send_a_to_b` for boot restore.
+- **Presets** are a separate **shared** store (`presets_send/`, one list for
+  both buses), wrapping up to 4 FX slots under a `send_fx` root.
+
+### Notable upstream-worthy fixes carried here
+
+- **`json_get_section_bounds` (`chain_host.c`)** now anchors on the key's
+  colon and only treats the value as a section when it *is* an object.
+  Previously a null-valued (empty) FX slot would grab a *later* slot's object,
+  corrupting saved presets with gaps (filled/empty/filled). This also fixes a
+  latent **Master**-preset bug, so it's worth carrying regardless of sends.
+- **Send `ui_hierarchy` falls back to `module.json`**, so modules without an
+  explicit hierarchy can still open their params on a send bus.
+
+### Files touched
+
+| File | Role |
+| --- | --- |
+| `src/host/shadow_chain_types.h` | per-slot `send_a`/`send_b` fields |
+| `src/host/shadow_chain_mgmt.{c,h}` | `shadow_send_fx_slots[]`, send load/unload, `send_fx:` SET/GET, return levels, A→B global |
+| `src/host/shadow_state.c` | persist `slot_send_a/b`, `send_return_level`, `send_a_to_b` |
+| `src/schwung_shim.c` | post-fader send accumulation, return mix, A→B tap |
+| `src/shadow/shadow_ui_master_fx.mjs` | generic bus-descriptor FX editor |
+| `src/shadow/shadow_ui_slots.mjs` | `slot:send_a/b` settings, `getSendFxDisplayName` |
+| `src/modules/chain/dsp/chain_host.c` | shared send-preset store, `json_get_section_bounds` fix |
+| `src/shadow/shadow_ui.js` | `FX_BUS` descriptors, FX-bus picker, send settings, A→B item, per-set persistence, bus-keyed knob cache |

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -60,6 +60,15 @@ int shadow_inprocess_ready = 0;
 /* Master FX slots */
 master_fx_slot_t shadow_master_fx_slots[MASTER_FX_SLOTS];
 
+/* Send FX slots */
+master_fx_slot_t shadow_send_fx_slots[SEND_BUS_COUNT][SEND_FX_SLOTS];
+
+/* Per-bus send return level (default unity) */
+float shadow_send_return_level[SEND_BUS_COUNT] = { 1.0f, 1.0f };
+
+/* Send A -> Send B routing level (0 = off). Parallel: A still returns to master. */
+float shadow_send_a_to_b_level = 0.0f;
+
 /* Master FX LFOs */
 lfo_state_t shadow_master_fx_lfos[MASTER_FX_LFO_COUNT];
 static float mfx_lfo_base_value[MASTER_FX_LFO_COUNT];
@@ -415,6 +424,8 @@ void shadow_chain_defaults(void) {
         shadow_chain_slots[i].patch_index = -1;
         shadow_chain_slots[i].channel = shadow_chain_parse_channel(1 + i);
         shadow_chain_slots[i].volume = 1.0f;
+        shadow_chain_slots[i].send_a = 0.0f;
+        shadow_chain_slots[i].send_b = 0.0f;
         shadow_chain_slots[i].muted = 0;
         shadow_chain_slots[i].soloed = 0;
         shadow_chain_slots[i].forward_channel = -1;
@@ -668,6 +679,148 @@ void shadow_master_fx_unload_all(void) {
     for (int i = 0; i < MASTER_FX_SLOTS; i++) {
         shadow_master_fx_slot_unload(i);
     }
+}
+
+/* ============================================================================
+ * Send FX Load / Unload
+ * ============================================================================ */
+
+void shadow_send_fx_slot_unload(int bus, int slot) {
+    if (bus < 0 || bus >= SEND_BUS_COUNT) return;
+    if (slot < 0 || slot >= SEND_FX_SLOTS) return;
+    master_fx_slot_t *s = &shadow_send_fx_slots[bus][slot];
+
+    if (s->instance && s->api && s->api->destroy_instance) {
+        s->api->destroy_instance(s->instance);
+    }
+    s->instance = NULL;
+    s->api = NULL;
+    s->on_midi = NULL;
+    if (s->handle) {
+        dlclose(s->handle);
+        s->handle = NULL;
+    }
+    s->module_path[0] = '\0';
+    s->module_id[0] = '\0';
+    s->bypassed = 0;
+    capture_clear(&s->capture);
+}
+
+void shadow_send_fx_unload_all(void) {
+    for (int b = 0; b < SEND_BUS_COUNT; b++) {
+        for (int i = 0; i < SEND_FX_SLOTS; i++) {
+            shadow_send_fx_slot_unload(b, i);
+        }
+    }
+}
+
+int shadow_send_fx_slot_load(int bus, int slot, const char *dsp_path) {
+    if (bus < 0 || bus >= SEND_BUS_COUNT) return -1;
+    if (slot < 0 || slot >= SEND_FX_SLOTS) return -1;
+    master_fx_slot_t *s = &shadow_send_fx_slots[bus][slot];
+
+    if (!dsp_path || !dsp_path[0]) {
+        shadow_send_fx_slot_unload(bus, slot);
+        return 0;
+    }
+
+    if (strcmp(s->module_path, dsp_path) == 0 && s->instance) {
+        return 0;
+    }
+
+    shadow_send_fx_slot_unload(bus, slot);
+
+    s->handle = dlopen(dsp_path, RTLD_NOW | RTLD_LOCAL);
+    if (!s->handle) {
+        fprintf(stderr, "Send FX[%d][%d]: failed to load %s: %s\n", bus, slot, dsp_path, dlerror());
+        return -1;
+    }
+
+    audio_fx_init_v2_fn init_fn = (audio_fx_init_v2_fn)dlsym(s->handle, AUDIO_FX_INIT_V2_SYMBOL);
+    if (!init_fn) {
+        fprintf(stderr, "Send FX[%d][%d]: %s not found in %s\n", bus, slot, AUDIO_FX_INIT_V2_SYMBOL, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        return -1;
+    }
+
+    s->api = init_fn(&shadow_host_api);
+    if (!s->api || !s->api->create_instance) {
+        fprintf(stderr, "Send FX[%d][%d]: init failed for %s\n", bus, slot, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        s->api = NULL;
+        return -1;
+    }
+
+    char module_dir[256];
+    strncpy(module_dir, dsp_path, sizeof(module_dir) - 1);
+    module_dir[sizeof(module_dir) - 1] = '\0';
+    char *last_slash = strrchr(module_dir, '/');
+    if (last_slash) *last_slash = '\0';
+
+    s->instance = s->api->create_instance(module_dir, NULL);
+    if (!s->instance) {
+        fprintf(stderr, "Send FX[%d][%d]: create_instance failed for %s\n", bus, slot, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        s->api = NULL;
+        return -1;
+    }
+
+    strncpy(s->module_path, dsp_path, sizeof(s->module_path) - 1);
+    s->module_path[sizeof(s->module_path) - 1] = '\0';
+
+    const char *id_start = strrchr(module_dir, '/');
+    if (id_start) {
+        strncpy(s->module_id, id_start + 1, sizeof(s->module_id) - 1);
+    } else {
+        strncpy(s->module_id, module_dir, sizeof(s->module_id) - 1);
+    }
+    s->module_id[sizeof(s->module_id) - 1] = '\0';
+
+    s->chain_params_cached = 0;
+    s->chain_params_cache[0] = '\0';
+
+    char module_json_path[512];
+    snprintf(module_json_path, sizeof(module_json_path), "%s/module.json", module_dir);
+    FILE *f = fopen(module_json_path, "r");
+    if (f) {
+        fseek(f, 0, SEEK_END);
+        long size = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        if (size > 0 && size < 65536) {
+            char *json = malloc(size + 1);
+            if (json) {
+                size_t nread = fread(json, 1, size, f);
+                json[nread] = '\0';
+                const char *chain_params = strstr(json, "\"chain_params\"");
+                if (chain_params) {
+                    const char *arr_start = strchr(chain_params, '[');
+                    if (arr_start) {
+                        int depth = 1;
+                        const char *arr_end = arr_start + 1;
+                        while (*arr_end && depth > 0) {
+                            if (*arr_end == '[') depth++;
+                            else if (*arr_end == ']') depth--;
+                            arr_end++;
+                        }
+                        int len = (int)(arr_end - arr_start);
+                        if (len > 0 && len < (int)sizeof(s->chain_params_cache) - 1) {
+                            memcpy(s->chain_params_cache, arr_start, len);
+                            s->chain_params_cache[len] = '\0';
+                            s->chain_params_cached = 1;
+                        }
+                    }
+                }
+                free(json);
+            }
+        }
+        fclose(f);
+    }
+
+    fprintf(stderr, "Send FX[%d][%d]: loaded %s\n", bus, slot, s->module_id);
+    return 0;
 }
 
 int shadow_master_fx_slot_load(int slot, const char *dsp_path) {
@@ -1341,6 +1494,9 @@ int shadow_inprocess_load_chain(void) {
     }
 
     shadow_inprocess_ready = 1;
+
+
+
     if (host.startup_modwheel_countdown) {
         *host.startup_modwheel_countdown = host.startup_modwheel_reset_frames;
     }
@@ -1570,6 +1726,20 @@ int shadow_handle_slot_param_set(int slot, const char *key, const char *value) {
         shadow_ui_state_update_slot(slot);
         return 1;
     }
+    if (strcmp(key, "slot:send_a") == 0) {
+        float lvl = atof(value);
+        if (lvl < 0.0f) lvl = 0.0f;
+        if (lvl > 1.0f) lvl = 1.0f;
+        shadow_chain_slots[slot].send_a = lvl;
+        return 1;
+    }
+    if (strcmp(key, "slot:send_b") == 0) {
+        float lvl = atof(value);
+        if (lvl < 0.0f) lvl = 0.0f;
+        if (lvl > 1.0f) lvl = 1.0f;
+        shadow_chain_slots[slot].send_b = lvl;
+        return 1;
+    }
     if (strcmp(key, "slot:muted") == 0) {
         shadow_apply_mute(slot, atoi(value));
         return 1;
@@ -1622,6 +1792,12 @@ int shadow_handle_slot_param_set(int slot, const char *key, const char *value) {
 int shadow_handle_slot_param_get(int slot, const char *key, char *buf, int buf_len) {
     if (strcmp(key, "slot:volume") == 0) {
         return snprintf(buf, buf_len, "%.2f", shadow_chain_slots[slot].volume);
+    }
+    if (strcmp(key, "slot:send_a") == 0) {
+        return snprintf(buf, buf_len, "%.2f", shadow_chain_slots[slot].send_a);
+    }
+    if (strcmp(key, "slot:send_b") == 0) {
+        return snprintf(buf, buf_len, "%.2f", shadow_chain_slots[slot].send_b);
     }
     if (strcmp(key, "slot:muted") == 0) {
         return snprintf(buf, buf_len, "%d", shadow_chain_slots[slot].muted);
@@ -1687,6 +1863,50 @@ void shadow_direct_set_param(uint8_t slot, const char *key, const char *value) {
         }
         /* Unrecognized master_fx:* keys (lfo*, specials): don't misroute to the
          * chain-slot plugin below — leave for the shadow_param path. */
+        return;
+    }
+
+    /* Handle send FX params: send_fx:a:fx1:param or send_fx:b:fx2:module */
+    if (strncmp(key, "send_fx:", 8) == 0) {
+        const char *rest = key + 8;
+        int bus = -1;
+        if (rest[0] == 'a' && rest[1] == ':') { bus = 0; rest += 2; }
+        else if (rest[0] == 'b' && rest[1] == ':') { bus = 1; rest += 2; }
+        if (bus < 0) return;
+
+        /* Bus-level params (no fxN prefix) */
+        if (strcmp(rest, "return_level") == 0) {
+            float lv = (value && value[0]) ? atof(value) : 1.0f;
+            if (lv < 0.0f) lv = 0.0f;
+            shadow_send_return_level[bus] = lv;
+            if (host.on_param_changed) host.on_param_changed(slot, key, value);
+            return;
+        }
+        if (strcmp(rest, "to_b") == 0) {
+            float lv = (value && value[0]) ? atof(value) : 0.0f;
+            if (lv < 0.0f) lv = 0.0f;
+            if (lv > 1.0f) lv = 1.0f;
+            if (bus == 0) shadow_send_a_to_b_level = lv;
+            if (host.on_param_changed) host.on_param_changed(slot, key, value);
+            return;
+        }
+
+        int sfx_slot = -1;
+        if      (strncmp(rest, "fx1:", 4) == 0) { sfx_slot = 0; rest += 4; }
+        else if (strncmp(rest, "fx2:", 4) == 0) { sfx_slot = 1; rest += 4; }
+        else if (strncmp(rest, "fx3:", 4) == 0) { sfx_slot = 2; rest += 4; }
+        else if (strncmp(rest, "fx4:", 4) == 0) { sfx_slot = 3; rest += 4; }
+        if (sfx_slot < 0) return;
+
+        master_fx_slot_t *sfx = &shadow_send_fx_slots[bus][sfx_slot];
+        if (strcmp(rest, "module") == 0) {
+            shadow_send_fx_slot_load(bus, sfx_slot, value);
+        } else if (strcmp(rest, "bypassed") == 0) {
+            sfx->bypassed = (value[0] && atoi(value)) ? 1 : 0;
+        } else if (sfx->api && sfx->instance && sfx->api->set_param) {
+            sfx->api->set_param(sfx->instance, rest, value);
+        }
+        if (host.on_param_changed) host.on_param_changed(slot, key, value);
         return;
     }
 
@@ -2618,6 +2838,212 @@ void shadow_inprocess_handle_param_request(void) {
         } else {
             shadow_param->error = 6;
             shadow_param->result_len = -1;
+        }
+        shadow_param_publish_response(req_id);
+        return;
+    }
+
+    /* Handle send FX params: send_fx:a:fx1:param or send_fx:b:fx2:module */
+    if (strncmp(shadow_param->key, "send_fx:", 8) == 0) {
+        const char *rest = shadow_param->key + 8;
+        int bus = -1;
+        if (rest[0] == 'a' && rest[1] == ':') { bus = 0; rest += 2; }
+        else if (rest[0] == 'b' && rest[1] == ':') { bus = 1; rest += 2; }
+        if (bus < 0) {
+            shadow_param->error = 1;
+            shadow_param->result_len = -1;
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        /* Bus-level params (no fxN prefix) */
+        if (strcmp(rest, "return_level") == 0) {
+            if (req_type == 1) {  /* SET */
+                float lv = (shadow_param->value[0]) ? atof(shadow_param->value) : 1.0f;
+                if (lv < 0.0f) lv = 0.0f;
+                shadow_send_return_level[bus] = lv;
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else if (req_type == 2) {  /* GET */
+                snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%.3f",
+                         shadow_send_return_level[bus]);
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            }
+            shadow_param_publish_response(req_id);
+            return;
+        }
+        if (strcmp(rest, "to_b") == 0) {
+            if (req_type == 1) {  /* SET */
+                float lv = (shadow_param->value[0]) ? atof(shadow_param->value) : 0.0f;
+                if (lv < 0.0f) lv = 0.0f;
+                if (lv > 1.0f) lv = 1.0f;
+                if (bus == 0) shadow_send_a_to_b_level = lv;
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else if (req_type == 2) {  /* GET */
+                snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%.3f",
+                         shadow_send_a_to_b_level);
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            }
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        int sfx_slot = -1;
+        if      (strncmp(rest, "fx1:", 4) == 0) { sfx_slot = 0; rest += 4; }
+        else if (strncmp(rest, "fx2:", 4) == 0) { sfx_slot = 1; rest += 4; }
+        else if (strncmp(rest, "fx3:", 4) == 0) { sfx_slot = 2; rest += 4; }
+        else if (strncmp(rest, "fx4:", 4) == 0) { sfx_slot = 3; rest += 4; }
+        if (sfx_slot < 0) {
+            shadow_param->error = 1;
+            shadow_param->result_len = -1;
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        master_fx_slot_t *sfx = &shadow_send_fx_slots[bus][sfx_slot];
+
+        if (req_type == 1) {  /* SET */
+            if (strcmp(rest, "module") == 0) {
+                int result = shadow_send_fx_slot_load(bus, sfx_slot, shadow_param->value);
+                shadow_param->error = (result == 0) ? 0 : 7;
+                shadow_param->result_len = 0;
+            } else if (strcmp(rest, "bypassed") == 0) {
+                sfx->bypassed = (shadow_param->value[0] && atoi(shadow_param->value)) ? 1 : 0;
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else if (sfx->api && sfx->instance && sfx->api->set_param) {
+                sfx->api->set_param(sfx->instance, rest, shadow_param->value);
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else {
+                shadow_param->error = 9;
+                shadow_param->result_len = -1;
+            }
+        } else if (req_type == 2) {  /* GET */
+            if (strcmp(rest, "module") == 0) {
+                strncpy(shadow_param->value, sfx->module_path, SHADOW_PARAM_VALUE_LEN - 1);
+                shadow_param->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            } else if (strcmp(rest, "name") == 0) {
+                strncpy(shadow_param->value, sfx->module_id, SHADOW_PARAM_VALUE_LEN - 1);
+                shadow_param->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            } else if (strcmp(rest, "bypassed") == 0) {
+                snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%d", sfx->bypassed ? 1 : 0);
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            } else if (strcmp(rest, "chain_params") == 0) {
+                if (sfx->api && sfx->instance && sfx->api->get_param) {
+                    int len = sfx->api->get_param(sfx->instance, "chain_params",
+                                                   shadow_param->value, SHADOW_PARAM_VALUE_LEN);
+                    if (len > 2) {
+                        shadow_param->error = 0;
+                        shadow_param->result_len = len;
+                        shadow_param_publish_response(req_id);
+                        return;
+                    }
+                }
+                if (sfx->chain_params_cached && sfx->chain_params_cache[0]) {
+                    int len = strlen(sfx->chain_params_cache);
+                    if (len < SHADOW_PARAM_VALUE_LEN - 1) {
+                        memcpy(shadow_param->value, sfx->chain_params_cache, len + 1);
+                        shadow_param->error = 0;
+                        shadow_param->result_len = len;
+                        shadow_param_publish_response(req_id);
+                        return;
+                    }
+                }
+                shadow_param->value[0] = '['; shadow_param->value[1] = ']'; shadow_param->value[2] = '\0';
+                shadow_param->error = 0;
+                shadow_param->result_len = 2;
+            } else if (strcmp(rest, "ui_hierarchy") == 0) {
+                if (sfx->api && sfx->instance && sfx->api->get_param) {
+                    int len = sfx->api->get_param(sfx->instance, "ui_hierarchy",
+                                                   shadow_param->value, SHADOW_PARAM_VALUE_LEN);
+                    if (len > 2) {
+                        shadow_param->error = 0;
+                        shadow_param->result_len = len;
+                        shadow_param_publish_response(req_id);
+                        return;
+                    }
+                }
+                /* Fall back to reading ui_hierarchy from module.json (mirrors the
+                 * master_fx handler). Modules like dissolver don't expose
+                 * ui_hierarchy via live get_param but declare it in module.json;
+                 * without this fallback the send param editor can't open them. */
+                {
+                    char module_dir[256];
+                    strncpy(module_dir, sfx->module_path, sizeof(module_dir) - 1);
+                    module_dir[sizeof(module_dir) - 1] = '\0';
+                    char *last_slash = strrchr(module_dir, '/');
+                    if (last_slash) *last_slash = '\0';
+
+                    char json_path[512];
+                    snprintf(json_path, sizeof(json_path), "%s/module.json", module_dir);
+
+                    FILE *f = fopen(json_path, "r");
+                    if (f) {
+                        fseek(f, 0, SEEK_END);
+                        long size = ftell(f);
+                        fseek(f, 0, SEEK_SET);
+                        if (size > 0 && size < 65536) {
+                            char *json = malloc(size + 1);
+                            if (json) {
+                                size_t nread = fread(json, 1, size, f);
+                                json[nread] = '\0';
+
+                                const char *ui_hier = strstr(json, "\"ui_hierarchy\"");
+                                if (ui_hier) {
+                                    const char *obj_start = strchr(ui_hier + 14, '{');
+                                    if (obj_start) {
+                                        int depth = 1;
+                                        const char *obj_end = obj_start + 1;
+                                        while (*obj_end && depth > 0) {
+                                            if (*obj_end == '{') depth++;
+                                            else if (*obj_end == '}') depth--;
+                                            obj_end++;
+                                        }
+                                        int hlen = (int)(obj_end - obj_start);
+                                        if (hlen > 0 && hlen < SHADOW_PARAM_VALUE_LEN - 1) {
+                                            memcpy(shadow_param->value, obj_start, hlen);
+                                            shadow_param->value[hlen] = '\0';
+                                            shadow_param->error = 0;
+                                            shadow_param->result_len = hlen;
+                                            free(json);
+                                            fclose(f);
+                                            shadow_param_publish_response(req_id);
+                                            return;
+                                        }
+                                    }
+                                }
+                                free(json);
+                            }
+                        }
+                        fclose(f);
+                    }
+                }
+                shadow_param->value[0] = '\0';
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else if (sfx->api && sfx->instance && sfx->api->get_param) {
+                int len = sfx->api->get_param(sfx->instance, rest,
+                                               shadow_param->value, SHADOW_PARAM_VALUE_LEN);
+                if (len >= 0) {
+                    shadow_param->error = 0;
+                    shadow_param->result_len = len;
+                } else {
+                    shadow_param->error = 10;
+                    shadow_param->result_len = -1;
+                }
+            } else {
+                shadow_param->error = 11;
+                shadow_param->result_len = -1;
+            }
         }
         shadow_param_publish_response(req_id);
         return;

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -19,6 +19,8 @@
  * ============================================================================ */
 
 #define MASTER_FX_SLOTS 4
+#define SEND_BUS_COUNT 2
+#define SEND_FX_SLOTS  4
 #define SHADOW_CHAIN_MODULE_DIR "/data/UserData/schwung/modules/chain"
 #define SHADOW_CHAIN_DSP_PATH "/data/UserData/schwung/modules/chain/dsp.so"
 
@@ -111,6 +113,14 @@ extern int shadow_inprocess_ready;
 /* Master FX slots */
 extern master_fx_slot_t shadow_master_fx_slots[MASTER_FX_SLOTS];
 
+/* Send FX slots — 2 buses (A, B) × 3 FX slots each */
+extern master_fx_slot_t shadow_send_fx_slots[SEND_BUS_COUNT][SEND_FX_SLOTS];
+
+/* Per-bus send return level (0..1+, default 1.0) applied to the bus's
+ * FX-processed return before it is summed into the mix. */
+extern float shadow_send_return_level[SEND_BUS_COUNT];
+extern float shadow_send_a_to_b_level;
+
 /* Master FX LFOs */
 #define MASTER_FX_LFO_COUNT 2
 extern lfo_state_t shadow_master_fx_lfos[MASTER_FX_LFO_COUNT];
@@ -166,6 +176,18 @@ static inline int shadow_master_fx_chain_active(void) {
     return 0;
 }
 
+/* Check if any send FX slot is active on a bus */
+static inline int shadow_send_fx_bus_active(int bus) {
+    if (bus < 0 || bus >= SEND_BUS_COUNT) return 0;
+    for (int fx = 0; fx < SEND_FX_SLOTS; fx++) {
+        master_fx_slot_t *s = &shadow_send_fx_slots[bus][fx];
+        if (s->instance && s->api && s->api->process_block) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* ============================================================================
  * Public functions
  * ============================================================================ */
@@ -213,6 +235,11 @@ int shadow_master_fx_slot_load_with_config(int slot, const char *dsp_path,
 int shadow_master_fx_load(const char *dsp_path);
 void shadow_master_fx_unload(void);
 void shadow_master_fx_forward_midi(const uint8_t *msg, int len, int source);
+
+/* --- Send FX --- */
+void shadow_send_fx_slot_unload(int bus, int slot);
+void shadow_send_fx_unload_all(void);
+int shadow_send_fx_slot_load(int bus, int slot, const char *dsp_path);
 
 /* --- Capture loading --- */
 void shadow_slot_load_capture(int slot, int patch_index);

--- a/src/host/shadow_chain_types.h
+++ b/src/host/shadow_chain_types.h
@@ -35,6 +35,8 @@ typedef struct shadow_chain_slot_t {
     int patch_index;
     int active;
     float volume;           /* 0.0 to 1.0, user-set level (never modified by mute/solo) */
+    float send_a;           /* 0.0 to 1.0, post-fader send level to Send A bus */
+    float send_b;           /* 0.0 to 1.0, post-fader send level to Send B bus */
     int muted;              /* 1 = muted (Mute+Track or Move speakerOn sync) */
     int soloed;             /* 1 = soloed (Shift+Mute+Track or Move solo-cue sync) */
     int forward_channel;    /* -2 = passthrough, -1 = auto, 0-15 = forward MIDI to this channel */

--- a/src/host/shadow_state.c
+++ b/src/host/shadow_state.c
@@ -16,6 +16,11 @@ static void (*host_log)(const char *msg);
 static shadow_chain_slot_t *host_chain_slots;
 static int *host_solo_count;
 
+/* Per-bus send return level — defined in shadow_chain_mgmt.c (same .so).
+ * Declared locally to avoid pulling in the full chain-mgmt header. */
+extern float shadow_send_return_level[2];
+extern float shadow_send_a_to_b_level;
+
 /* Fix file ownership after writing as root */
 static void chown_to_ableton(const char *path) {
     struct passwd *pw = getpwnam("ableton");
@@ -202,6 +207,16 @@ void shadow_save_state(void)
             host_chain_slots[1].volume,
             host_chain_slots[2].volume,
             host_chain_slots[3].volume);
+    fprintf(f, "  \"slot_send_a\": [%.3f, %.3f, %.3f, %.3f],\n",
+            host_chain_slots[0].send_a,
+            host_chain_slots[1].send_a,
+            host_chain_slots[2].send_a,
+            host_chain_slots[3].send_a);
+    fprintf(f, "  \"slot_send_b\": [%.3f, %.3f, %.3f, %.3f],\n",
+            host_chain_slots[0].send_b,
+            host_chain_slots[1].send_b,
+            host_chain_slots[2].send_b,
+            host_chain_slots[3].send_b);
     fprintf(f, "  \"slot_channels\": [%d, %d, %d, %d],\n",
             host_chain_slots[0].channel,
             host_chain_slots[1].channel,
@@ -222,11 +237,15 @@ void shadow_save_state(void)
             host_chain_slots[1].muted,
             host_chain_slots[2].muted,
             host_chain_slots[3].muted);
-    fprintf(f, "  \"slot_soloed\": [%d, %d, %d, %d]\n",
+    fprintf(f, "  \"slot_soloed\": [%d, %d, %d, %d],\n",
             host_chain_slots[0].soloed,
             host_chain_slots[1].soloed,
             host_chain_slots[2].soloed,
             host_chain_slots[3].soloed);
+    fprintf(f, "  \"send_return_level\": [%.3f, %.3f],\n",
+            shadow_send_return_level[0],
+            shadow_send_return_level[1]);
+    fprintf(f, "  \"send_a_to_b\": %.3f\n", shadow_send_a_to_b_level);
     fprintf(f, "}\n");
     fclose(f);
     chown_to_ableton(SHADOW_CONFIG_PATH);
@@ -298,6 +317,74 @@ void shadow_load_state(void)
                          v0, v1, v2, v3);
                 if (host_log) host_log(msg);
             }
+        }
+    }
+
+    /* Parse slot_send_a array */
+    const char *sa_key = "\"slot_send_a\":";
+    char *sa_pos = strstr(json, sa_key);
+    if (sa_pos) {
+        sa_pos = strchr(sa_pos, '[');
+        if (sa_pos) {
+            float s0, s1, s2, s3;
+            if (sscanf(sa_pos, "[%f, %f, %f, %f]", &s0, &s1, &s2, &s3) == 4) {
+                if (s0 < 0.0f) s0 = 0.0f; if (s0 > 1.0f) s0 = 1.0f;
+                if (s1 < 0.0f) s1 = 0.0f; if (s1 > 1.0f) s1 = 1.0f;
+                if (s2 < 0.0f) s2 = 0.0f; if (s2 > 1.0f) s2 = 1.0f;
+                if (s3 < 0.0f) s3 = 0.0f; if (s3 > 1.0f) s3 = 1.0f;
+                host_chain_slots[0].send_a = s0;
+                host_chain_slots[1].send_a = s1;
+                host_chain_slots[2].send_a = s2;
+                host_chain_slots[3].send_a = s3;
+            }
+        }
+    }
+
+    /* Parse slot_send_b array */
+    const char *sb_key = "\"slot_send_b\":";
+    char *sb_pos = strstr(json, sb_key);
+    if (sb_pos) {
+        sb_pos = strchr(sb_pos, '[');
+        if (sb_pos) {
+            float s0, s1, s2, s3;
+            if (sscanf(sb_pos, "[%f, %f, %f, %f]", &s0, &s1, &s2, &s3) == 4) {
+                if (s0 < 0.0f) s0 = 0.0f; if (s0 > 1.0f) s0 = 1.0f;
+                if (s1 < 0.0f) s1 = 0.0f; if (s1 > 1.0f) s1 = 1.0f;
+                if (s2 < 0.0f) s2 = 0.0f; if (s2 > 1.0f) s2 = 1.0f;
+                if (s3 < 0.0f) s3 = 0.0f; if (s3 > 1.0f) s3 = 1.0f;
+                host_chain_slots[0].send_b = s0;
+                host_chain_slots[1].send_b = s1;
+                host_chain_slots[2].send_b = s2;
+                host_chain_slots[3].send_b = s3;
+            }
+        }
+    }
+
+    /* Parse send_return_level array (missing key → leaves the 1.0 default) */
+    const char *srl_key = "\"send_return_level\":";
+    char *srl_pos = strstr(json, srl_key);
+    if (srl_pos) {
+        srl_pos = strchr(srl_pos, '[');
+        if (srl_pos) {
+            float r0, r1;
+            if (sscanf(srl_pos, "[%f, %f]", &r0, &r1) == 2) {
+                if (r0 < 0.0f) r0 = 0.0f;
+                if (r1 < 0.0f) r1 = 0.0f;
+                shadow_send_return_level[0] = r0;
+                shadow_send_return_level[1] = r1;
+            }
+        }
+    }
+
+    /* Parse send_a_to_b (missing key → leaves the 0.0 default) */
+    const char *satb_key = "\"send_a_to_b\":";
+    char *satb_pos = strstr(json, satb_key);
+    if (satb_pos) {
+        float v;
+        if (sscanf(satb_pos + strlen(satb_key), " %f", &v) == 1) {
+            if (v < 0.0f) v = 0.0f;
+            if (v > 1.0f) v = 1.0f;
+            shadow_send_a_to_b_level = v;
         }
     }
 

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1915,8 +1915,15 @@ static int json_get_section_bounds(const char *json, const char *section_key,
     const char *pos = strstr(json, search);
     if (!pos) return -1;
 
-    const char *start = strchr(pos, '{');
-    if (!start) return -1;
+    /* Only treat this key as a section if its VALUE is an object. Skipping
+     * straight to the next '{' would, for a null-valued key (e.g. an empty FX
+     * slot: "fx2":null), grab a LATER slot's object — corrupting saved presets
+     * with gaps (filled/empty/filled). Anchor on the key's colon + value. */
+    const char *colon = strchr(pos + strlen(search), ':');
+    if (!colon) return -1;
+    const char *start = colon + 1;
+    while (*start == ' ' || *start == '\t' || *start == '\n' || *start == '\r') start++;
+    if (*start != '{') return -1;   /* value is null / not an object */
 
     int depth = 0;
     const char *end = NULL;
@@ -6049,6 +6056,203 @@ static int load_master_preset_json(int index, char *buf, int buf_len) {
 
 /* ========== End Master Preset Functions ========== */
 
+/* ========== Send Preset Functions ========== */
+/* Single SHARED send preset store: Send A and Send B draw from one list/dir
+ * (presets are interchangeable between buses). Wraps up to 4 FX slots under a
+ * "send_fx" root. JS editor is descriptor-driven (presetJsonRoot "send_fx"). */
+
+#define PRESETS_SEND_DIR "/data/UserData/schwung/presets_send"
+#define MAX_SEND_PRESETS 64
+
+static char send_preset_names[MAX_SEND_PRESETS][MAX_NAME_LEN];
+static char send_preset_paths[MAX_SEND_PRESETS][MAX_PATH_LEN];
+static int send_preset_count = 0;
+
+static void ensure_presets_send_dir(void) {
+    struct stat st = {0};
+    if (stat(PRESETS_SEND_DIR, &st) == -1) {
+        mkdir(PRESETS_SEND_DIR, 0755);
+    }
+}
+
+static void scan_send_presets(void) {
+    send_preset_count = 0;
+    memset(send_preset_names, 0, sizeof(send_preset_names));
+    memset(send_preset_paths, 0, sizeof(send_preset_paths));
+    ensure_presets_send_dir();
+
+    DIR *dir = opendir(PRESETS_SEND_DIR);
+    if (!dir) return;
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL && send_preset_count < MAX_SEND_PRESETS) {
+        if (entry->d_type != DT_REG) continue;
+
+        const char *name = entry->d_name;
+        size_t len = strlen(name);
+        if (len < 6 || strcmp(name + len - 5, ".json") != 0) continue;
+
+        size_t name_len = len - 5;
+        if (name_len >= MAX_NAME_LEN) name_len = MAX_NAME_LEN - 1;
+
+        char path[MAX_PATH_LEN];
+        snprintf(path, sizeof(path), "%s/%s", PRESETS_SEND_DIR, name);
+
+        int idx = send_preset_count;
+        FILE *f = fopen(path, "r");
+        if (f) {
+            char json_buf[2048];
+            size_t read_len = fread(json_buf, 1, sizeof(json_buf) - 1, f);
+            json_buf[read_len] = '\0';
+            fclose(f);
+
+            char parsed_name[MAX_NAME_LEN] = {0};
+            if (json_get_string(json_buf, "name", parsed_name, sizeof(parsed_name)) == 0) {
+                strncpy(send_preset_names[idx], parsed_name, MAX_NAME_LEN - 1);
+                send_preset_names[idx][MAX_NAME_LEN - 1] = '\0';
+            } else {
+                memcpy(send_preset_names[idx], name, name_len);
+                send_preset_names[idx][name_len] = '\0';
+            }
+        } else {
+            memcpy(send_preset_names[idx], name, name_len);
+            send_preset_names[idx][name_len] = '\0';
+        }
+
+        strncpy(send_preset_paths[idx], path, MAX_PATH_LEN - 1);
+        send_preset_paths[idx][MAX_PATH_LEN - 1] = '\0';
+        send_preset_count++;
+    }
+    closedir(dir);
+}
+
+/* Build the wrapped preset JSON for 3 send slots. Buffers sized to match the
+ * master path so large modules round-trip under the 64KB GET limit. */
+static void build_send_preset_json(char *out, int out_len,
+                                   const char *name, const char *json_str) {
+    char fx1[8192], fx2[8192], fx3[8192], fx4[8192];
+    extract_fx_section(json_str, "fx1", fx1, sizeof(fx1));
+    extract_fx_section(json_str, "fx2", fx2, sizeof(fx2));
+    extract_fx_section(json_str, "fx3", fx3, sizeof(fx3));
+    extract_fx_section(json_str, "fx4", fx4, sizeof(fx4));
+    snprintf(out, out_len,
+        "{\n"
+        "    \"name\": \"%s\",\n"
+        "    \"version\": 1,\n"
+        "    \"send_fx\": {\n"
+        "        \"fx1\": %s,\n"
+        "        \"fx2\": %s,\n"
+        "        \"fx3\": %s,\n"
+        "        \"fx4\": %s\n"
+        "    }\n"
+        "}\n",
+        name, fx1, fx2, fx3, fx4);
+}
+
+static int save_send_preset(const char *json_str) {
+    ensure_presets_send_dir();
+
+    char name[MAX_NAME_LEN] = "Send FX";
+    json_get_string(json_str, "custom_name", name, sizeof(name));
+
+    char filename[MAX_NAME_LEN];
+    sanitize_filename(filename, sizeof(filename), name);
+
+    char path[MAX_PATH_LEN];
+    snprintf(path, sizeof(path), "%s/%s.json", PRESETS_SEND_DIR, filename);
+
+    char final_json[40960];
+    build_send_preset_json(final_json, sizeof(final_json), name, json_str);
+
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Failed to save send preset: %s", path);
+        chain_log(msg);
+        return -1;
+    }
+    fputs(final_json, f);
+    fclose(f);
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Saved send preset: %s", name);
+        chain_log(msg);
+    }
+    scan_send_presets();
+    return 0;
+}
+
+static int update_send_preset(int index, const char *json_str) {
+    if (index < 0 || index >= send_preset_count) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Invalid send preset index: %d", index);
+        chain_log(msg);
+        return -1;
+    }
+
+    char name[MAX_NAME_LEN];
+    if (json_get_string(json_str, "custom_name", name, sizeof(name)) != 0) {
+        strncpy(name, send_preset_names[index], sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
+    }
+
+    char final_json[40960];
+    build_send_preset_json(final_json, sizeof(final_json), name, json_str);
+
+    FILE *f = fopen(send_preset_paths[index], "w");
+    if (!f) return -1;
+    fputs(final_json, f);
+    fclose(f);
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Updated send preset: %s", name);
+        chain_log(msg);
+    }
+    scan_send_presets();
+    return 0;
+}
+
+static int delete_send_preset(int index) {
+    if (index < 0 || index >= send_preset_count) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Invalid send preset index: %d", index);
+        chain_log(msg);
+        return -1;
+    }
+    if (remove(send_preset_paths[index]) != 0) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Failed to delete send preset: %s", send_preset_paths[index]);
+        chain_log(msg);
+        return -1;
+    }
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Deleted send preset: %s", send_preset_names[index]);
+        chain_log(msg);
+    }
+    scan_send_presets();
+    return 0;
+}
+
+static int load_send_preset_json(int index, char *buf, int buf_len) {
+    if (index < 0 || index >= send_preset_count) { buf[0] = '\0'; return 0; }
+
+    FILE *f = fopen(send_preset_paths[index], "r");
+    if (!f) { buf[0] = '\0'; return 0; }
+
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len <= 0) { fclose(f); buf[0] = '\0'; return 0; }
+    if (len >= buf_len) len = buf_len - 1;
+    size_t nr = fread(buf, 1, len, f);
+    buf[nr] = '\0';
+    fclose(f);
+    return (int)nr;
+}
+
+/* ========== End Send Preset Functions ========== */
+
 /* Debug logging helper for parsing */
 static void parse_debug_log(const char *msg) {
     struct stat st;
@@ -7422,6 +7626,17 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             update_master_preset(index, colon + 1);
         }
     }
+    /* Send preset commands (shared list across both buses) */
+    else if (strcmp(key, "save_send_preset") == 0) {
+        save_send_preset(val);
+    }
+    else if (strcmp(key, "delete_send_preset") == 0) {
+        delete_send_preset(atoi(val));
+    }
+    else if (strcmp(key, "update_send_preset") == 0) {
+        const char *colon = strchr(val, ':');
+        if (colon) update_send_preset(atoi(val), colon + 1);
+    }
     else if (strncmp(key, "synth:", 6) == 0) {
         const char *subkey = key + 6;
         /* Intercept module change to swap synth dynamically */
@@ -8162,6 +8377,20 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     if (strncmp(key, "master_preset_json_", 19) == 0) {
         int idx = atoi(key + 19);
         return load_master_preset_json(idx, buf, buf_len);
+    }
+    /* Send preset queries (shared list across both buses) */
+    if (strcmp(key, "send_preset_count") == 0) {
+        scan_send_presets();
+        return snprintf(buf, buf_len, "%d", send_preset_count);
+    }
+    if (strncmp(key, "send_preset_name_", 17) == 0) {
+        int idx = atoi(key + 17);
+        if (idx >= 0 && idx < send_preset_count)
+            return snprintf(buf, buf_len, "%s", send_preset_names[idx]);
+        return -1;
+    }
+    if (strncmp(key, "send_preset_json_", 17) == 0) {
+        return load_send_preset_json(atoi(key + 17), buf, buf_len);
     }
     if (strcmp(key, "fx_count") == 0) {
         return snprintf(buf, buf_len, "%d", inst->fx_count);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1905,6 +1905,19 @@ static void shadow_latency_delay_apply(int slot, const int16_t *in,
     shadow_latency_delay_wp[slot] = wp + FRAMES_PER_BLOCK * 2;
 }
 
+static inline void accumulate_sends(int slot, const int16_t *fx_buf,
+                                    int32_t send_accum[][FRAMES_PER_BLOCK * 2]) {
+    float vol = shadow_effective_volume(slot) * shadow_chain_slots[slot].fade.gain;
+    float levels[SEND_BUS_COUNT] = { shadow_chain_slots[slot].send_a,
+                                     shadow_chain_slots[slot].send_b };
+    for (int b = 0; b < SEND_BUS_COUNT; b++) {
+        if (levels[b] < 0.001f) continue;
+        float g = levels[b] * vol;
+        for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++)
+            send_accum[b][i] += (int32_t)lroundf((float)fx_buf[i] * g);
+    }
+}
+
 static void shadow_inprocess_mix_from_buffer(void) {
     if (!shadow_inprocess_ready || !global_mmap_addr) return;
     if (!shadow_deferred_dsp_valid) return;  /* No buffer to mix yet */
@@ -1923,8 +1936,9 @@ static void shadow_inprocess_mix_from_buffer(void) {
     int any_la_rebuild = (link_audio.enabled && link_audio_routing_enabled &&
                          shadow_chain_process_fx && shim_move_channel_count() >= 4);
     int any_capture = (sampler_source == SAMPLER_SOURCE_RESAMPLE);
+    int any_send_fx = (shadow_send_fx_bus_active(0) || shadow_send_fx_bus_active(1));
 
-    if (!any_slot && !any_mfx && !any_overtake_dsp && !any_la_rebuild && !any_capture) {
+    if (!any_slot && !any_mfx && !any_overtake_dsp && !any_la_rebuild && !any_capture && !any_send_fx) {
         int16_t *mailbox_audio = (int16_t *)(global_mmap_addr + AUDIO_OUT_OFFSET);
         memcpy(native_bridge_move_component, mailbox_audio, AUDIO_BUFFER_SIZE);
         memset(native_bridge_me_component, 0, AUDIO_BUFFER_SIZE);
@@ -1950,6 +1964,10 @@ static void shadow_inprocess_mix_from_buffer(void) {
      * me_full without reading it; Task 4 will consume it. */
     int32_t me_unity[FRAMES_PER_BLOCK * 2];
     memset(me_unity, 0, sizeof(me_unity));
+
+    /* Send bus accumulators — post-fader taps summed across all slots */
+    int32_t send_accum[SEND_BUS_COUNT][FRAMES_PER_BLOCK * 2];
+    memset(send_accum, 0, sizeof(send_accum));
 
     /* Zero-and-rebuild approach: if Link Audio provides per-track data,
      * zero the mailbox and rebuild from Link Audio, applying FX per-slot.
@@ -2266,6 +2284,7 @@ static void shadow_inprocess_mix_from_buffer(void) {
                     me_unity[i] += (int32_t)lroundf((float)fx_buf[i] * vol);
                     if (i & 1) shadow_fade_advance(s);
                 }
+                accumulate_sends(s, fx_buf, send_accum);
             } else if (have_move_track) {
                 /* Inactive slot: pass Link Audio through at unity level.
                  * Master volume is applied after capture at the end. */
@@ -2323,6 +2342,7 @@ skip_la_rebuild:
                     me_unity[i] += contrib;
                     if (i & 1) shadow_fade_advance(s);
                 }
+                accumulate_sends(s, fx_buf, send_accum);
             } else if (shadow_slot_deferred_valid[s]) {
                 /* Fallback: FX not deferred — run inline (legacy path) */
                 if (shadow_slot_fx_idle[s] && shadow_slot_idle[s]) continue;
@@ -2368,6 +2388,54 @@ skip_la_rebuild:
                     me_unity[i] += contrib;
                     if (i & 1) shadow_fade_advance(s);
                 }
+                accumulate_sends(s, fx_buf, send_accum);
+            }
+        }
+    }
+
+    /* Process send FX buses and sum returns into ME bus (before Master FX) */
+    for (int b = 0; b < SEND_BUS_COUNT; b++) {
+        if (!shadow_send_fx_bus_active(b)) continue;
+
+        int16_t send_buf[FRAMES_PER_BLOCK * 2];
+        for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+            int32_t v = send_accum[b][i];
+            if (v > 32767) v = 32767;
+            if (v < -32768) v = -32768;
+            send_buf[i] = (int16_t)v;
+        }
+
+        for (int fx = 0; fx < SEND_FX_SLOTS; fx++) {
+            master_fx_slot_t *sf = &shadow_send_fx_slots[b][fx];
+            if (!(sf->instance && sf->api && sf->api->process_block)) continue;
+            if (sf->bypassed) continue;
+            sf->api->process_block(sf->instance, send_buf, FRAMES_PER_BLOCK);
+        }
+
+        /* Per-bus return level scales the FX-processed return into the mix. */
+        float rl = shadow_send_return_level[b];
+        for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+            int32_t sv = (int32_t)lroundf((float)send_buf[i] * rl);
+            me_full[i] += sv;
+            me_unity[i] += sv;
+        }
+        if (rebuild_from_la) {
+            for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+                int32_t sv = (int32_t)lroundf((float)send_buf[i] * rl);
+                int32_t mixed = (int32_t)mailbox_audio[i] + sv;
+                if (mixed > 32767) mixed = 32767;
+                if (mixed < -32768) mixed = -32768;
+                mailbox_audio[i] = (int16_t)mixed;
+            }
+        }
+
+        /* Send A -> Send B (post-fader): tap A's return-scaled output into B's
+         * accumulator, so A->B follows A's return level (like Ableton return-track
+         * sends). Bus order (A=0 then B=1) is feedback-safe: B is built/processed
+         * after this and A is already done, so B can never reach back into A. */
+        if (b == 0 && shadow_send_a_to_b_level > 0.0f) {
+            for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+                send_accum[1][i] += (int32_t)lroundf((float)send_buf[i] * rl * shadow_send_a_to_b_level);
             }
         }
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -4265,10 +4265,14 @@ function loadChainConfigFromDir(dir) {
             if (typeof s.forward_channel === "number") setSlotParamWithTimeout(i, "slot:forward_channel", String(s.forward_channel), 500);
             if (typeof s.muted === "number") setSlotParamWithTimeout(i, "slot:muted", String(s.muted), 500);
             if (typeof s.soloed === "number") setSlotParamWithTimeout(i, "slot:soloed", String(s.soloed), 500);
-            /* Per-slot send levels (missing in configs written before sends existed
-             * → leave the shim default of 0, i.e. no send). */
-            if (typeof s.send_a === "number") setSlotParamWithTimeout(i, "slot:send_a", String(s.send_a), 500);
-            if (typeof s.send_b === "number") setSlotParamWithTimeout(i, "slot:send_b", String(s.send_b), 500);
+            /* Per-slot send levels: ALWAYS write — saved value if present, else
+             * default 0 (no send). The shim's slot sends are global and NOT reset
+             * per set, so skipping a missing field (configs written before sends
+             * existed) leaves them stale from the prior set, like receive_channel. */
+            const sa = (typeof s.send_a === "number") ? s.send_a : 0;
+            setSlotParamWithTimeout(i, "slot:send_a", String(sa), 500);
+            const sb = (typeof s.send_b === "number") ? s.send_b : 0;
+            setSlotParamWithTimeout(i, "slot:send_b", String(sb), 500);
         }
         debugLog("SET_CHANGED: loaded chain config from " + path);
     } catch (e) {
@@ -6797,22 +6801,24 @@ function restoreSendFxFromFiles() {
                 if (data.bypassed) shadow_set_param(0, key + ":bypassed", "1");
             }
         }
-        /* Restore per-set send return levels (missing → leave shim default) +
-         * Send A->B routing level. send_a_to_b is ALWAYS pushed (default 0) so a set
-         * without it resets to off instead of inheriting the previous set's value. */
+        /* Restore per-set send return levels + Send A->B routing level. ALL are
+         * ALWAYS pushed (return level default 1.0 unity, Send A->B default 0) so a
+         * set with no meta file — or one predating these fields — resets to the
+         * defaults instead of inheriting the previous set's values. The shim params
+         * are global and not reset per set. */
         try {
-            let atobVal = 0;  /* per-set default: 0% (off) */
+            let rlA = 1.0, rlB = 1.0, atobVal = 0;
             const raw = host_read_file(activeSlotStateDir + "/send_fx_meta.json");
             if (raw) {
                 const meta = JSON.parse(raw);
                 if (meta && meta.return_level) {
-                    if (typeof meta.return_level.a === "number")
-                        shadow_set_param(0, "send_fx:a:return_level", meta.return_level.a.toFixed(3));
-                    if (typeof meta.return_level.b === "number")
-                        shadow_set_param(0, "send_fx:b:return_level", meta.return_level.b.toFixed(3));
+                    if (typeof meta.return_level.a === "number") rlA = meta.return_level.a;
+                    if (typeof meta.return_level.b === "number") rlB = meta.return_level.b;
                 }
                 if (meta && typeof meta.send_a_to_b === "number") atobVal = meta.send_a_to_b;
             }
+            shadow_set_param(0, "send_fx:a:return_level", rlA.toFixed(3));
+            shadow_set_param(0, "send_fx:b:return_level", rlB.toFixed(3));
             shadow_set_param(0, "send_fx:a:to_b", atobVal.toFixed(3));
         } catch (e) {}
     } catch (e) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -312,7 +312,8 @@ const VIEWS = {
     LFO_EDIT: "lfoedit",                      // LFO sub-menu editor
     ANALYTICS_PROMPT: "analyticsprompt",       // First-run analytics opt-out prompt
     LFO_TARGET_COMPONENT: "lfotargetcomp",    // LFO target picker step 1: component
-    LFO_TARGET_PARAM: "lfotargetparam"        // LFO target picker step 2: parameter
+    LFO_TARGET_PARAM: "lfotargetparam",       // LFO target picker step 2: parameter
+    FX_BUS_PICKER: "fxbuspicker"              // Pick Master FX / Send A / Send B
 };
 
 /* Special action key for swap module option */
@@ -855,6 +856,84 @@ const MASTER_FX_CHAIN_COMPONENTS = [
     { key: "settings", label: "Settings", position: 4, paramPrefix: "" }
 ];
 
+/* ---- FX bus descriptors -------------------------------------------------- *
+ * One editor (shadow_ui_master_fx.mjs + the helpers below) serves Master FX,
+ * Send A, and Send B. The FX bus picker selects the active bus before entry.
+ * Sends are identical to Master minus LFOs (hasLfo:false), with a different
+ * param prefix and (Phase 2 checkpoint B) their own per-bus presets + return
+ * level. Descriptors are plain object literals (QuickJS: no member-expression
+ * keys). Only one editor is open at a time, so the editor's transient state
+ * (selection, masterFxConfig, preset list) is shared and repopulated per bus
+ * on entry — no per-bus copies needed. */
+const SEND_FX_COMPONENTS_A = [
+    { key: "fx1", label: "FX 1", position: 0, paramPrefix: "send_fx:a:fx1:" },
+    { key: "fx2", label: "FX 2", position: 1, paramPrefix: "send_fx:a:fx2:" },
+    { key: "fx3", label: "FX 3", position: 2, paramPrefix: "send_fx:a:fx3:" },
+    { key: "fx4", label: "FX 4", position: 3, paramPrefix: "send_fx:a:fx4:" },
+    { key: "settings", label: "Settings", position: 4, paramPrefix: "" }
+];
+const SEND_FX_COMPONENTS_B = [
+    { key: "fx1", label: "FX 1", position: 0, paramPrefix: "send_fx:b:fx1:" },
+    { key: "fx2", label: "FX 2", position: 1, paramPrefix: "send_fx:b:fx2:" },
+    { key: "fx3", label: "FX 3", position: 2, paramPrefix: "send_fx:b:fx3:" },
+    { key: "fx4", label: "FX 4", position: 3, paramPrefix: "send_fx:b:fx4:" },
+    { key: "settings", label: "Settings", position: 4, paramPrefix: "" }
+];
+const FX_BUS = {
+    master: {
+        id: "master", title: "Master FX", paramPrefix: "master_fx:",
+        slotCount: 4, hasLfo: true, persistConfig: true,
+        volumeKey: "master_fx:volume", components: MASTER_FX_CHAIN_COMPONENTS,
+        presetPickerTitle: "Master Presets",
+        presetJsonRoot: "master_fx",
+        presetCountKey: "master_preset_count",
+        presetNamePrefix: "master_preset_name_",
+        presetJsonPrefix: "master_preset_json_",
+        presetSaveKey: "save_master_preset",
+        presetUpdateKey: "update_master_preset",
+        presetDeleteKey: "delete_master_preset"
+    },
+    sendA: {
+        id: "sendA", title: "Send FX A", paramPrefix: "send_fx:a:",
+        slotCount: 4, hasLfo: false, persistConfig: false,
+        volumeKey: "send_fx:a:return_level", components: SEND_FX_COMPONENTS_A,
+        presetPickerTitle: "Send Presets",
+        presetJsonRoot: "send_fx",
+        presetCountKey: "send_preset_count",
+        presetNamePrefix: "send_preset_name_",
+        presetJsonPrefix: "send_preset_json_",
+        presetSaveKey: "save_send_preset",
+        presetUpdateKey: "update_send_preset",
+        presetDeleteKey: "delete_send_preset"
+    },
+    sendB: {
+        id: "sendB", title: "Send FX B", paramPrefix: "send_fx:b:",
+        slotCount: 4, hasLfo: false, persistConfig: false,
+        volumeKey: "send_fx:b:return_level", components: SEND_FX_COMPONENTS_B,
+        presetPickerTitle: "Send Presets",
+        presetJsonRoot: "send_fx",
+        presetCountKey: "send_preset_count",
+        presetNamePrefix: "send_preset_name_",
+        presetJsonPrefix: "send_preset_json_",
+        presetSaveKey: "save_send_preset",
+        presetUpdateKey: "update_send_preset",
+        presetDeleteKey: "delete_send_preset"
+    }
+};
+/* Active bus for the FX editor. Set by the FX bus picker; persists through the
+ * editor's sub-views. Defaults to master. */
+let activeFxBus = FX_BUS.master;
+/* Per-bus loaded-preset name, so the preset name/overwrite target doesn't leak
+ * across buses (e.g. a master "SPECTRA" preselecting overwrite on a send save).
+ * Stashed/restored on bus switch in enterFxBusEditor. */
+let fxBusPresetName = { master: "", sendA: "", sendB: "" };
+
+/* Build a slot param key for the active bus, e.g.
+ *   master: master_fx:fx2:bypassed   sendA: send_fx:a:fx2:bypassed */
+function fxBusSlotKey(slotIdx, leaf) {
+    return activeFxBus.paramPrefix + "fx" + (slotIdx + 1) + ":" + leaf;
+}
+
 /* Master FX chain editing state */
 let masterFxConfig = {
     fx1: { module: "" },
@@ -871,7 +950,7 @@ const MASTER_FX_SETTINGS_ITEMS_BASE = [
     { key: "master_volume", label: "Volume", type: "float", min: 0, max: 1, step: 0.05 },
     { key: "mfx_lfo1", label: "LFO 1", type: "action" },
     { key: "mfx_lfo2", label: "LFO 2", type: "action" },
-    { key: "save", label: "[Save MFX Preset]", type: "action" },
+    { key: "save", label: "[Save Preset]", type: "action" },
     { key: "save_as", label: "[Save As]", type: "action" },
     { key: "delete", label: "[Delete]", type: "action" }
 ];
@@ -1142,14 +1221,24 @@ function parseResampleBridgeMode(raw) {
 
 /* Get dynamic settings items based on whether preset is loaded */
 function getMasterFxSettingsItems() {
-    if (currentMasterPresetName) {
-        /* Existing preset: show all items */
-        return MASTER_FX_SETTINGS_ITEMS_BASE;
+    /* Sends have no LFOs (hasLfo:false) — drop the dead LFO menu items so they
+     * aren't presented as editable. Master (hasLfo:true) keeps them. */
+    let base = MASTER_FX_SETTINGS_ITEMS_BASE;
+    if (!activeFxBus.hasLfo) {
+        base = base.filter(item => item.key !== "mfx_lfo1" && item.key !== "mfx_lfo2");
     }
     /* New/unsaved: hide Save As and Delete */
-    return MASTER_FX_SETTINGS_ITEMS_BASE.filter(item =>
-        item.key !== "save_as" && item.key !== "delete"
-    );
+    if (!currentMasterPresetName) {
+        base = base.filter(item => item.key !== "save_as" && item.key !== "delete");
+    }
+    /* Send A gets a "-> Send B" routing level, shown right after its return level
+     * (the "Volume" item). param-backed → rendered as % and adjusted generically. */
+    if (activeFxBus.id === "sendA") {
+        base = base.slice();
+        base.splice(1, 0, { key: "send_a_to_b", label: "-> Send B", type: "float",
+                            min: 0, max: 1, step: 0.05, param: "send_fx:a:to_b" });
+    }
+    return base;
 }
 
 let selectedMasterFxSetting = 0;
@@ -1602,6 +1691,8 @@ function processAllUpdates() {
 const CHAIN_SETTINGS_ITEMS = [
     { key: "knobs", label: "Knobs", type: "action" },  // Opens knob assignment editor
     { key: "slot:volume", label: "Volume", type: "float", min: 0, max: 4, step: 0.05 },
+    { key: "slot:send_a", label: "Send A", type: "float", min: 0, max: 1, step: 0.05 },
+    { key: "slot:send_b", label: "Send B", type: "float", min: 0, max: 1, step: 0.05 },
     { key: "slot:muted", label: "Muted", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:soloed", label: "Soloed", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:receive_channel", label: "Recv Ch", type: "int", min: 0, max: 16, step: 1 },
@@ -1617,6 +1708,7 @@ const CHAIN_SETTINGS_ITEMS = [
 ];
 let selectedChainSetting = 0;
 let editingChainSettingValue = false;
+let hierEditorReturnView = null;
 
 /* LFO editor state — generic context drives slot or MFX LFO */
 let lfoCtx = null;  /* Active LFO context: { lfoIdx, getParam, setParam, getTargetComponents, getTargetParams, title, returnView, returnAnnounce } */
@@ -3881,9 +3973,8 @@ function getComponentHierarchy(slot, componentKey) {
 
 /* Fetch chain_params metadata from a Master FX slot */
 function getMasterFxChainParams(fxSlot) {
-    if (fxSlot < 0 || fxSlot >= 4) return [];
-    const fxKey = `fx${fxSlot + 1}`;
-    const key = `master_fx:${fxKey}:chain_params`;
+    if (fxSlot < 0 || fxSlot >= activeFxBus.slotCount) return [];
+    const key = fxBusSlotKey(fxSlot, "chain_params");
     const json = shadow_get_param(0, key);
     if (!json) return [];
     try {
@@ -3895,9 +3986,8 @@ function getMasterFxChainParams(fxSlot) {
 
 /* Fetch ui_hierarchy from a Master FX slot */
 function getMasterFxHierarchy(fxSlot) {
-    if (fxSlot < 0 || fxSlot >= 4) return null;
-    const fxKey = `fx${fxSlot + 1}`;
-    const key = `master_fx:${fxKey}:ui_hierarchy`;
+    if (fxSlot < 0 || fxSlot >= activeFxBus.slotCount) return null;
+    const key = fxBusSlotKey(fxSlot, "ui_hierarchy");
     const json = shadow_get_param(0, key);
     if (!json) return null;
     try {
@@ -3992,7 +4082,9 @@ function saveChainConfigToDir(dir) {
             const fwd = parseInt(getSlotParam(i, "slot:forward_channel") || "-1");
             const muted = parseInt(getSlotParam(i, "slot:muted") || "0");
             const soloed = parseInt(getSlotParam(i, "slot:soloed") || "0");
-            cfgSlots.push({ name: slots[i] ? slots[i].name : "", channel: ch, volume: vol, forward_channel: fwd, muted: muted, soloed: soloed });
+            const sendA = parseFloat(getSlotParam(i, "slot:send_a") || "0");
+            const sendB = parseFloat(getSlotParam(i, "slot:send_b") || "0");
+            cfgSlots.push({ name: slots[i] ? slots[i].name : "", channel: ch, volume: vol, forward_channel: fwd, muted: muted, soloed: soloed, send_a: sendA, send_b: sendB });
         }
         host_write_file(path, JSON.stringify({ slots: cfgSlots }, null, 2) + "\n");
     } catch (e) {
@@ -4173,6 +4265,10 @@ function loadChainConfigFromDir(dir) {
             if (typeof s.forward_channel === "number") setSlotParamWithTimeout(i, "slot:forward_channel", String(s.forward_channel), 500);
             if (typeof s.muted === "number") setSlotParamWithTimeout(i, "slot:muted", String(s.muted), 500);
             if (typeof s.soloed === "number") setSlotParamWithTimeout(i, "slot:soloed", String(s.soloed), 500);
+            /* Per-slot send levels (missing in configs written before sends existed
+             * → leave the shim default of 0, i.e. no send). */
+            if (typeof s.send_a === "number") setSlotParamWithTimeout(i, "slot:send_a", String(s.send_a), 500);
+            if (typeof s.send_b === "number") setSlotParamWithTimeout(i, "slot:send_b", String(s.send_b), 500);
         }
         debugLog("SET_CHANGED: loaded chain config from " + path);
     } catch (e) {
@@ -4656,12 +4752,12 @@ function announceSavePreview(name, selectedIndex, full = true) {
 
 function loadMasterPresetList() {
     masterPresets = [];
-    const countStr = getSlotParam(0, "master_preset_count");
+    const countStr = getSlotParam(0, activeFxBus.presetCountKey);
     const count = parseInt(countStr, 10) || 0;
     debugLog(`loadMasterPresetList: countStr='${countStr}' count=${count}`);
 
     for (let i = 0; i < count; i++) {
-        const name = getSlotParam(0, `master_preset_name_${i}`) || `Preset ${i + 1}`;
+        const name = getSlotParam(0, `${activeFxBus.presetNamePrefix}${i}`) || `Preset ${i + 1}`;
         /* Hex dump first 20 chars to debug garbage issue */
         let hex = "";
         for (let j = 0; j < Math.min(20, name.length); j++) {
@@ -4679,7 +4775,7 @@ function enterMasterPresetPicker() {
     needsRedraw = true;
 
     /* Announce menu title + initial selection */
-    announce("Master Presets, [New]");
+    announce(`${activeFxBus.presetPickerTitle}, [New]`);
 }
 
 function exitMasterPresetPicker() {
@@ -4700,7 +4796,7 @@ function findMasterPresetByName(name) {
 
 function generateMasterPresetName() {
     const parts = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         const key = `fx${i + 1}`;
         const moduleId = masterFxConfig[key]?.module;
         if (moduleId) {
@@ -4708,12 +4804,12 @@ function generateMasterPresetName() {
             parts.push(abbrev);
         }
     }
-    return parts.length > 0 ? parts.join(" + ") : "Master FX";
+    return parts.length > 0 ? parts.join(" + ") : activeFxBus.title;
 }
 
 function clearMasterFx() {
-    /* Clear all 4 FX slots */
-    for (let i = 0; i < 4; i++) {
+    /* Clear all FX slots on the active bus */
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         setMasterFxSlotModule(i, "");
         masterFxConfig[`fx${i + 1}`].module = "";
     }
@@ -4724,15 +4820,15 @@ function clearMasterFx() {
 
 function loadMasterPreset(index, presetName) {
     /* Get preset JSON from DSP */
-    const json = getSlotParam(0, `master_preset_json_${index}`);
+    const json = getSlotParam(0, `${activeFxBus.presetJsonPrefix}${index}`);
     if (!json) return;
 
     try {
         const preset = JSON.parse(json);
-        const fx = preset.master_fx || {};
+        const fx = preset[activeFxBus.presetJsonRoot] || {};
 
         /* Apply each FX slot */
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < activeFxBus.slotCount; i++) {
             const key = `fx${i + 1}`;
             const fxConfig = fx[key];
             if (fxConfig && fxConfig.type) {
@@ -4745,12 +4841,12 @@ function loadMasterPreset(index, presetName) {
                     /* Restore plugin_id first (CLAP sub-plugin selection) */
                     if (fxConfig.params && typeof shadow_set_param === "function") {
                         if (fxConfig.params.plugin_id) {
-                            shadow_set_param(0, `master_fx:${key}:plugin_id`, fxConfig.params.plugin_id);
+                            shadow_set_param(0, fxBusSlotKey(i, "plugin_id"), fxConfig.params.plugin_id);
                         }
                         /* Restore remaining params */
                         for (const [pkey, pval] of Object.entries(fxConfig.params)) {
                             if (pkey !== "plugin_id") {
-                                shadow_set_param(0, `master_fx:${key}:${pkey}`, String(pval));
+                                shadow_set_param(0, fxBusSlotKey(i, pkey), String(pval));
                             }
                         }
                     }
@@ -4765,17 +4861,19 @@ function loadMasterPreset(index, presetName) {
             }
         }
 
-        /* Restore master FX LFO configs */
-        for (let li = 1; li <= 2; li++) {
-            const lfoConfig = preset["lfo" + li];
-            if (lfoConfig && typeof shadow_set_param === "function") {
-                restoreMasterFxLfo(li, lfoConfig);
-            } else {
-                /* No LFO in preset — disable */
-                if (typeof shadow_set_param === "function") {
-                    shadow_set_param(0, "master_fx:lfo" + li + ":enabled", "0");
-                    shadow_set_param(0, "master_fx:lfo" + li + ":target", "");
-                    shadow_set_param(0, "master_fx:lfo" + li + ":target_param", "");
+        /* Restore FX LFO configs (master bus only — sends have no LFOs) */
+        if (activeFxBus.hasLfo) {
+            for (let li = 1; li <= 2; li++) {
+                const lfoConfig = preset["lfo" + li];
+                if (lfoConfig && typeof shadow_set_param === "function") {
+                    restoreMasterFxLfo(li, lfoConfig);
+                } else {
+                    /* No LFO in preset — disable */
+                    if (typeof shadow_set_param === "function") {
+                        shadow_set_param(0, "master_fx:lfo" + li + ":enabled", "0");
+                        shadow_set_param(0, "master_fx:lfo" + li + ":target", "");
+                        shadow_set_param(0, "master_fx:lfo" + li + ":target_param", "");
+                    }
                 }
             }
         }
@@ -4793,15 +4891,15 @@ function loadMasterPreset(index, presetName) {
 
 /* Build JSON for saving master preset */
 function buildMasterPresetJson(name) {
-    const preset = {
-        custom_name: name,
-        fx1: null,
-        fx2: null,
-        fx3: null,
-        fx4: null
-    };
+    /* Flat fx1..N + custom_name. The DSP side re-roots this under the bus's
+     * presetJsonRoot ("master_fx" / "send_fx") on save; loadMasterPreset reads
+     * it back from that root. */
+    const preset = { custom_name: name };
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
+        preset[`fx${i + 1}`] = null;
+    }
 
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         const key = `fx${i + 1}`;
         const moduleId = masterFxConfig[key]?.module;
         if (moduleId) {
@@ -4813,7 +4911,7 @@ function buildMasterPresetJson(name) {
             /* Capture plugin_id (for CLAP sub-plugin selection) */
             if (typeof shadow_get_param === "function") {
                 try {
-                    const pluginId = shadow_get_param(0, `master_fx:${key}:plugin_id`);
+                    const pluginId = shadow_get_param(0, fxBusSlotKey(i, "plugin_id"));
                     if (pluginId) {
                         slotPreset.params["plugin_id"] = pluginId;
                     }
@@ -4824,7 +4922,7 @@ function buildMasterPresetJson(name) {
                     const chainParams = getMasterFxChainParams(i);
                     if (chainParams && chainParams.length > 0) {
                         for (const p of chainParams) {
-                            const val = shadow_get_param(0, `master_fx:${key}:${p.key}`);
+                            const val = shadow_get_param(0, fxBusSlotKey(i, p.key));
                             if (val !== null && val !== undefined && val !== "") {
                                 slotPreset.params[p.key] = val;
                             }
@@ -4837,14 +4935,16 @@ function buildMasterPresetJson(name) {
         }
     }
 
-    /* Include master FX LFO configs */
-    for (let li = 1; li <= 2; li++) {
-        try {
-            const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
-            if (configJson) {
-                preset["lfo" + li] = JSON.parse(configJson);
-            }
-        } catch (e) {}
+    /* Include FX LFO configs (master bus only) */
+    if (activeFxBus.hasLfo) {
+        for (let li = 1; li <= 2; li++) {
+            try {
+                const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
+                if (configJson) {
+                    preset["lfo" + li] = JSON.parse(configJson);
+                }
+            } catch (e) {}
+        }
     }
 
     return JSON.stringify(preset);
@@ -4856,10 +4956,10 @@ function doSaveMasterPreset(name) {
 
     if (masterOverwriteTargetIndex >= 0) {
         /* Overwriting existing preset */
-        setSlotParam(0, "update_master_preset", masterOverwriteTargetIndex + ":" + json);
+        setSlotParam(0, activeFxBus.presetUpdateKey, masterOverwriteTargetIndex + ":" + json);
     } else {
         /* Creating new preset */
-        setSlotParam(0, "save_master_preset", json);
+        setSlotParam(0, activeFxBus.presetSaveKey, json);
     }
 
     currentMasterPresetName = name;
@@ -5085,7 +5185,7 @@ function handleMasterFxSettingsAction(key) {
 function doDeleteMasterPreset() {
     const index = findMasterPresetByName(currentMasterPresetName);
     if (index >= 0) {
-        setSlotParam(0, "delete_master_preset", String(index));
+        setSlotParam(0, activeFxBus.presetDeleteKey, String(index));
     }
 
     /* Clear current preset and return to picker */
@@ -5951,15 +6051,15 @@ function handleGlobalSettingsAction(key) {
 
 /* Load master FX chain configuration from DSP */
 function loadMasterFxChainConfig() {
-    masterFxConfig = {
-        fx1: { module: "" },
-        fx2: { module: "" },
-        fx3: { module: "" },
-        fx4: { module: "" }
-    };
+    /* Rebuild masterFxConfig for the active bus's slot count. Shared object,
+     * repopulated on each editor entry (only one bus open at a time). */
+    masterFxConfig = {};
+    for (let i = 1; i <= activeFxBus.slotCount; i++) {
+        masterFxConfig[`fx${i}`] = { module: "" };
+    }
 
     /* Query each slot's module from DSP */
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= activeFxBus.slotCount; i++) {
         const key = `fx${i}`;
         const moduleId = getMasterFxSlotModule(i - 1);
         masterFxConfig[key].module = moduleId || "";
@@ -5970,30 +6070,30 @@ function loadMasterFxChainConfig() {
 function getMasterFxParam(slotIndex, key) {
     if (typeof shadow_get_param !== "function") return "";
     try {
-        return shadow_get_param(0, `master_fx:fx${slotIndex + 1}:${key}`) || "";
+        return shadow_get_param(0, fxBusSlotKey(slotIndex, key)) || "";
     } catch (e) {
         return "";
     }
 }
 
-/* Get module ID loaded in a master FX slot (0-3) */
+/* Get module ID loaded in an FX slot (0-based) on the active bus */
 function getMasterFxSlotModule(slotIndex) {
     if (typeof shadow_get_param !== "function") return "";
     try {
         /* Query returns the module_id from the shim */
-        return shadow_get_param(0, `master_fx:fx${slotIndex + 1}:name`) || "";
+        return shadow_get_param(0, fxBusSlotKey(slotIndex, "name")) || "";
     } catch (e) {
         return "";
     }
 }
 
-/* Set module for a master FX slot */
+/* Set module for an FX slot on the active bus */
 function setMasterFxSlotModule(slotIndex, dspPath) {
     if (typeof shadow_set_param !== "function") return false;
     /* Clear warning tracking for this slot so warning can show again for new module */
     warningShownForMasterFx.delete(slotIndex);
     try {
-        return shadow_set_param(0, `master_fx:fx${slotIndex + 1}:module`, dspPath || "");
+        return shadow_set_param(0, fxBusSlotKey(slotIndex, "module"), dspPath || "");
     } catch (e) {
         return false;
     }
@@ -6001,7 +6101,7 @@ function setMasterFxSlotModule(slotIndex, dspPath) {
 
 /* Enter module selection for a Master FX slot */
 function enterMasterFxModuleSelect(componentIndex) {
-    const comp = MASTER_FX_CHAIN_COMPONENTS[componentIndex];
+    const comp = activeFxBus.components[componentIndex];
     if (!comp || comp.key === "settings") return;
 
     /* Set selection index to current module if any */
@@ -6019,7 +6119,7 @@ function enterMasterFxModuleSelect(componentIndex) {
 
 /* Apply module selection for Master FX slot */
 function applyMasterFxModuleSelection() {
-    const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+    const comp = activeFxBus.components[selectedMasterFxComponent];
     if (!comp || comp.key === "settings") return;
 
     const selected = MASTER_FX_OPTIONS[selectedMasterFxModuleIndex];
@@ -6044,6 +6144,9 @@ function applyMasterFxModuleSelection() {
 
 /* Save master FX chain configuration */
 function saveMasterFxChainConfig() {
+    /* Master-bus-only below. Send buses persist via per-set send_fx_<bus>_<slot>
+     * files instead — dispatch to that path so in-editor send edits are saved. */
+    if (!activeFxBus.persistConfig) { saveSendFxChainConfig(); return; }
     /* The shim persists the state, but we also save to shadow config */
     try {
         const configPath = "/data/UserData/schwung/shadow_config.json";
@@ -6573,6 +6676,147 @@ function loadMasterFxChainFromConfig() {
         }
     } catch (e) {
         /* Ignore errors */
+    }
+}
+
+/* ====================================================================
+ * Send FX per-set persistence (auto-recall across set changes).
+ *
+ * Unlike Master FX (whose modules are restored C-side by the shim at
+ * boot from master_fx_<n>.json), the send-FX shim has no boot/set-change
+ * restore. So we persist each send slot to per-set files
+ * (send_fx_<bus>_<slot>.json + send_fx_meta.json for return levels) and
+ * re-load them in JS on set change and init. Format mirrors the master
+ * slot files: { id, path, state | params, bypassed }.
+ * These use explicit send_fx:* keys (NOT activeFxBus), so they are safe
+ * to call regardless of which FX editor is open. JS-only — the Phase-1
+ * send GET/SET handlers already forward :state/:chain_params/params. */
+const SEND_FX_BUSES = ["a", "b"];
+const SEND_FX_SLOTS_JS = 4;
+
+function saveSendFxChainConfig() {
+    if (typeof shadow_get_param !== "function") return;
+    try {
+        for (let bi = 0; bi < SEND_FX_BUSES.length; bi++) {
+            const busId = SEND_FX_BUSES[bi];
+            for (let s = 0; s < SEND_FX_SLOTS_JS; s++) {
+                const key = "send_fx:" + busId + ":fx" + (s + 1);
+                const filePath = activeSlotStateDir + "/send_fx_" + busId + "_" + s + ".json";
+                const moduleId = shadow_get_param(0, key + ":name") || "";
+                if (!moduleId) { host_write_file(filePath, "{}\n"); continue; }
+
+                const opt = (MASTER_FX_OPTIONS || []).find(o => o.id === moduleId);
+                const slotConfig = {
+                    id: moduleId,
+                    module_id: moduleId,
+                    path: opt?.dspPath || "",
+                    bypassed: parseInt(shadow_get_param(0, key + ":bypassed") || "0", 10) === 1 ? 1 : 0
+                };
+
+                /* Prefer opaque module state; fall back to chain_params snapshot. */
+                let stateObj = null;
+                let paramsObj = null;
+                try {
+                    const stateJson = shadow_get_param(0, key + ":state");
+                    if (stateJson) {
+                        try { stateObj = JSON.parse(stateJson); } catch (pe) { stateObj = stateJson; }
+                        slotConfig.state = stateObj;
+                    }
+                } catch (e) {}
+                if (!stateObj) {
+                    try {
+                        paramsObj = {};
+                        const pid = shadow_get_param(0, key + ":plugin_id");
+                        if (pid) paramsObj["plugin_id"] = pid;
+                        const cpJson = shadow_get_param(0, key + ":chain_params");
+                        if (cpJson) {
+                            const cps = JSON.parse(cpJson);
+                            if (Array.isArray(cps)) {
+                                for (const p of cps) {
+                                    if (p && p.key) {
+                                        const v = shadow_get_param(0, key + ":" + p.key);
+                                        if (v !== null && v !== undefined && v !== "") paramsObj[p.key] = v;
+                                    }
+                                }
+                            }
+                        }
+                        if (Object.keys(paramsObj).length > 0) slotConfig.params = paramsObj;
+                    } catch (e) {}
+                }
+
+                /* Guard against clobbering a good file with empty data when the
+                 * shim stalls mid-query (mirrors the master snapshotOk guard). */
+                const realParamKeys = paramsObj ? Object.keys(paramsObj).filter(k => k !== "plugin_id") : [];
+                if (!stateObj && realParamKeys.length === 0) {
+                    /* Got a module id but no usable state — keep any existing file. */
+                    continue;
+                }
+                host_write_file(filePath, JSON.stringify(slotConfig, null, 2) + "\n");
+            }
+        }
+        /* Per-set send return levels + Send A->B routing level. */
+        const rlA = parseFloat(shadow_get_param(0, "send_fx:a:return_level") || "1.0");
+        const rlB = parseFloat(shadow_get_param(0, "send_fx:b:return_level") || "1.0");
+        const atob = parseFloat(shadow_get_param(0, "send_fx:a:to_b") || "0");
+        host_write_file(activeSlotStateDir + "/send_fx_meta.json",
+            JSON.stringify({ return_level: { a: isNaN(rlA) ? 1.0 : rlA, b: isNaN(rlB) ? 1.0 : rlB },
+                             send_a_to_b: isNaN(atob) ? 0 : atob }, null, 2) + "\n");
+    } catch (e) {
+        debugLog("saveSendFxChainConfig error: " + e);
+    }
+}
+
+function restoreSendFxFromFiles() {
+    if (typeof shadow_set_param !== "function") return;
+    try {
+        for (let bi = 0; bi < SEND_FX_BUSES.length; bi++) {
+            const busId = SEND_FX_BUSES[bi];
+            for (let s = 0; s < SEND_FX_SLOTS_JS; s++) {
+                const key = "send_fx:" + busId + ":fx" + (s + 1);
+                const filePath = activeSlotStateDir + "/send_fx_" + busId + "_" + s + ".json";
+                let data = null;
+                try {
+                    const raw = host_read_file(filePath);
+                    if (raw && raw.length > 3) data = JSON.parse(raw);
+                } catch (e) {}
+
+                const dspPath = (data && data.path) ? data.path : "";
+                /* Load (or unload when empty) the module first. */
+                shadow_set_param(0, key + ":module", dspPath);
+                if (!dspPath) continue;
+
+                if (data.state) {
+                    const stateStr = (typeof data.state === "string") ? data.state : JSON.stringify(data.state);
+                    shadow_set_param(0, key + ":state", stateStr);
+                } else if (data.params) {
+                    if (data.params.plugin_id) shadow_set_param(0, key + ":plugin_id", data.params.plugin_id);
+                    for (const [pk, pv] of Object.entries(data.params)) {
+                        if (pk !== "plugin_id") shadow_set_param(0, key + ":" + pk, String(pv));
+                    }
+                }
+                if (data.bypassed) shadow_set_param(0, key + ":bypassed", "1");
+            }
+        }
+        /* Restore per-set send return levels (missing → leave shim default) +
+         * Send A->B routing level. send_a_to_b is ALWAYS pushed (default 0) so a set
+         * without it resets to off instead of inheriting the previous set's value. */
+        try {
+            let atobVal = 0;  /* per-set default: 0% (off) */
+            const raw = host_read_file(activeSlotStateDir + "/send_fx_meta.json");
+            if (raw) {
+                const meta = JSON.parse(raw);
+                if (meta && meta.return_level) {
+                    if (typeof meta.return_level.a === "number")
+                        shadow_set_param(0, "send_fx:a:return_level", meta.return_level.a.toFixed(3));
+                    if (typeof meta.return_level.b === "number")
+                        shadow_set_param(0, "send_fx:b:return_level", meta.return_level.b.toFixed(3));
+                }
+                if (meta && typeof meta.send_a_to_b === "number") atobVal = meta.send_a_to_b;
+            }
+            shadow_set_param(0, "send_fx:a:to_b", atobVal.toFixed(3));
+        } catch (e) {}
+    } catch (e) {
+        debugLog("restoreSendFxFromFiles error: " + e);
     }
 }
 
@@ -7449,6 +7693,10 @@ function getChainSettingValue(slot, setting) {
     if (val === null) return "-";
 
     if (setting.key === "slot:volume") {
+        const pct = Math.round(parseFloat(val) * 100);
+        return `${pct}%`;
+    }
+    if (setting.key === "slot:send_a" || setting.key === "slot:send_b") {
         const pct = Math.round(parseFloat(val) * 100);
         return `${pct}%`;
     }
@@ -8356,6 +8604,67 @@ function enterMasterFxHierarchyEditor(fxSlot) {
     }
 }
 
+function enterSendFxHierarchyEditor(bus, fxSlot) {
+    /* Each send bus has 4 FX slots (SEND_FX_SLOTS_JS); the prior >= 3 cap was a
+     * leftover from the 3-slot era and blocked the 4th slot's param editor. */
+    if (fxSlot < 0 || fxSlot >= SEND_FX_SLOTS_JS) return;
+    const busKey = bus === 0 ? "a" : "b";
+    const busLabel = bus === 0 ? "Send FX A" : "Send FX B";
+    const compKey = `send_fx:${busKey}:fx${fxSlot + 1}`;
+
+    const hierJson = shadow_get_param(0, `${compKey}:ui_hierarchy`);
+    let hierarchy = null;
+    if (hierJson) {
+        try { hierarchy = JSON.parse(hierJson); } catch (e) { /* ignore */ }
+    }
+    if (!hierarchy) return;
+
+    hideOverlay();
+    invalidateKnobContextCache();
+    pendingHierKnobIndex = -1;
+    pendingHierKnobDelta = 0;
+
+    hierEditorSlot = 0;
+    hierEditorComponent = compKey;
+    hierEditorHierarchy = hierarchy;
+    hierEditorLevel = hierarchy.modes ? null : "root";
+    hierEditorPath = [];
+    hierEditorChildIndex = -1;
+    hierEditorChildCount = 0;
+    hierEditorChildLabel = "";
+    hierEditorSelectedIdx = 0;
+    hierEditorEditMode = false;
+    resetHierarchyEditState();
+    /* Treat a send slot as an FX-bus component (same as Master FX), NOT a chain
+     * slot. The param engine's isMasterFx path builds keys as `${component}:key`
+     * (here send_fx:bus:fxN:key) and uses the bus-aware getMasterFx* helpers
+     * (activeFxBus is the send bus during send editing) — so it resolves to
+     * send_fx:* correctly. The isMasterFx=false (chain-slot) path used
+     * getComponentParamPrefix + `${prefix}_module`, which doesn't fit send_fx
+     * keys and left modules like dissolver unable to open their params. */
+    hierEditorIsMasterFx = true;
+    hierEditorMasterFxSlot = fxSlot;
+    resetDynamicParamPickerState();
+
+    hierEditorChainParams = getMasterFxChainParams(fxSlot);
+
+    setupModuleParamShims(0, compKey);
+    loadHierarchyLevel();
+
+    /* Sends now live in the shared generic editor (MASTER_FX view); return there. */
+    hierEditorReturnView = VIEWS.MASTER_FX;
+    setView(VIEWS.HIERARCHY_EDITOR);
+    needsRedraw = true;
+
+    const moduleName = shadow_get_param(0, `${compKey}:name`) || `FX ${fxSlot + 1}`;
+    if (hierEditorParams.length > 0) {
+        const param = hierEditorParams[0];
+        announce(`${busLabel} ${moduleName}, ${param.label || param.key}: ${param.value || ""}`);
+    } else {
+        announce(`${busLabel} ${moduleName}, No parameters`);
+    }
+}
+
 /* Load params and knobs for current hierarchy level */
 function loadHierarchyLevel() {
     if (!hierEditorHierarchy) return;
@@ -8555,7 +8864,12 @@ function exitHierarchyEditor() {
     filepathBrowserParamKey = "";
     resetDynamicParamPickerState();
 
-    view = returnToMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT;
+    if (hierEditorReturnView) {
+        view = hierEditorReturnView;
+        hierEditorReturnView = null;
+    } else {
+        view = returnToMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT;
+    }
     needsRedraw = true;
 }
 
@@ -9059,12 +9373,21 @@ function buildKnobContextForKnob(knobIndex) {
         }
     }
 
-    /* Master FX view with FX slot selected */
-    if (view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
-        const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+    /* FX-bus overview with an FX slot selected: home-screen knobs (71-78) edit
+     * that slot's params for ANY bus (Master / Send A-B / Move FX), using the
+     * bus's own per-component paramPrefix. Previously master-only ("for now");
+     * generalized so every bus behaves like upstream's master — the param engine
+     * (isMasterFx path) + getMasterFx* helpers are already bus-aware via
+     * activeFxBus, so only the component list + key prefixes needed unpinning. */
+    if (view === VIEWS.MASTER_FX &&
+        selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
+        const comp = activeFxBus.components[selectedMasterFxComponent];
         if (comp && comp.key !== "settings") {
+            /* Bus-aware overlay tag (master keeps its compact "MFX"; other buses
+             * show their own title) — replaces the old hardcoded master label. */
+            const busTag = activeFxBus.id === "master" ? "MFX" : (activeFxBus.title || "FX");
             const chainParams = getMasterFxChainParams(selectedMasterFxComponent);
-            const pluginName = shadow_get_param(0, `master_fx:${comp.key}:name`) || "";
+            const pluginName = shadow_get_param(0, comp.paramPrefix + "name") || "";
             const hasModule = pluginName && pluginName.length > 0;
 
             /* No module loaded in this slot */
@@ -9076,7 +9399,7 @@ function buildKnobContextForKnob(knobIndex) {
                     meta: null,
                     pluginName: comp.label,
                     displayName: `Knob ${knobIndex + 1}`,
-                    title: `MFX ${comp.label}`,
+                    title: `${busTag} ${comp.label}`,
                     noModule: true,
                     isMasterFx: true,
                     masterFxSlot: selectedMasterFxComponent
@@ -9096,7 +9419,7 @@ function buildKnobContextForKnob(knobIndex) {
                 }
                 if (levelDef && levelDef.knobs && knobIndex < levelDef.knobs.length) {
                     const key = levelDef.knobs[knobIndex];
-                    const fullKey = `master_fx:${comp.key}:${key}`;
+                    const fullKey = comp.paramPrefix + key;
                     const rawMeta = chainParams.find(p => p.key === key);
                     const meta = normalizeExpandedParamMeta(key, rawMeta);
                     const displayName = meta && meta.name ? meta.name : key.replace(/_/g, " ");
@@ -9107,7 +9430,7 @@ function buildKnobContextForKnob(knobIndex) {
                         meta,
                         pluginName,
                         displayName,
-                        title: `MFX ${pluginName} ${displayName}`,
+                        title: `${busTag} ${pluginName} ${displayName}`,
                         isMasterFx: true,
                         masterFxSlot: selectedMasterFxComponent
                     };
@@ -9127,7 +9450,7 @@ function buildKnobContextForKnob(knobIndex) {
                     meta: normalizeExpandedParamMeta(key, param),
                     pluginName,
                     displayName,
-                    title: `MFX ${pluginName} ${displayName}`,
+                    title: `${busTag} ${pluginName} ${displayName}`,
                     isMasterFx: true,
                     masterFxSlot: selectedMasterFxComponent
                 };
@@ -9141,7 +9464,7 @@ function buildKnobContextForKnob(knobIndex) {
                 meta: null,
                 pluginName,
                 displayName: `Knob ${knobIndex + 1}`,
-                title: `MFX ${pluginName}`,
+                title: `${busTag} ${pluginName}`,
                 noMapping: true,
                 isMasterFx: true,
                 masterFxSlot: selectedMasterFxComponent
@@ -9174,6 +9497,11 @@ function rebuildKnobContextCache() {
  * Uses caching to avoid IPC calls on every CC message
  */
 let cachedKnobContextsMasterFxComp = -1;  /* Track Master FX component for cache */
+let cachedKnobContextsFxBus = "";         /* Track active FX bus id for cache —
+                                           * now that every bus (not just master)
+                                           * uses FX-overview knob contexts, a bus
+                                           * switch with the same view/slot must
+                                           * invalidate or knobs leak across buses. */
 
 function getKnobContext(knobIndex) {
     /* Check if cache is valid */
@@ -9182,6 +9510,7 @@ function getKnobContext(knobIndex) {
     const currentLevel = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorLevel : "";
     const currentChildIndex = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorChildIndex : -1;
     const currentMasterFxComp = (view === VIEWS.MASTER_FX) ? selectedMasterFxComponent : -1;
+    const currentFxBus = activeFxBus ? activeFxBus.id : "";
 
     const cacheValid = (
         cachedKnobContexts.length === NUM_KNOBS &&
@@ -9190,12 +9519,14 @@ function getKnobContext(knobIndex) {
         cachedKnobContextsComp === currentComp &&
         cachedKnobContextsLevel === currentLevel &&
         cachedKnobContextsChildIndex === currentChildIndex &&
-        cachedKnobContextsMasterFxComp === currentMasterFxComp
+        cachedKnobContextsMasterFxComp === currentMasterFxComp &&
+        cachedKnobContextsFxBus === currentFxBus
     );
 
     if (!cacheValid) {
         rebuildKnobContextCache();
         cachedKnobContextsMasterFxComp = currentMasterFxComp;
+        cachedKnobContextsFxBus = currentFxBus;
     }
 
     return cachedKnobContexts[knobIndex] || null;
@@ -11054,8 +11385,15 @@ function changeComponentPreset(delta) {
 
 /* Get Master FX setting current value for display */
 function getMasterFxSettingValue(setting) {
+    /* Param-backed items (e.g. Send A's "-> Send B") render generically as %. */
+    if (setting.param) {
+        const val = shadow_get_param(0, setting.param);
+        if (val === null || val === undefined || val === "") return "0%";
+        const num = parseFloat(val);
+        return isNaN(num) ? val : `${Math.round(num * 100)}%`;
+    }
     if (setting.key === "master_volume") {
-        const val = shadow_get_param(0, "master_fx:volume");
+        const val = shadow_get_param(0, activeFxBus.volumeKey);
         if (!val) return "100%";
         const num = parseFloat(val);
         return isNaN(num) ? val : `${Math.round(num * 100)}%`;
@@ -11167,11 +11505,20 @@ function getMasterFxSettingValue(setting) {
 function adjustMasterFxSetting(setting, delta) {
     if (setting.type === "action") return;
 
-    if (setting.key === "master_volume") {
-        let val = parseFloat(shadow_get_param(0, "master_fx:volume") || "1.0");
+    /* Param-backed items (e.g. Send A's "-> Send B") adjust generically. */
+    if (setting.param) {
+        let val = parseFloat(shadow_get_param(0, setting.param) || "0");
         val += delta * setting.step;
         val = Math.max(setting.min, Math.min(setting.max, val));
-        shadow_set_param(0, "master_fx:volume", val.toFixed(2));
+        shadow_set_param(0, setting.param, val.toFixed(2));
+        return;
+    }
+
+    if (setting.key === "master_volume") {
+        let val = parseFloat(shadow_get_param(0, activeFxBus.volumeKey) || "1.0");
+        val += delta * setting.step;
+        val = Math.max(setting.min, Math.min(setting.max, val));
+        shadow_set_param(0, activeFxBus.volumeKey, val.toFixed(2));
         return;
     }
 
@@ -11503,11 +11850,11 @@ function handleJog(delta) {
             } else {
                 /* Navigate chain components (-1 = preset selection, like instrument slots)
                  * Preset picker is only accessible via click, not scroll */
-                selectedMasterFxComponent = Math.max(-1, Math.min(MASTER_FX_CHAIN_COMPONENTS.length - 1, selectedMasterFxComponent + delta));
+                selectedMasterFxComponent = Math.max(-1, Math.min(activeFxBus.components.length - 1, selectedMasterFxComponent + delta));
                 if (selectedMasterFxComponent === -1) {
                     announce("Preset Selection");
                 } else {
-                    const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+                    const comp = activeFxBus.components[selectedMasterFxComponent];
                     const compKey = comp.key;
                     const moduleName = masterFxConfig?.[compKey]?.module || "Empty";
                     announceMenuItem(comp.label, moduleName);
@@ -11516,6 +11863,9 @@ function handleJog(delta) {
             break;
         case VIEWS.SLOT_SETTINGS:
             handleSlotSettingsJog(delta);
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            fxBusPickerIndex = Math.max(0, Math.min(2, fxBusPickerIndex + delta));
             break;
         case VIEWS.PATCHES:
             handlePatchesJog(delta);
@@ -11966,7 +12316,7 @@ function handleSelect() {
                 /* Preset selected - enter preset picker */
                 enterMasterPresetPicker();
             } else {
-                const selectedComp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+                const selectedComp = activeFxBus.components[selectedMasterFxComponent];
                 if (selectedComp.key === "settings") {
                     /* Enter settings submenu */
                     inMasterFxSettingsMenu = true;
@@ -11978,15 +12328,15 @@ function handleSelect() {
                     if (items.length > 0) {
                         const item = items[0];
                         const value = getMasterFxSettingValue(item);
-                        announce(`Master FX Settings, ${item.label}: ${value}`);
+                        announce(`${activeFxBus.title} Settings, ${item.label}: ${value}`);
                     }
                 } else {
                     /* FX slot - check if module is loaded with hierarchy */
                     const moduleData = masterFxConfig[selectedComp.key];
 
-                    /* Mute+JogClick: toggle bypass on a populated MFX slot */
+                    /* Mute+JogClick: toggle bypass on a populated slot */
                     if (hostMuteHeld && moduleData && moduleData.module) {
-                        const fullKey = `master_fx:${selectedComp.key}:bypassed`;
+                        const fullKey = activeFxBus.paramPrefix + selectedComp.key + ":bypassed";
                         const cur = parseInt(shadow_get_param(0, fullKey) || "0", 10);
                         const next = cur ? 0 : 1;
                         shadow_set_param(0, fullKey, String(next));
@@ -11996,13 +12346,27 @@ function handleSelect() {
                     }
 
                     if (moduleData && moduleData.module) {
-                        /* Module is loaded - try hierarchy editor first */
-                        const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
-                        if (hierarchy) {
-                            enterMasterFxHierarchyEditor(selectedMasterFxComponent);
+                        /* Module is loaded - open the param editor. Sends use the
+                         * dedicated send hierarchy editor; master uses its own. */
+                        if (activeFxBus.id === "master") {
+                            const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
+                            if (hierarchy) {
+                                enterMasterFxHierarchyEditor(selectedMasterFxComponent);
+                            } else {
+                                enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            }
                         } else {
-                            /* No hierarchy - enter module selection to swap */
-                            enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            const busIdx = (activeFxBus.id === "sendB") ? 1 : 0;
+                            /* Mirror master exactly: use the PARSED hierarchy (getMasterFxHierarchy
+                             * is activeFxBus-relative, so it reads this send slot). A module whose
+                             * ui_hierarchy is empty/invalid (e.g. dissolver) parses to null → fall
+                             * back to the module browser instead of a silent no-op. */
+                            const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
+                            if (hierarchy) {
+                                enterSendFxHierarchyEditor(busIdx, selectedMasterFxComponent);
+                            } else {
+                                enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            }
                         }
                     } else {
                         /* No module loaded - enter module selection */
@@ -12013,6 +12377,13 @@ function handleSelect() {
             break;
         case VIEWS.SLOT_SETTINGS:
             handleSlotSettingsSelect();
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            if (fxBusPickerIndex === 0) {
+                enterFxBusEditor("master");
+            } else {
+                enterFxBusEditor(fxBusPickerIndex === 1 ? "sendA" : "sendB");
+            }
             break;
         case VIEWS.PATCHES:
             handlePatchesSelect();
@@ -12871,22 +13242,34 @@ function handleBack() {
         case VIEWS.COMPONENT_PARAMS:
             handleComponentParamsBack();
             break;
+        case VIEWS.FX_BUS_PICKER:
+            if (coRunChainEditSlot >= 0) {
+                view = VIEWS.CHAIN_EDIT;
+                coRunView = VIEWS.CHAIN_EDIT;
+            } else {
+                /* Back exits the shadow UI back to Move native. (The previous
+                 * exitShadowUI() was undefined and threw, so Back did nothing.) */
+                if (typeof shadow_request_exit === "function") {
+                    shadow_request_exit();
+                }
+            }
+            break;
         case VIEWS.MASTER_FX:
             if (masterShowingNamePreview) {
                 /* Cancel name preview */
                 masterShowingNamePreview = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (masterConfirmingOverwrite) {
                 /* Cancel overwrite - return to settings */
                 masterConfirmingOverwrite = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (masterConfirmingDelete) {
                 /* Cancel delete */
                 masterConfirmingDelete = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (helpDetailScrollState) {
                 helpDetailScrollState = null;
                 needsRedraw = true;
@@ -12902,28 +13285,25 @@ function handleBack() {
                     helpReturnView = null;
                     enterGlobalSettings();
                 } else {
-                    announce("Master FX Settings");
+                    announce(`${activeFxBus.title} Settings`);
                 }
             } else if (inMasterPresetPicker) {
                 /* Exit preset picker, return to FX list */
                 exitMasterPresetPicker();
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else if (inMasterFxSettingsMenu) {
                 /* Exit settings menu */
                 inMasterFxSettingsMenu = false;
                 editingMasterFxSetting = false;
                 needsRedraw = true;
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else if (selectingMasterFxModule) {
                 /* Cancel module selection, return to chain view */
                 selectingMasterFxModule = false;
                 needsRedraw = true;
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else {
-                /* Exit shadow mode and return to Move */
-                if (typeof shadow_request_exit === "function") {
-                    shadow_request_exit();
-                }
+                enterFxBusPicker();
             }
             break;
         case VIEWS.CHAIN_EDIT:
@@ -13073,8 +13453,9 @@ function handleBack() {
             } else {
                 /* At root level - exit hierarchy editor */
                 const wasMasterFx = hierEditorIsMasterFx;
+                const returnView = hierEditorReturnView;
                 exitHierarchyEditor();
-                announce(wasMasterFx ? "Master FX" : "Chain Editor");
+                announce(returnView === VIEWS.MASTER_FX ? activeFxBus.title : wasMasterFx ? "Master FX" : "Chain Editor");
             }
             break;
         }
@@ -13392,12 +13773,12 @@ function drawChainEdit() {
     const cfg = chainConfigs[selectedSlot] || createEmptyChainConfig();
     const chainSelected = selectedChainComponent === -1;
 
-    /* Calculate box layout - 5 components, offset right to make room for slot indicators */
-    const BOX_W = 22;
+    /* Calculate box layout - 7 components, offset right to make room for slot indicators */
+    const BOX_W = 16;
     const BOX_H = 16;
-    const GAP = 2;
-    const TOTAL_W = 5 * BOX_W + 4 * GAP;  // 118px
-    const START_X = 6 + Math.floor((SCREEN_WIDTH - 6 - TOTAL_W) / 2);  // centered right of indicators
+    const GAP = 1;
+    const TOTAL_W = CHAIN_COMPONENTS.length * BOX_W + (CHAIN_COMPONENTS.length - 1) * GAP;
+    const START_X = 6 + Math.floor((SCREEN_WIDTH - 6 - TOTAL_W) / 2);
     const BOX_Y = 20;  // Below header
 
     /* Draw slot indicators - 4 marks in left margin, spanning from below header to footer */
@@ -14042,7 +14423,14 @@ function drawHelpDetail() {
         get() { return masterConfirmIndex; }, enumerable: true
     });
 
-    _ctx.MASTER_FX_CHAIN_COMPONENTS = MASTER_FX_CHAIN_COMPONENTS;
+    /* Components follow the active bus (master: 4 slots, sends: 3). */
+    Object.defineProperty(_ctx, 'MASTER_FX_CHAIN_COMPONENTS', {
+        get() { return activeFxBus.components; }, enumerable: true
+    });
+    /* Active FX bus descriptor (master/sendA/sendB) for the generic editor. */
+    Object.defineProperty(_ctx, 'activeFxBus', {
+        get() { return activeFxBus; }, set(v) { if (v) activeFxBus = v; }, enumerable: true
+    });
 
     /* Utility functions */
     _ctx.setView = setView;
@@ -14238,6 +14626,9 @@ function drawHelpDetail() {
     _ctx.enterChainEdit = (...args) => enterChainEdit(...args);
     _ctx.enterPatchBrowser = (...args) => _enterPatchBrowser(...args);
     _ctx.enterMasterFxSettings = (...args) => enterMasterFxSettings(...args);
+    _ctx.enterFxBusEditor = (...args) => enterFxBusEditor(...args);
+    _ctx.enterFxBusPicker = () => enterFxBusPicker();
+    _ctx.enterSendFxHierarchyEditor = (...args) => enterSendFxHierarchyEditor(...args);
     _ctx.enterSlotSettings = (...args) => _enterSlotSettings(...args);
 })();
 
@@ -14255,6 +14646,45 @@ function applyPatchSelection() { _applyPatchSelection(); }
 function drawMasterFx() { _drawMasterFx(); }
 function getMasterFxDisplayName() { return _getMasterFxDisplayName(); }
 function enterMasterFxSettings() { _enterMasterFxSettings(); }
+
+/* Enter the generic FX editor for a bus (master/sendA/sendB). Sets the active
+ * bus descriptor, then runs the shared Master-FX-style editor entry. */
+function enterFxBusEditor(busId) {
+    /* Stash the outgoing bus's loaded-preset name, then restore the incoming
+     * bus's — keeps the preset name + overwrite target per-bus so a master
+     * preset (e.g. SPECTRA) can't preselect overwrite on a send save. */
+    if (activeFxBus && activeFxBus.id) fxBusPresetName[activeFxBus.id] = currentMasterPresetName;
+    activeFxBus = FX_BUS[busId] || FX_BUS.master;
+    currentMasterPresetName = fxBusPresetName[activeFxBus.id] || "";
+    masterOverwriteTargetIndex = -1;
+    enterMasterFxSettings();
+}
+
+let fxBusPickerIndex = 0;
+function enterFxBusPicker() {
+    fxBusPickerIndex = 0;
+    view = VIEWS.FX_BUS_PICKER;
+    if (coRunChainEditSlot >= 0) coRunView = VIEWS.FX_BUS_PICKER;
+    needsRedraw = true;
+}
+function drawFxBusPicker() {
+    clear_screen();
+    drawHeader("FX Buses");
+    const items = [
+        { label: "Master FX", value: getMasterFxDisplayName() },
+        { label: "Send FX A", value: "" },
+        { label: "Send FX B", value: "" },
+    ];
+    drawMenuList({
+        items,
+        selectedIndex: fxBusPickerIndex,
+        listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
+        getLabel: (item) => item.label,
+        getValue: (item) => item.value,
+        valueAlignRight: true
+    });
+    drawFooter("Back: exit");
+}
 function scanForToolModules() { return _scanForToolModules(); }
 function enterToolsMenu() {
     _enterToolsMenu();
@@ -14689,6 +15119,8 @@ globalThis.init = function() {
     }
     /* Re-apply Master FX sync after activeSlotStateDir resolves to the active set. */
     loadMasterFxChainFromConfig();
+    /* Send FX has no shim-side boot restore — load the active set's send chains here. */
+    restoreSendFxFromFiles();
 
     /* Sync dirty cache and slot names from autosave files (shim loaded them on startup) */
     for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
@@ -14803,6 +15235,7 @@ globalThis.init = function() {
 globalThis.shadow_save_state_now = function() {
     autosaveAllSlots();
     saveMasterFxChainConfig();
+    saveSendFxChainConfig();  /* persist send FX chains + return levels per set */
     /* Also persist volumes/channels/mute/solo — otherwise the set's
      * shadow_chain_config.json drifts from slot_N.json across reboots,
      * e.g. toggling MPE (recv=All) before shutdown would revert on boot. */
@@ -14874,6 +15307,8 @@ function dispatchCoRunDraw() {
             drawMessageOverlay('Install Complete', storePostInstallLines);
             break;
         case VIEWS.FILEPATH_BROWSER:     drawFilepathBrowser(); break;
+        case VIEWS.FX_BUS_PICKER:        drawFxBusPicker(); break;
+        case VIEWS.MASTER_FX:            drawMasterFx(); break;
         default:
             /* Unknown view in co-run — render slot list as a recoverable
              * fallback so user can navigate back. */
@@ -15094,9 +15529,11 @@ globalThis.tick = function() {
                 }
             }
             if (flags & SHADOW_UI_FLAG_JUMP_TO_MASTER_FX) {
-                /* Always jump to Master FX view */
-                enterMasterFxSettings();
-                /* Clear the flag */
+                if (coRunChainEditSlot >= 0) {
+                    coRunView = VIEWS.FX_BUS_PICKER;
+                } else {
+                    enterFxBusPicker();
+                }
                 if (typeof shadow_clear_ui_flags === "function") {
                     shadow_clear_ui_flags(SHADOW_UI_FLAG_JUMP_TO_MASTER_FX);
                 }
@@ -15195,6 +15632,16 @@ globalThis.tick = function() {
                         const mfx = host_read_file(copySourceDir + "/master_fx_" + i + ".json");
                         if (mfx) host_write_file(newDir + "/master_fx_" + i + ".json", mfx);
                     }
+                    /* Copy send FX per-set files (2 buses × 4 slots) + return-level meta */
+                    for (let bi = 0; bi < SEND_FX_BUSES.length; bi++) {
+                        for (let s = 0; s < SEND_FX_SLOTS_JS; s++) {
+                            const sfxName = "/send_fx_" + SEND_FX_BUSES[bi] + "_" + s + ".json";
+                            const sfx = host_read_file(copySourceDir + sfxName);
+                            if (sfx) host_write_file(newDir + sfxName, sfx);
+                        }
+                    }
+                    const sfxMeta = host_read_file(copySourceDir + "/send_fx_meta.json");
+                    if (sfxMeta) host_write_file(newDir + "/send_fx_meta.json", sfxMeta);
                     /* Also copy chain config */
                     const chainCfg = host_read_file(copySourceDir + "/shadow_chain_config.json");
                     if (chainCfg) host_write_file(newDir + "/shadow_chain_config.json", chainCfg);
@@ -15204,6 +15651,12 @@ globalThis.tick = function() {
                     for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                         host_write_file(newDir + "/slot_" + i + ".json", "{}\n");
                         host_write_file(newDir + "/master_fx_" + i + ".json", "{}\n");
+                    }
+                    /* Empty send FX files so a new set starts with no send chains. */
+                    for (let bi = 0; bi < SEND_FX_BUSES.length; bi++) {
+                        for (let s = 0; s < SEND_FX_SLOTS_JS; s++) {
+                            host_write_file(newDir + "/send_fx_" + SEND_FX_BUSES[bi] + "_" + s + ".json", "{}\n");
+                        }
                     }
                     /* Seed a default chain config so receive channels reset to
                      * per-track defaults (Ch 1-4). Without this, the upcoming
@@ -15281,7 +15734,23 @@ globalThis.tick = function() {
              * overwrite the freshly-written slot files */
             autosaveSuppressUntil = 150; /* ~5 seconds at 30fps */
 
-            /* 7. Reload master FX modules from per-set state files */
+            /* 7. Reload master FX modules from per-set state files.
+             * This restore is always about the MASTER bus. Two things must be
+             * reset first, because a Send FX editor (3 slots) may have been the
+             * last-active bus when the set changed:
+             *   - activeFxBus: setMasterFxSlotModule() is activeFxBus-relative, so
+             *     a stale send bus would misdirect the master chain's modules to
+             *     send_fx:* keys (loading heavy modules into send slots + firing the
+             *     out-of-range fx4) and flood the blocking set_param channel.
+             *   - masterFxConfig: it is rebuilt to activeFxBus.slotCount on editor
+             *     entry, so after a 3-slot send editor it only has fx1..fx3. The
+             *     loop below writes masterFxConfig["fx4"], which would be undefined
+             *     → TypeError → the handler throws BEFORE clearing SHADOW_UI_FLAG_SET_CHANGED
+             *     (step 11) → SET_CHANGED re-runs every tick → persistent global lag.
+             * Rebuilding it for the 4 master slots makes the restore self-contained. */
+            activeFxBus = FX_BUS.master;
+            masterFxConfig = { fx1: { module: "" }, fx2: { module: "" },
+                               fx3: { module: "" }, fx4: { module: "" } };
             for (let mfxi = 0; mfxi < 4; mfxi++) {
                 const mfxPath = activeSlotStateDir + "/master_fx_" + mfxi + ".json";
                 let mfxDspPath = "";
@@ -15327,6 +15796,11 @@ globalThis.tick = function() {
                 }
                 debugLog("SET_CHANGED: MFX " + mfxi + " -> " + (mfxModuleId || "(none)"));
             }
+
+            /* 7b. Reload send FX chains + return levels for the new set. Uses
+             * explicit send_fx:* keys, so it's independent of activeFxBus. */
+            restoreSendFxFromFiles();
+
             /* 8. Refresh slot names from new autosave files */
             for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                 slots[i].name = "";
@@ -15456,7 +15930,7 @@ globalThis.tick = function() {
     /* Poll FX display_name for change-based announcements (e.g. key detection).
      * Check every ~1 second (30 ticks at 30fps). Only poll slots that have FX loaded. */
     if (!isOvertakeActive && refreshCounter % 30 === 0) {
-        const fxComponents = ["fx1", "fx2"];
+        const fxComponents = ["fx1", "fx2", "fx3", "fx4"];
         /* Per-slot FX */
         for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
             const cfg = chainConfigs[i];
@@ -15643,6 +16117,7 @@ globalThis.tick = function() {
         }
     }
 
+
     switch (view) {
         case VIEWS.SLOTS:
             drawSlots();
@@ -15661,6 +16136,9 @@ globalThis.tick = function() {
             break;
         case VIEWS.MASTER_FX:
             drawMasterFx();
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            drawFxBusPicker();
             break;
         case VIEWS.CHAIN_EDIT:
             drawChainEdit();
@@ -16109,7 +16587,7 @@ globalThis.onMidiMessageInternal = function(data) {
                 runCoRunChainEdit(function() {
                     if (hostShiftHeld && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
                         handleShiftSelect();
-                    } else if (hostShiftHeld && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
+                    } else if (hostShiftHeld && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
                         enterMasterFxModuleSelect(selectedMasterFxComponent);
                     } else {
                         handleSelect();
@@ -16147,6 +16625,13 @@ globalThis.onMidiMessageInternal = function(data) {
              * Eating it here prevents the tool from reacting (e.g. its own
              * Shift+button shortcuts while you're navigating the editor). */
             if (d1 === 49 && coRunCedes(CORUN_GRP_SHIFT)) {
+                needsRedraw = true;
+                return;
+            }
+            /* Menu (CC 50): open FX bus picker during co-run */
+            if (d1 === 50 && d2 > 0) {
+                coRunView = VIEWS.FX_BUS_PICKER;
+                runCoRunChainEdit(function() { enterFxBusPicker(); });
                 needsRedraw = true;
                 return;
             }
@@ -16277,8 +16762,8 @@ globalThis.onMidiMessageInternal = function(data) {
             /* Shift+Click in chain edit enters component edit mode */
             if (isShiftHeld() && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
                 handleShiftSelect();
-            } else if (isShiftHeld() && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
-                /* Shift+Click in Master FX view enters module selector for the slot */
+            } else if (isShiftHeld() && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
+                /* Shift+Click in FX editor enters module selector for the slot */
                 enterMasterFxModuleSelect(selectedMasterFxComponent);
             } else {
                 handleSelect();

--- a/src/shadow/shadow_ui_master_fx.mjs
+++ b/src/shadow/shadow_ui_master_fx.mjs
@@ -21,12 +21,22 @@ import {
     announce, announceMenuItem
 } from '/data/UserData/schwung/shared/screen_reader.mjs';
 
+/* Throttle the FX editor's per-draw blocking GETs (slot bypass + LFO targets).
+ * These only change on user action, but the editor redraws periodically — so we
+ * cache and refresh every FX_STATE_POLL_EVERY draws (and immediately on a bus
+ * switch) instead of querying the param channel on every redraw. */
+const FX_STATE_POLL_EVERY = 8;
+let _fxStateDrawCount = 0;
+let _fxStateCacheBus = "";
+let _fxBypassCache = {};
+let _fxLfoTargetsCache = {};
+
 /* ---- Enter -------------------------------------------------------------- */
 
 export function enterMasterFxSettings() {
     const { scanForAudioFxModules, loadMasterFxChainConfig,
             getMasterFxSlotModule, MASTER_FX_CHAIN_COMPONENTS,
-            setView, VIEWS } = ctx;
+            activeFxBus, setView, VIEWS } = ctx;
 
     ctx.MASTER_FX_OPTIONS = scanForAudioFxModules();
     loadMasterFxChainConfig();
@@ -37,15 +47,16 @@ export function enterMasterFxSettings() {
 
     const comp = MASTER_FX_CHAIN_COMPONENTS[0];
     const moduleName = getMasterFxSlotModule(0) || "Empty";
-    announce(`Master FX, ${comp.label} ${moduleName}`);
+    announce(`${activeFxBus.title}, ${comp.label} ${moduleName}`);
 }
 
 /* ---- Display name (used in slot list) ----------------------------------- */
 
 export function getMasterFxDisplayName() {
-    const { masterFxConfig } = ctx;
+    const { masterFxConfig, activeFxBus } = ctx;
+    const slotCount = activeFxBus ? activeFxBus.slotCount : 4;
     const parts = [];
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= slotCount; i++) {
         const key = `fx${i}`;
         if (masterFxConfig[key]?.module) {
             parts.push(masterFxConfig[key].module);
@@ -62,7 +73,7 @@ export function drawMasterFx() {
             inMasterPresetPicker, inMasterFxSettingsMenu,
             selectingMasterFxModule, selectedMasterFxComponent,
             masterFxConfig, MASTER_FX_CHAIN_COMPONENTS, MASTER_FX_OPTIONS,
-            currentMasterPresetName, getMasterFxParam,
+            currentMasterPresetName, getMasterFxParam, activeFxBus,
             getModuleAbbrev, isTextEntryActive, drawTextEntry,
             drawHelpDetail, drawHelpList } = ctx;
 
@@ -112,7 +123,7 @@ export function drawMasterFx() {
         return;
     }
 
-    drawHeader("Master FX");
+    drawHeader(activeFxBus.title);
 
     const BOX_W = 22;
     const BOX_H = 16;
@@ -152,38 +163,56 @@ export function drawMasterFx() {
     /* Draw bypass 'B' marker above box, left side. Same style as the chain
      * editor: 3-wide × 4-tall glyph at iy=BOX_Y-6. Sits left of where the LFO
      * indicator is centered, so they coexist without overlap. */
+    /* Refresh the cached bypass + LFO-target state every Nth draw (or on bus
+     * switch) rather than on every periodic redraw — see FX_STATE_POLL_EVERY. */
     if (typeof shadow_get_param === "function") {
-        for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
-            const comp = MASTER_FX_CHAIN_COMPONENTS[i];
-            if (comp.key === "settings") continue;
-            const bypassed = parseInt(
-                shadow_get_param(0, `master_fx:${comp.key}:bypassed`) || "0", 10
-            ) === 1;
-            if (!bypassed) continue;
-            const x = START_X + i * (BOX_W + GAP);
-            const bx = x + 1;
-            const by = BOX_Y - 6;
-            /* "B" glyph: ##. / #.# / ##. / ### */
-            set_pixel(bx,     by,     1); set_pixel(bx + 1, by,     1);
-            set_pixel(bx,     by + 1, 1); set_pixel(bx + 2, by + 1, 1);
-            set_pixel(bx,     by + 2, 1); set_pixel(bx + 1, by + 2, 1);
-            set_pixel(bx,     by + 3, 1); set_pixel(bx + 1, by + 3, 1); set_pixel(bx + 2, by + 3, 1);
-        }
-    }
-
-    /* Draw LFO indicators above targeted FX boxes */
-    if (typeof shadow_get_param === "function") {
-        const mfxLfoTargets = {};
-        for (let li = 1; li <= 2; li++) {
-            const enabled = shadow_get_param(0, "master_fx:lfo" + li + ":enabled");
-            if (enabled === "1") {
-                const t = shadow_get_param(0, "master_fx:lfo" + li + ":target") || "";
-                if (t) {
-                    if (!mfxLfoTargets[t]) mfxLfoTargets[t] = {};
-                    mfxLfoTargets[t]["lfo" + li] = true;
+        _fxStateDrawCount++;
+        if (_fxStateCacheBus !== activeFxBus.id ||
+            (_fxStateDrawCount % FX_STATE_POLL_EVERY) === 0) {
+            _fxStateCacheBus = activeFxBus.id;
+            _fxBypassCache = {};
+            _fxLfoTargetsCache = {};
+            for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
+                const comp = MASTER_FX_CHAIN_COMPONENTS[i];
+                if (comp.key === "settings") continue;
+                _fxBypassCache[comp.key] = parseInt(
+                    shadow_get_param(0, activeFxBus.paramPrefix + comp.key + ":bypassed") || "0", 10
+                ) === 1;
+            }
+            if (activeFxBus.hasLfo) {
+                for (let li = 1; li <= 2; li++) {
+                    const enabled = shadow_get_param(0, "master_fx:lfo" + li + ":enabled");
+                    if (enabled === "1") {
+                        const t = shadow_get_param(0, "master_fx:lfo" + li + ":target") || "";
+                        if (t) {
+                            if (!_fxLfoTargetsCache[t]) _fxLfoTargetsCache[t] = {};
+                            _fxLfoTargetsCache[t]["lfo" + li] = true;
+                        }
+                    }
                 }
             }
         }
+    }
+
+    /* Draw bypass 'B' markers from cache. */
+    for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
+        const comp = MASTER_FX_CHAIN_COMPONENTS[i];
+        if (comp.key === "settings") continue;
+        if (!_fxBypassCache[comp.key]) continue;
+        const x = START_X + i * (BOX_W + GAP);
+        const bx = x + 1;
+        const by = BOX_Y - 6;
+        /* "B" glyph: ##. / #.# / ##. / ### */
+        set_pixel(bx,     by,     1); set_pixel(bx + 1, by,     1);
+        set_pixel(bx,     by + 1, 1); set_pixel(bx + 2, by + 1, 1);
+        set_pixel(bx,     by + 2, 1); set_pixel(bx + 1, by + 2, 1);
+        set_pixel(bx,     by + 3, 1); set_pixel(bx + 1, by + 3, 1); set_pixel(bx + 2, by + 3, 1);
+    }
+
+    /* Draw LFO indicators above targeted FX boxes (master bus only — sends
+     * have no LFOs). Reads the cached targets refreshed above. */
+    if (activeFxBus.hasLfo) {
+        const mfxLfoTargets = _fxLfoTargetsCache;
         /* 4px-high tiny indicators: ~1, ~2, or ~1+2 */
         /* Tilde: 4w x 2h squiggle (rows 1-2 of 4, padded top/bottom) */
         const TILDE_4PX = [0x0, 0x5, 0xA, 0x0];  /* .... / .#.# / #.#. / .... */
@@ -280,9 +309,9 @@ export function drawMasterFx() {
 
 function drawMasterFxSettingsMenu() {
     const { currentMasterPresetName, selectedMasterFxSetting,
-            getMasterFxSettingsItems, getMasterFxSettingValue } = ctx;
+            getMasterFxSettingsItems, getMasterFxSettingValue, activeFxBus } = ctx;
 
-    const title = currentMasterPresetName || "Master FX";
+    const title = currentMasterPresetName || activeFxBus.title;
     drawHeader(truncateText(title, 18));
 
     const items = getMasterFxSettingsItems();
@@ -330,9 +359,9 @@ function drawMasterFxModuleSelect() {
 
 function drawMasterPresetPicker() {
     const { masterPresets, selectedMasterPresetIndex,
-            currentMasterPresetName } = ctx;
+            currentMasterPresetName, activeFxBus } = ctx;
 
-    drawHeader("Master Presets");
+    drawHeader(activeFxBus.presetPickerTitle);
 
     const items = [{ name: "[New]", index: -1 }];
     for (let i = 0; i < masterPresets.length; i++) {

--- a/src/shadow/shadow_ui_slots.mjs
+++ b/src/shadow/shadow_ui_slots.mjs
@@ -27,6 +27,8 @@ export const SLOT_SETTINGS = [
     { key: "patch", label: "Patch", type: "action" },
     { key: "chain", label: "Edit Chain", type: "action" },
     { key: "slot:volume", label: "Volume", type: "float", min: 0, max: 4, step: 0.05 },
+    { key: "slot:send_a", label: "Send A", type: "float", min: 0, max: 1, step: 0.05 },
+    { key: "slot:send_b", label: "Send B", type: "float", min: 0, max: 1, step: 0.05 },
     { key: "slot:muted", label: "Muted", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:soloed", label: "Soloed", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:receive_channel", label: "Recv Ch", type: "int", min: 0, max: 16, step: 1 },
@@ -40,6 +42,17 @@ export const SLOT_SETTINGS = [
 
 let selectedSetting = 0;
 let editingSettingValue = false;
+
+function getSendFxDisplayName(bus) {
+    const { getSlotParam } = ctx;
+    const busKey = bus === 0 ? "a" : "b";
+    const parts = [];
+    for (let i = 1; i <= 3; i++) {
+        const name = getSlotParam(0, `send_fx:${busKey}:fx${i}:name`);
+        if (name) parts.push(name);
+    }
+    return parts.length > 0 ? parts.join("+") : "None";
+}
 
 /* ---- Helpers ------------------------------------------------------------ */
 
@@ -63,6 +76,11 @@ export function getSlotSettingValue(slot, setting) {
     if (val === null) return "-";
 
     if (setting.key === "slot:volume") {
+        const num = parseFloat(val);
+        const pct = isNaN(num) ? 0 : Math.round(num * 100);
+        return `${pct}%`;
+    }
+    if (setting.key === "slot:send_a" || setting.key === "slot:send_b") {
         const num = parseFloat(val);
         const pct = isNaN(num) ? 0 : Math.round(num * 100);
         return `${pct}%`;
@@ -183,7 +201,9 @@ export function drawSlots() {
                 isSlot: true
             };
         }),
-        { label: " Master FX", value: getMasterFxDisplayName(), isSlot: false }
+        { label: " Master FX", value: getMasterFxDisplayName(), isSlot: false },
+        { label: " Send FX A", value: getSendFxDisplayName(0), isSlot: false },
+        { label: " Send FX B", value: getSendFxDisplayName(1), isSlot: false }
     ];
 
     drawMenuList({
@@ -256,7 +276,7 @@ export function drawSlotSettings() {
 
 export function handleSlotsJog(delta) {
     const { slots, updateFocusedSlot } = ctx;
-    ctx.selectedSlot = Math.max(0, Math.min(slots.length, ctx.selectedSlot + delta));
+    ctx.selectedSlot = Math.max(0, Math.min(slots.length + 2, ctx.selectedSlot + delta));
     updateFocusedSlot(ctx.selectedSlot);
 }
 
@@ -278,11 +298,15 @@ export function handleSlotSettingsJog(delta) {
 /* ---- Select ------------------------------------------------------------- */
 
 export function handleSlotsSelect() {
-    const { selectedSlot, slots, enterChainEdit, enterMasterFxSettings } = ctx;
+    const { selectedSlot, slots, enterChainEdit, enterFxBusEditor } = ctx;
     if (selectedSlot < slots.length) {
         enterChainEdit(selectedSlot);
-    } else {
-        enterMasterFxSettings();
+    } else if (selectedSlot === slots.length) {
+        enterFxBusEditor("master");
+    } else if (selectedSlot === slots.length + 1) {
+        enterFxBusEditor("sendA");
+    } else if (selectedSlot === slots.length + 2) {
+        enterFxBusEditor("sendB");
     }
 }
 


### PR DESCRIPTION
Adds two **post-fader send buses** (Send A / Send B), each with its own FX chain (up to 4 effects), plus a generic **FX-bus picker** that also hosts the existing Master FX. Classic mixer aux/return model: tracks feed a shared effect instead of duplicating it per track.

## Highlights
- Per-track **Send A/B** levels (post-fader), per-bus **return level**, **Send A→B** parallel routing (feedback-safe), **shared presets** (A/B), full **per-set persistence**.
- The Master-FX editor is genericized into one **bus-descriptor-driven** editor serving Master + Send A/B; sends hide LFO items; the home-screen knob-context cache is keyed per bus.
- Send buses are hosted like Master FX (`master_fx_slot_t[]`), so module hosting / presets / bypass are reused, not duplicated. The mix + A→B tap live in the shim's send loop (post-fader accumulate → bus FX → return-level → ME bus; A→B taps A's return-scaled output into B before B runs, so it's feedback-safe by bus order).

## Carried fixes (worth taking regardless of sends)
- `json_get_section_bounds` now anchors on the key's colon and only reads an object when the value *is* one — a null-valued (empty) FX slot previously grabbed a *later* slot's object and corrupted saved presets (also fixes a latent **Master**-preset bug).
- Send `ui_hierarchy` falls back to `module.json`, so modules without an explicit hierarchy can still open their params on a send bus.

## Docs
Full design — topology, parameters, mix path, persistence, and per-file roles — in **`docs/SEND_FX.md`**.

## Testing
Built against `main` (v0.9.18). Device-verified on Move: FX-bus picker (Master / Send A / Send B), Send A/B FX + return level + shared presets, Send A→B routing (audio + post-fader behavior), LFO items hidden on sends, and persistence across set changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
