### PR TITLE
feat(fx): Move FX — per-Move-track insert FX (4 buses) + shared FX-bus picker

### DIFF
--- a/docs/MOVE_FX.md
+++ b/docs/MOVE_FX.md
@@ -1,0 +1,149 @@
+# Move FX
+
+Move FX gives each **Move track** its own **insert-FX mini-bus** — a small
+audio-effects chain that the track's Move-side signal runs through before it
+hits the master mix. Four of them (one per Move track / channel) sit alongside
+Master FX in a generic **FX-bus picker**. It's the classic *channel insert*
+model: an effect placed directly in one track's path, as opposed to a shared
+send/return.
+
+---
+
+## What it does (plain terms)
+
+- **Four Move FX buses**, one per Move track. Each is a small FX chain of up to
+  **2 insert effects** in series.
+- **Per-bus volume.** Each bus has a **Volume** that scales its output into the
+  master mix.
+- **Routed vs. peeled.** A Move track normally **rides its Schwung synth slot**
+  (`Move>SchwFX` On) — its audio shares that slot's chain. Turning `Move>SchwFX`
+  **Off** *peels* the track onto its own Move FX bus. The picker lets you open
+  any of the 4 Move FX buses directly; opening one whose track is still routed
+  prompts **"Route to this chain instead?"** to peel it for you.
+- **Shared presets.** You can save/recall a Move FX chain (its 2 effects) as a
+  preset. The preset list is **shared across all 4 Move FX buses** — a preset
+  saved from Move 1 can be loaded onto Move 3 and vice-versa. (Presets capture
+  the effects only, not the per-bus volume.)
+- **Per-set persistence.** Move FX chains and per-bus volume save and restore
+  with the Move Set.
+
+### Using it
+
+1. Open the **FX-bus picker** and choose **Master FX** or one of **Move 1–4
+   FX**. (Master FX behaves exactly as before — it's now just one of the buses
+   the picker can open.)
+2. If the Move FX you pick belongs to a track still routed to its Schwung slot,
+   confirm **Yes** at the *"Route to this chain instead?"* prompt to peel it
+   (this sets `Move>SchwFX` Off for that track). Already-peeled buses open
+   directly.
+3. In the bus editor, load effects into the 2 slots, tweak params, and set the
+   **Volume**. Move FX buses have **no LFOs**.
+4. **Presets:** in the bus editor's **settings** menu use **[Save Preset] /
+   [Save As] / [Delete]**; to **load**, scroll the chain editor all the way
+   **left** to the preset column and click to open the **Move FX Presets**
+   picker. Because the store is shared, a preset saved on any bus is loadable
+   on any other.
+
+> **Note:** per-track **Send A/B** routing for Move FX buses is a planned
+> follow-up; it depends on the Send FX buses, which land separately.
+
+---
+
+## How it works (technical)
+
+### Topology
+
+```
+Move track 0 (peeled: move_to_slot==0) ─► [Move FX 1: fx1..2] ─► ×volume[0] ─┐
+Move track 1 (peeled)                  ─► [Move FX 2: fx1..2] ─► ×volume[1] ─┤
+Move track 2 (peeled)                  ─► [Move FX 3: fx1..2] ─► ×volume[2] ─┼─► ME bus ─► Master FX ─► out
+Move track 3 (peeled)                  ─► [Move FX 4: fx1..2] ─► ×volume[3] ─┘
+(routed track: move_to_slot!=0 → rides its Schwung synth slot's chain instead)
+```
+
+Buses are **4** (`MOVE_FX_SLOTS`, one per Move track), each with **2** insert FX
+slots (`MOVE_FX_BLOCKS`). Each Move FX bus is hosted exactly like Master FX — an
+array of `master_fx_slot_t`
+(`shadow_move_fx_slots[MOVE_FX_SLOTS][MOVE_FX_BLOCKS]`) — so all the Master-FX
+module hosting, presets, and bypass machinery is reused rather than duplicated.
+Per-bus strip state is a small `move_fx_strip_t { float volume; }` array
+(`shadow_move_fx_strip[MOVE_FX_SLOTS]`).
+
+### Mix path (`src/schwung_shim.c`)
+
+Per audio block, for each Move track whose synth slot is **peeled**
+(`move_to_slot == 0`) and that has a live Move track input:
+
+1. The track's Move audio is run through its Move FX bus's insert slots
+   (`shadow_move_fx_slots[s][b]`, in series, honoring per-slot bypass), idle-
+   gated so an empty/silent strip costs nothing.
+2. The processed result is scaled by `shadow_move_fx_strip[s].volume` and summed
+   into the **master mailbox** and the **ME bus** (pre–Master FX), so Move FX
+   output is colored by Master FX like everything else.
+
+Move FX strips are kept **independent of the synth slot's mute/solo** — a peeled
+Move track is its own voice.
+
+### Parameters
+
+| Key | Where | Meaning |
+| --- | --- | --- |
+| `move_fx:<1-4>:fx<1-2>:<param>` | host | param on a Move-bus FX slot (`module`, `bypassed`, plugin params, `state`, `chain_params`, `ui_hierarchy`) |
+| `move_fx:<1-4>:volume` | host | per-bus output volume 0–4 (default 1.0) |
+| `slot:move_to_slot` | per chain slot | 1 = Move track rides its Schwung synth slot; 0 = peeled to its Move FX bus |
+| `save_move_preset` / `update_move_preset` / `delete_move_preset` | DSP | shared Move-preset writes |
+| `move_preset_count` / `move_preset_name_<i>` / `move_preset_json_<i>` | DSP | shared Move-preset reads |
+
+`move_fx:` SET/GET is handled in the host param paths
+(`shadow_direct_set_param` and `shadow_inprocess_handle_param_request` in
+`src/host/shadow_chain_mgmt.c`); the shared Move preset SET/GET keys live in the
+chain DSP (`src/modules/chain/dsp/chain_host.c`), mirroring the Master preset
+store.
+
+### UI — one editor, many buses
+
+The former Master-FX editor is **genericized** into a single
+**bus-descriptor-driven** editor (`src/shadow/shadow_ui_master_fx.mjs`). A
+descriptor (`FX_BUS.master` / `moveFx1`…`moveFx4`) carries the bus's `id`,
+`paramPrefix` (`master_fx:` vs `move_fx:1:` …), `slotCount`, `hasLfo`, component
+list, settings items, and preset config. The Move buses are built
+**programmatically** (`for mvSlot in 1..MOVE_FX_SLOTS_JS`), so raising
+`MOVE_FX_BLOCKS_JS` needs no further UI edits — the generic editor adapts.
+
+The **FX-bus picker** (`VIEWS.FX_BUS_PICKER` / `enterFxBusPicker` in
+`src/shadow/shadow_ui.js`) shows **Master FX + all 4 Move FX rows** and selects
+the active bus before entry; only one editor is open at a time. Opening a Move
+row whose track is routed raises an in-picker **route-to-chain confirm** overlay
+(`pendingMoveFxRouteConfirm` / `moveFxRouted`, refreshed in the render path) —
+**Yes** writes `slot:move_to_slot = 0` (a single, co-run-safe write) and opens
+the bus; **No** dismisses.
+
+- Move buses set `hasLfo:false`, so the LFO settings items are filtered out of
+  their settings menu; Master (`hasLfo:true`) keeps them.
+- The shared **Move FX preset** actions ([Save Preset]/[Save As]/[Delete]) are
+  appended to the Move bus settings; loading is via the chain editor's `-1`
+  preset column (the same generic flow Master uses). Buses with a preset store
+  (`presetCountKey` set) reach that column.
+
+### Persistence
+
+- **Per-set** (mirrors Master-FX per-set files): each Move slot's chain is
+  written to `move_fx_<slot>_<block>.json` in the set's state dir, and per-bus
+  volume to `move_fx_meta.json` (`strips: [{volume}, …]`). On set change/init
+  all 4 strips are re-applied, defaulting to unity volume when a set has no
+  meta, so the global `shadow_move_fx_strip[]` can't inherit the previous set's
+  levels. The per-track `slot:move_to_slot` routing saves with the chain config
+  (`shadow_state.c` writes `slot_move_to_slot`).
+- **Shared presets** live in `/data/UserData/schwung/presets_move/` — one flat
+  list, written/read by the DSP, wrapping each preset's 2 FX slots under a
+  `move_fx` root (`{ name, version, move_fx: { fx1, fx2 } }`).
+
+### Shared FX-bus picker — same foundation as the Send FX PR
+
+The **FX-bus picker / generic multi-bus editor** here is the *same* foundation
+introduced in the Send FX PR (`#115`). It is bundled in **both** PRs so that
+either can be merged independently — neither depends on the other. The picker /
+generic-editor hunks (and the `json_get_section_bounds` fix) are **identical**
+between the two PRs, so if both land they merge cleanly with no conflict; the
+picker simply gains the Send buses or the Move buses depending on which PR is
+applied (or both).

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -60,6 +60,12 @@ int shadow_inprocess_ready = 0;
 /* Master FX slots */
 master_fx_slot_t shadow_master_fx_slots[MASTER_FX_SLOTS];
 
+/* Move FX slots — one mini FX bus per Move track (channel) */
+master_fx_slot_t shadow_move_fx_slots[MOVE_FX_SLOTS][MOVE_FX_BLOCKS];
+move_fx_strip_t shadow_move_fx_strip[MOVE_FX_SLOTS] = {
+    { 1.0f }, { 1.0f }, { 1.0f }, { 1.0f },
+};
+
 /* Master FX LFOs */
 lfo_state_t shadow_master_fx_lfos[MASTER_FX_LFO_COUNT];
 static float mfx_lfo_base_value[MASTER_FX_LFO_COUNT];
@@ -419,6 +425,7 @@ void shadow_chain_defaults(void) {
         shadow_chain_slots[i].soloed = 0;
         shadow_chain_slots[i].forward_channel = -1;
         shadow_chain_slots[i].transpose = 0;
+        shadow_chain_slots[i].move_to_slot = 1;  /* default: Move track rides the synth slot */
         capture_clear(&shadow_chain_slots[i].capture);
         shadow_chain_slots[i].fade.gain = 0.0f;
         shadow_chain_slots[i].fade.target = 0.0f;
@@ -668,6 +675,148 @@ void shadow_master_fx_unload_all(void) {
     for (int i = 0; i < MASTER_FX_SLOTS; i++) {
         shadow_master_fx_slot_unload(i);
     }
+}
+
+/* ============================================================================
+ * Move FX Load / Unload — indexed by (slot, block)
+ * ============================================================================ */
+
+void shadow_move_fx_slot_unload(int slot, int block) {
+    if (slot < 0 || slot >= MOVE_FX_SLOTS) return;
+    if (block < 0 || block >= MOVE_FX_BLOCKS) return;
+    master_fx_slot_t *s = &shadow_move_fx_slots[slot][block];
+
+    if (s->instance && s->api && s->api->destroy_instance) {
+        s->api->destroy_instance(s->instance);
+    }
+    s->instance = NULL;
+    s->api = NULL;
+    s->on_midi = NULL;
+    if (s->handle) {
+        dlclose(s->handle);
+        s->handle = NULL;
+    }
+    s->module_path[0] = '\0';
+    s->module_id[0] = '\0';
+    s->bypassed = 0;
+    capture_clear(&s->capture);
+}
+
+void shadow_move_fx_unload_all(void) {
+    for (int sl = 0; sl < MOVE_FX_SLOTS; sl++) {
+        for (int b = 0; b < MOVE_FX_BLOCKS; b++) {
+            shadow_move_fx_slot_unload(sl, b);
+        }
+    }
+}
+
+int shadow_move_fx_slot_load(int slot, int block, const char *dsp_path) {
+    if (slot < 0 || slot >= MOVE_FX_SLOTS) return -1;
+    if (block < 0 || block >= MOVE_FX_BLOCKS) return -1;
+    master_fx_slot_t *s = &shadow_move_fx_slots[slot][block];
+
+    if (!dsp_path || !dsp_path[0]) {
+        shadow_move_fx_slot_unload(slot, block);
+        return 0;
+    }
+
+    if (strcmp(s->module_path, dsp_path) == 0 && s->instance) {
+        return 0;
+    }
+
+    shadow_move_fx_slot_unload(slot, block);
+
+    s->handle = dlopen(dsp_path, RTLD_NOW | RTLD_LOCAL);
+    if (!s->handle) {
+        fprintf(stderr, "Move FX[%d][%d]: failed to load %s: %s\n", slot, block, dsp_path, dlerror());
+        return -1;
+    }
+
+    audio_fx_init_v2_fn init_fn = (audio_fx_init_v2_fn)dlsym(s->handle, AUDIO_FX_INIT_V2_SYMBOL);
+    if (!init_fn) {
+        fprintf(stderr, "Move FX[%d][%d]: %s not found in %s\n", slot, block, AUDIO_FX_INIT_V2_SYMBOL, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        return -1;
+    }
+
+    s->api = init_fn(&shadow_host_api);
+    if (!s->api || !s->api->create_instance) {
+        fprintf(stderr, "Move FX[%d][%d]: init failed for %s\n", slot, block, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        s->api = NULL;
+        return -1;
+    }
+
+    char module_dir[256];
+    strncpy(module_dir, dsp_path, sizeof(module_dir) - 1);
+    module_dir[sizeof(module_dir) - 1] = '\0';
+    char *last_slash = strrchr(module_dir, '/');
+    if (last_slash) *last_slash = '\0';
+
+    s->instance = s->api->create_instance(module_dir, NULL);
+    if (!s->instance) {
+        fprintf(stderr, "Move FX[%d][%d]: create_instance failed for %s\n", slot, block, dsp_path);
+        dlclose(s->handle);
+        s->handle = NULL;
+        s->api = NULL;
+        return -1;
+    }
+
+    strncpy(s->module_path, dsp_path, sizeof(s->module_path) - 1);
+    s->module_path[sizeof(s->module_path) - 1] = '\0';
+
+    const char *id_start = strrchr(module_dir, '/');
+    if (id_start) {
+        strncpy(s->module_id, id_start + 1, sizeof(s->module_id) - 1);
+    } else {
+        strncpy(s->module_id, module_dir, sizeof(s->module_id) - 1);
+    }
+    s->module_id[sizeof(s->module_id) - 1] = '\0';
+
+    s->chain_params_cached = 0;
+    s->chain_params_cache[0] = '\0';
+
+    char module_json_path[512];
+    snprintf(module_json_path, sizeof(module_json_path), "%s/module.json", module_dir);
+    FILE *f = fopen(module_json_path, "r");
+    if (f) {
+        fseek(f, 0, SEEK_END);
+        long size = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        if (size > 0 && size < 65536) {
+            char *json = malloc(size + 1);
+            if (json) {
+                size_t nread = fread(json, 1, size, f);
+                json[nread] = '\0';
+                const char *chain_params = strstr(json, "\"chain_params\"");
+                if (chain_params) {
+                    const char *arr_start = strchr(chain_params, '[');
+                    if (arr_start) {
+                        int depth = 1;
+                        const char *arr_end = arr_start + 1;
+                        while (*arr_end && depth > 0) {
+                            if (*arr_end == '[') depth++;
+                            else if (*arr_end == ']') depth--;
+                            arr_end++;
+                        }
+                        int len = (int)(arr_end - arr_start);
+                        if (len > 0 && len < (int)sizeof(s->chain_params_cache) - 1) {
+                            memcpy(s->chain_params_cache, arr_start, len);
+                            s->chain_params_cache[len] = '\0';
+                            s->chain_params_cached = 1;
+                        }
+                    }
+                }
+                free(json);
+            }
+        }
+        fclose(f);
+    }
+
+    fprintf(stderr, "Move FX[%d][%d]: loaded %s\n", slot, block, s->module_id);
+    return 0;
 }
 
 int shadow_master_fx_slot_load(int slot, const char *dsp_path) {
@@ -1341,6 +1490,7 @@ int shadow_inprocess_load_chain(void) {
     }
 
     shadow_inprocess_ready = 1;
+
     if (host.startup_modwheel_countdown) {
         *host.startup_modwheel_countdown = host.startup_modwheel_reset_frames;
     }
@@ -1616,6 +1766,10 @@ int shadow_handle_slot_param_set(int slot, const char *key, const char *value) {
         shadow_ui_state_update_slot(slot);
         return 1;
     }
+    if (strcmp(key, "slot:move_to_slot") == 0) {
+        shadow_chain_slots[slot].move_to_slot = atoi(value) ? 1 : 0;
+        return 1;
+    }
     return 0;
 }
 
@@ -1638,6 +1792,9 @@ int shadow_handle_slot_param_get(int slot, const char *key, char *buf, int buf_l
     }
     if (strcmp(key, "slot:transpose") == 0) {
         return snprintf(buf, buf_len, "%d", shadow_chain_slots[slot].transpose);
+    }
+    if (strcmp(key, "slot:move_to_slot") == 0) {
+        return snprintf(buf, buf_len, "%d", shadow_chain_slots[slot].move_to_slot);
     }
     if (strcmp(key, "active_set") == 0) {
         /* Return "uuid\nname" for UI thread to write active_set.txt */
@@ -1687,6 +1844,43 @@ void shadow_direct_set_param(uint8_t slot, const char *key, const char *value) {
         }
         /* Unrecognized master_fx:* keys (lfo*, specials): don't misroute to the
          * chain-slot plugin below — leave for the shadow_param path. */
+        return;
+    }
+
+    /* Handle Move FX params: move_fx:N:fx1:param or move_fx:N:volume (N = 1..4) */
+    if (strncmp(key, "move_fx:", 8) == 0) {
+        const char *rest = key + 8;
+        int sl = -1;
+        if (rest[0] >= '1' && rest[0] <= '4' && rest[1] == ':') { sl = rest[0] - '1'; rest += 2; }
+        if (sl < 0) return;
+
+        /* Strip-level params (no fxN prefix) */
+        if (strcmp(rest, "volume") == 0) {
+            float v = (value && value[0]) ? atof(value) : 1.0f;
+            if (v < 0.0f) v = 0.0f; if (v > 4.0f) v = 4.0f;
+            shadow_move_fx_strip[sl].volume = v;
+            if (host.on_param_changed) host.on_param_changed(slot, key, value);
+            return;
+        }
+
+        /* Generic fxN: parse (N = 1..MOVE_FX_BLOCKS) so the fork can raise the
+         * block count via a single #define with no parser changes. */
+        int blk = -1;
+        if (rest[0] == 'f' && rest[1] == 'x' && rest[2] >= '1' && rest[2] <= '9' && rest[3] == ':') {
+            int n = rest[2] - '1';
+            if (n < MOVE_FX_BLOCKS) { blk = n; rest += 4; }
+        }
+        if (blk < 0) return;
+
+        master_fx_slot_t *mfx = &shadow_move_fx_slots[sl][blk];
+        if (strcmp(rest, "module") == 0) {
+            shadow_move_fx_slot_load(sl, blk, value);
+        } else if (strcmp(rest, "bypassed") == 0) {
+            mfx->bypassed = (value[0] && atoi(value)) ? 1 : 0;
+        } else if (mfx->api && mfx->instance && mfx->api->set_param) {
+            mfx->api->set_param(mfx->instance, rest, value);
+        }
+        if (host.on_param_changed) host.on_param_changed(slot, key, value);
         return;
     }
 
@@ -2244,6 +2438,108 @@ void shadow_master_fx_lfo_tick(int frames) {
     }
 }
 
+/* Handle a per-FX-slot param request (everything after the slot prefix is
+ * resolved) for one master_fx_slot_t: the non-module SET cases and all GET
+ * cases (module/name/bypassed/chain_params/ui_hierarchy/live param). Sets
+ * p->value/error/result_len but does NOT publish — the caller publishes once.
+ * Module-load SET is handled by the caller (loaders differ per FX-bus type). */
+static void fx_slot_param_rest(master_fx_slot_t *s, const char *rest,
+                               shadow_param_t *p, uint8_t req_type) {
+    if (req_type == 1) {  /* SET (module handled by caller) */
+        if (strcmp(rest, "bypassed") == 0) {
+            s->bypassed = (p->value[0] && atoi(p->value)) ? 1 : 0;
+            p->error = 0; p->result_len = 0;
+        } else if (s->api && s->instance && s->api->set_param) {
+            s->api->set_param(s->instance, rest, p->value);
+            p->error = 0; p->result_len = 0;
+        } else {
+            p->error = 9; p->result_len = -1;
+        }
+        return;
+    }
+    /* GET */
+    if (strcmp(rest, "module") == 0) {
+        strncpy(p->value, s->module_path, SHADOW_PARAM_VALUE_LEN - 1);
+        p->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';
+        p->error = 0; p->result_len = strlen(p->value);
+    } else if (strcmp(rest, "name") == 0) {
+        strncpy(p->value, s->module_id, SHADOW_PARAM_VALUE_LEN - 1);
+        p->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';
+        p->error = 0; p->result_len = strlen(p->value);
+    } else if (strcmp(rest, "bypassed") == 0) {
+        snprintf(p->value, SHADOW_PARAM_VALUE_LEN, "%d", s->bypassed ? 1 : 0);
+        p->error = 0; p->result_len = strlen(p->value);
+    } else if (strcmp(rest, "chain_params") == 0) {
+        if (s->api && s->instance && s->api->get_param) {
+            int len = s->api->get_param(s->instance, "chain_params", p->value, SHADOW_PARAM_VALUE_LEN);
+            if (len > 2) { p->error = 0; p->result_len = len; return; }
+        }
+        if (s->chain_params_cached && s->chain_params_cache[0]) {
+            int len = strlen(s->chain_params_cache);
+            if (len < SHADOW_PARAM_VALUE_LEN - 1) {
+                memcpy(p->value, s->chain_params_cache, len + 1);
+                p->error = 0; p->result_len = len; return;
+            }
+        }
+        p->value[0] = '['; p->value[1] = ']'; p->value[2] = '\0';
+        p->error = 0; p->result_len = 2;
+    } else if (strcmp(rest, "ui_hierarchy") == 0) {
+        if (s->api && s->instance && s->api->get_param) {
+            int len = s->api->get_param(s->instance, "ui_hierarchy", p->value, SHADOW_PARAM_VALUE_LEN);
+            if (len > 2) { p->error = 0; p->result_len = len; return; }
+        }
+        /* Fall back to reading ui_hierarchy from module.json (some modules
+         * declare it there but don't expose it via live get_param). */
+        {
+            char module_dir[256];
+            strncpy(module_dir, s->module_path, sizeof(module_dir) - 1);
+            module_dir[sizeof(module_dir) - 1] = '\0';
+            char *last_slash = strrchr(module_dir, '/');
+            if (last_slash) *last_slash = '\0';
+            char json_path[512];
+            snprintf(json_path, sizeof(json_path), "%s/module.json", module_dir);
+            FILE *f = fopen(json_path, "r");
+            if (f) {
+                fseek(f, 0, SEEK_END); long size = ftell(f); fseek(f, 0, SEEK_SET);
+                if (size > 0 && size < 65536) {
+                    char *json = malloc(size + 1);
+                    if (json) {
+                        size_t nread = fread(json, 1, size, f); json[nread] = '\0';
+                        const char *ui_hier = strstr(json, "\"ui_hierarchy\"");
+                        if (ui_hier) {
+                            const char *obj_start = strchr(ui_hier + 14, '{');
+                            if (obj_start) {
+                                int depth = 1; const char *obj_end = obj_start + 1;
+                                while (*obj_end && depth > 0) {
+                                    if (*obj_end == '{') depth++;
+                                    else if (*obj_end == '}') depth--;
+                                    obj_end++;
+                                }
+                                int hlen = (int)(obj_end - obj_start);
+                                if (hlen > 0 && hlen < SHADOW_PARAM_VALUE_LEN - 1) {
+                                    memcpy(p->value, obj_start, hlen);
+                                    p->value[hlen] = '\0';
+                                    p->error = 0; p->result_len = hlen;
+                                    free(json); fclose(f); return;
+                                }
+                            }
+                        }
+                        free(json);
+                    }
+                }
+                fclose(f);
+            }
+        }
+        p->value[0] = '\0'; p->error = 0; p->result_len = 0;
+    } else if (s->api && s->instance && s->api->get_param) {
+        int len = s->api->get_param(s->instance, rest, p->value, SHADOW_PARAM_VALUE_LEN);
+        if (len >= 0) { p->error = 0; p->result_len = len; }
+        else { p->error = 10; p->result_len = -1; }
+    } else {
+        p->error = 11; p->result_len = -1;
+    }
+}
+
 void shadow_inprocess_handle_param_request(void) {
     shadow_param_t *shadow_param = host.shadow_param_ptr ? *host.shadow_param_ptr : NULL;
     if (!shadow_param) return;
@@ -2618,6 +2914,62 @@ void shadow_inprocess_handle_param_request(void) {
         } else {
             shadow_param->error = 6;
             shadow_param->result_len = -1;
+        }
+        shadow_param_publish_response(req_id);
+        return;
+    }
+
+    /* Handle Move FX params: move_fx:N:fx1:param or move_fx:N:volume (N = 1..4) */
+    if (strncmp(shadow_param->key, "move_fx:", 8) == 0) {
+        const char *rest = shadow_param->key + 8;
+        int sl = -1;
+        if (rest[0] >= '1' && rest[0] <= '4' && rest[1] == ':') { sl = rest[0] - '1'; rest += 2; }
+        if (sl < 0) {
+            shadow_param->error = 1;
+            shadow_param->result_len = -1;
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        /* Strip-level params (no fxN prefix): volume */
+        if (strcmp(rest, "volume") == 0) {
+            float *tgt = &shadow_move_fx_strip[sl].volume;
+            if (req_type == 1) {  /* SET */
+                float v = (shadow_param->value[0]) ? atof(shadow_param->value) : 1.0f;
+                if (v < 0.0f) v = 0.0f;
+                if (v > 4.0f) v = 4.0f;
+                *tgt = v;
+                shadow_param->error = 0;
+                shadow_param->result_len = 0;
+            } else if (req_type == 2) {  /* GET */
+                snprintf(shadow_param->value, SHADOW_PARAM_VALUE_LEN, "%.3f", *tgt);
+                shadow_param->error = 0;
+                shadow_param->result_len = strlen(shadow_param->value);
+            }
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        /* Generic fxN: parse (N = 1..MOVE_FX_BLOCKS) */
+        int blk = -1;
+        if (rest[0] == 'f' && rest[1] == 'x' && rest[2] >= '1' && rest[2] <= '9' && rest[3] == ':') {
+            int n = rest[2] - '1';
+            if (n < MOVE_FX_BLOCKS) { blk = n; rest += 4; }
+        }
+        if (blk < 0) {
+            shadow_param->error = 1;
+            shadow_param->result_len = -1;
+            shadow_param_publish_response(req_id);
+            return;
+        }
+
+        master_fx_slot_t *mfx = &shadow_move_fx_slots[sl][blk];
+        if (req_type == 1 && strcmp(rest, "module") == 0) {
+            int result = shadow_move_fx_slot_load(sl, blk, shadow_param->value);
+            shadow_param->error = (result == 0) ? 0 : 7;
+            shadow_param->result_len = 0;
+        } else {
+            fx_slot_param_rest(mfx, rest, shadow_param, req_type);
         }
         shadow_param_publish_response(req_id);
         return;

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -19,6 +19,8 @@
  * ============================================================================ */
 
 #define MASTER_FX_SLOTS 4
+#define MOVE_FX_SLOTS  4   /* one Move FX mini-bus per Move track / channel */
+#define MOVE_FX_BLOCKS 2   /* up to 2 insert FX per Move FX slot */
 #define SHADOW_CHAIN_MODULE_DIR "/data/UserData/schwung/modules/chain"
 #define SHADOW_CHAIN_DSP_PATH "/data/UserData/schwung/modules/chain/dsp.so"
 
@@ -111,6 +113,17 @@ extern int shadow_inprocess_ready;
 /* Master FX slots */
 extern master_fx_slot_t shadow_master_fx_slots[MASTER_FX_SLOTS];
 
+/* Move FX slots — one mini FX bus per Move track (channel), each with up to
+ * MOVE_FX_BLOCKS insert FX in series. Fed by the channel's Move track when the
+ * synth slot's move_to_slot == 0. Output mixes to the master at the strip's
+ * volume. */
+extern master_fx_slot_t shadow_move_fx_slots[MOVE_FX_SLOTS][MOVE_FX_BLOCKS];
+
+typedef struct {
+    float volume;   /* 0..4, default 1.0 (unity) */
+} move_fx_strip_t;
+extern move_fx_strip_t shadow_move_fx_strip[MOVE_FX_SLOTS];
+
 /* Master FX LFOs */
 #define MASTER_FX_LFO_COUNT 2
 extern lfo_state_t shadow_master_fx_lfos[MASTER_FX_LFO_COUNT];
@@ -166,6 +179,19 @@ static inline int shadow_master_fx_chain_active(void) {
     return 0;
 }
 
+/* Check if any FX block on a Move FX slot has a loaded instance. When false the
+ * Move track still routes through the slot (volume) but skips FX. */
+static inline int shadow_move_fx_has_fx(int slot) {
+    if (slot < 0 || slot >= MOVE_FX_SLOTS) return 0;
+    for (int b = 0; b < MOVE_FX_BLOCKS; b++) {
+        master_fx_slot_t *s = &shadow_move_fx_slots[slot][b];
+        if (s->instance && s->api && s->api->process_block) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* ============================================================================
  * Public functions
  * ============================================================================ */
@@ -213,6 +239,11 @@ int shadow_master_fx_slot_load_with_config(int slot, const char *dsp_path,
 int shadow_master_fx_load(const char *dsp_path);
 void shadow_master_fx_unload(void);
 void shadow_master_fx_forward_midi(const uint8_t *msg, int len, int source);
+
+/* --- Move FX --- */
+void shadow_move_fx_slot_unload(int slot, int block);
+void shadow_move_fx_unload_all(void);
+int shadow_move_fx_slot_load(int slot, int block, const char *dsp_path);
 
 /* --- Capture loading --- */
 void shadow_slot_load_capture(int slot, int patch_index);

--- a/src/host/shadow_chain_types.h
+++ b/src/host/shadow_chain_types.h
@@ -39,6 +39,9 @@ typedef struct shadow_chain_slot_t {
     int soloed;             /* 1 = soloed (Shift+Mute+Track or Move solo-cue sync) */
     int forward_channel;    /* -2 = passthrough, -1 = auto, 0-15 = forward MIDI to this channel */
     int transpose;          /* semitone offset applied to incoming note-on/off/poly-AT, range -12..+12 */
+    int move_to_slot;       /* Move>Slot: 1 = sum same-channel Move track into this synth slot
+                             * (default, shares the slot's FX); 0 = peel Move track off to its
+                             * dedicated Move FX slot */
     char patch_name[64];
     shadow_capture_rules_t capture;  /* MIDI controls this slot captures when focused */
     slot_fade_t fade;                /* fade envelope for seamless transitions */

--- a/src/host/shadow_state.c
+++ b/src/host/shadow_state.c
@@ -222,11 +222,16 @@ void shadow_save_state(void)
             host_chain_slots[1].muted,
             host_chain_slots[2].muted,
             host_chain_slots[3].muted);
-    fprintf(f, "  \"slot_soloed\": [%d, %d, %d, %d]\n",
+    fprintf(f, "  \"slot_soloed\": [%d, %d, %d, %d],\n",
             host_chain_slots[0].soloed,
             host_chain_slots[1].soloed,
             host_chain_slots[2].soloed,
             host_chain_slots[3].soloed);
+    fprintf(f, "  \"slot_move_to_slot\": [%d, %d, %d, %d]\n",
+            host_chain_slots[0].move_to_slot,
+            host_chain_slots[1].move_to_slot,
+            host_chain_slots[2].move_to_slot,
+            host_chain_slots[3].move_to_slot);
     fprintf(f, "}\n");
     fclose(f);
     chown_to_ableton(SHADOW_CONFIG_PATH);
@@ -407,6 +412,21 @@ void shadow_load_state(void)
                 snprintf(msg, sizeof(msg), "Loaded slot soloed: [%d, %d, %d, %d]",
                          s0, s1, s2, s3);
                 if (host_log) host_log(msg);
+            }
+        }
+    }
+
+    /* Parse slot_move_to_slot array (missing key → leaves default 1) */
+    const char *mts_key = "\"slot_move_to_slot\":";
+    char *mts_pos = strstr(json, mts_key);
+    if (mts_pos) {
+        mts_pos = strchr(mts_pos, '[');
+        if (mts_pos) {
+            int m0, m1, m2, m3;
+            if (sscanf(mts_pos, "[%d, %d, %d, %d]", &m0, &m1, &m2, &m3) == 4) {
+                int mts[4] = {m0, m1, m2, m3};
+                for (int i = 0; i < 4; i++)
+                    host_chain_slots[i].move_to_slot = mts[i] ? 1 : 0;
             }
         }
     }

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1915,8 +1915,15 @@ static int json_get_section_bounds(const char *json, const char *section_key,
     const char *pos = strstr(json, search);
     if (!pos) return -1;
 
-    const char *start = strchr(pos, '{');
-    if (!start) return -1;
+    /* Only treat this key as a section if its VALUE is an object. Skipping
+     * straight to the next '{' would, for a null-valued key (e.g. an empty FX
+     * slot: "fx2":null), grab a LATER slot's object — corrupting saved presets
+     * with gaps (filled/empty/filled). Anchor on the key's colon + value. */
+    const char *colon = strchr(pos + strlen(search), ':');
+    if (!colon) return -1;
+    const char *start = colon + 1;
+    while (*start == ' ' || *start == '\t' || *start == '\n' || *start == '\r') start++;
+    if (*start != '{') return -1;   /* value is null / not an object */
 
     int depth = 0;
     const char *end = NULL;
@@ -6049,6 +6056,200 @@ static int load_master_preset_json(int index, char *buf, int buf_len) {
 
 /* ========== End Master Preset Functions ========== */
 
+/* ========== Move FX Preset Functions ========== */
+/* Single SHARED Move FX preset store: all 4 Move FX buses draw from one
+ * list/dir (presets are interchangeable between buses). Wraps the bus's 2 FX
+ * slots under a "move_fx" root. JS editor is descriptor-driven (presetJsonRoot
+ * "move_fx"). Mirrors the master preset store. */
+
+#define PRESETS_MOVE_DIR "/data/UserData/schwung/presets_move"
+#define MAX_MOVE_PRESETS 64
+
+static char move_preset_names[MAX_MOVE_PRESETS][MAX_NAME_LEN];
+static char move_preset_paths[MAX_MOVE_PRESETS][MAX_PATH_LEN];
+static int move_preset_count = 0;
+
+static void ensure_presets_move_dir(void) {
+    struct stat st = {0};
+    if (stat(PRESETS_MOVE_DIR, &st) == -1) {
+        mkdir(PRESETS_MOVE_DIR, 0755);
+    }
+}
+
+static void scan_move_presets(void) {
+    move_preset_count = 0;
+    memset(move_preset_names, 0, sizeof(move_preset_names));
+    memset(move_preset_paths, 0, sizeof(move_preset_paths));
+    ensure_presets_move_dir();
+
+    DIR *dir = opendir(PRESETS_MOVE_DIR);
+    if (!dir) return;
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL && move_preset_count < MAX_MOVE_PRESETS) {
+        if (entry->d_type != DT_REG) continue;
+
+        const char *name = entry->d_name;
+        size_t len = strlen(name);
+        if (len < 6 || strcmp(name + len - 5, ".json") != 0) continue;
+
+        size_t name_len = len - 5;
+        if (name_len >= MAX_NAME_LEN) name_len = MAX_NAME_LEN - 1;
+
+        char path[MAX_PATH_LEN];
+        snprintf(path, sizeof(path), "%s/%s", PRESETS_MOVE_DIR, name);
+
+        int idx = move_preset_count;
+        FILE *f = fopen(path, "r");
+        if (f) {
+            char json_buf[2048];
+            size_t read_len = fread(json_buf, 1, sizeof(json_buf) - 1, f);
+            json_buf[read_len] = '\0';
+            fclose(f);
+
+            char parsed_name[MAX_NAME_LEN] = {0};
+            if (json_get_string(json_buf, "name", parsed_name, sizeof(parsed_name)) == 0) {
+                strncpy(move_preset_names[idx], parsed_name, MAX_NAME_LEN - 1);
+                move_preset_names[idx][MAX_NAME_LEN - 1] = '\0';
+            } else {
+                memcpy(move_preset_names[idx], name, name_len);
+                move_preset_names[idx][name_len] = '\0';
+            }
+        } else {
+            memcpy(move_preset_names[idx], name, name_len);
+            move_preset_names[idx][name_len] = '\0';
+        }
+
+        strncpy(move_preset_paths[idx], path, MAX_PATH_LEN - 1);
+        move_preset_paths[idx][MAX_PATH_LEN - 1] = '\0';
+        move_preset_count++;
+    }
+    closedir(dir);
+}
+
+/* Build the wrapped preset JSON for the bus's 2 Move FX slots. Buffers sized to
+ * match the master path so large modules round-trip under the 64KB GET limit. */
+static void build_move_preset_json(char *out, int out_len,
+                                   const char *name, const char *json_str) {
+    char fx1[8192], fx2[8192];
+    extract_fx_section(json_str, "fx1", fx1, sizeof(fx1));
+    extract_fx_section(json_str, "fx2", fx2, sizeof(fx2));
+    snprintf(out, out_len,
+        "{\n"
+        "    \"name\": \"%s\",\n"
+        "    \"version\": 1,\n"
+        "    \"move_fx\": {\n"
+        "        \"fx1\": %s,\n"
+        "        \"fx2\": %s\n"
+        "    }\n"
+        "}\n",
+        name, fx1, fx2);
+}
+
+static int save_move_preset(const char *json_str) {
+    ensure_presets_move_dir();
+
+    char name[MAX_NAME_LEN] = "Move FX";
+    json_get_string(json_str, "custom_name", name, sizeof(name));
+
+    char filename[MAX_NAME_LEN];
+    sanitize_filename(filename, sizeof(filename), name);
+
+    char path[MAX_PATH_LEN];
+    snprintf(path, sizeof(path), "%s/%s.json", PRESETS_MOVE_DIR, filename);
+
+    char final_json[40960];
+    build_move_preset_json(final_json, sizeof(final_json), name, json_str);
+
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Failed to save Move FX preset: %s", path);
+        chain_log(msg);
+        return -1;
+    }
+    fputs(final_json, f);
+    fclose(f);
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Saved Move FX preset: %s", name);
+        chain_log(msg);
+    }
+    scan_move_presets();
+    return 0;
+}
+
+static int update_move_preset(int index, const char *json_str) {
+    if (index < 0 || index >= move_preset_count) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Invalid Move FX preset index: %d", index);
+        chain_log(msg);
+        return -1;
+    }
+
+    char name[MAX_NAME_LEN];
+    if (json_get_string(json_str, "custom_name", name, sizeof(name)) != 0) {
+        strncpy(name, move_preset_names[index], sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
+    }
+
+    char final_json[40960];
+    build_move_preset_json(final_json, sizeof(final_json), name, json_str);
+
+    FILE *f = fopen(move_preset_paths[index], "w");
+    if (!f) return -1;
+    fputs(final_json, f);
+    fclose(f);
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Updated Move FX preset: %s", name);
+        chain_log(msg);
+    }
+    scan_move_presets();
+    return 0;
+}
+
+static int delete_move_preset(int index) {
+    if (index < 0 || index >= move_preset_count) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Invalid Move FX preset index: %d", index);
+        chain_log(msg);
+        return -1;
+    }
+    if (remove(move_preset_paths[index]) != 0) {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Failed to delete Move FX preset: %s", move_preset_paths[index]);
+        chain_log(msg);
+        return -1;
+    }
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Deleted Move FX preset: %s", move_preset_names[index]);
+        chain_log(msg);
+    }
+    scan_move_presets();
+    return 0;
+}
+
+static int load_move_preset_json(int index, char *buf, int buf_len) {
+    if (index < 0 || index >= move_preset_count) { buf[0] = '\0'; return 0; }
+
+    FILE *f = fopen(move_preset_paths[index], "r");
+    if (!f) { buf[0] = '\0'; return 0; }
+
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len <= 0) { fclose(f); buf[0] = '\0'; return 0; }
+    if (len >= buf_len) len = buf_len - 1;
+    size_t nr = fread(buf, 1, len, f);
+    buf[nr] = '\0';
+    fclose(f);
+    return (int)nr;
+}
+
+/* ========== End Move FX Preset Functions ========== */
+
 /* Debug logging helper for parsing */
 static void parse_debug_log(const char *msg) {
     struct stat st;
@@ -7422,6 +7623,22 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             update_master_preset(index, colon + 1);
         }
     }
+    /* Move FX preset commands (shared store across all 4 Move FX buses) */
+    else if (strcmp(key, "save_move_preset") == 0) {
+        save_move_preset(val);
+    }
+    else if (strcmp(key, "delete_move_preset") == 0) {
+        int index = atoi(val);
+        delete_move_preset(index);
+    }
+    else if (strcmp(key, "update_move_preset") == 0) {
+        /* Format: "index:json_data" */
+        const char *colon = strchr(val, ':');
+        if (colon) {
+            int index = atoi(val);
+            update_move_preset(index, colon + 1);
+        }
+    }
     else if (strncmp(key, "synth:", 6) == 0) {
         const char *subkey = key + 6;
         /* Intercept module change to swap synth dynamically */
@@ -8162,6 +8379,22 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     if (strncmp(key, "master_preset_json_", 19) == 0) {
         int idx = atoi(key + 19);
         return load_master_preset_json(idx, buf, buf_len);
+    }
+    /* Move FX preset queries (shared store across all 4 Move FX buses) */
+    if (strcmp(key, "move_preset_count") == 0) {
+        scan_move_presets();
+        return snprintf(buf, buf_len, "%d", move_preset_count);
+    }
+    if (strncmp(key, "move_preset_name_", 17) == 0) {
+        int idx = atoi(key + 17);
+        if (idx >= 0 && idx < move_preset_count) {
+            return snprintf(buf, buf_len, "%s", move_preset_names[idx]);
+        }
+        return -1;
+    }
+    if (strncmp(key, "move_preset_json_", 17) == 0) {
+        int idx = atoi(key + 17);
+        return load_move_preset_json(idx, buf, buf_len);
     }
     if (strcmp(key, "fx_count") == 0) {
         return snprintf(buf, buf_len, "%d", inst->fx_count);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2090,14 +2090,56 @@ static void shadow_inprocess_mix_from_buffer(void) {
             int16_t *move_track = la_cache[s];
             int have_move_track = la_cache_valid[s];
 
+            /* Move>Slot: 1 = sum Move track into this synth slot (shares FX +
+             * sends); 0 = peel it off to the dedicated Move FX slot below. */
+            int route_to_synth = shadow_chain_slots[s].move_to_slot;
+
             int slot_active = (shadow_chain_slots[s].active &&
                                shadow_chain_slots[s].instance &&
                                shadow_slot_deferred_valid[s]);
 
+            /* Move FX slot: when Move>Slot is off, the channel's Move track is
+             * routed through its own ≤MOVE_FX_BLOCKS insert FX chain (independent
+             * of the synth on this channel), then mixed to the master at the
+             * strip's volume. Runs regardless of whether a synth is loaded on the
+             * slot, and BEFORE the synth block so the synth's idle-continue below
+             * can't skip it. Mixing is additive, so order doesn't change the sum. */
+            if (!route_to_synth && have_move_track && s < MOVE_FX_SLOTS) {
+                /* Skip the copy + FX loop entirely when no FX is loaded — the
+                 * track then mixes straight from la_cache (read-only). */
+                const int16_t *msrc = move_track;
+                int16_t mbuf[FRAMES_PER_BLOCK * 2];
+                if (shadow_move_fx_has_fx(s)) {
+                    memcpy(mbuf, move_track, sizeof(mbuf));
+                    for (int b = 0; b < MOVE_FX_BLOCKS; b++) {
+                        master_fx_slot_t *mf = &shadow_move_fx_slots[s][b];
+                        if (!(mf->instance && mf->api && mf->api->process_block)) continue;
+                        if (mf->bypassed) continue;
+                        mf->api->process_block(mf->instance, mbuf, FRAMES_PER_BLOCK);
+                    }
+                    msrc = mbuf;
+                }
+                /* The Move FX strip is fully independent of the synth slot on
+                 * this channel — its own volume only, deliberately NOT gated by
+                 * the synth slot's mute/solo (that independence is the feature). */
+                float mvol = shadow_move_fx_strip[s].volume;
+                for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+                    int32_t scaled = (int32_t)lroundf((float)msrc[i] * mvol);
+                    int32_t mixed = (int32_t)mailbox_audio[i] + scaled;
+                    if (mixed > 32767) mixed = 32767;
+                    if (mixed < -32768) mixed = -32768;
+                    mailbox_audio[i] = (int16_t)mixed;
+                    me_full[i]  += scaled;
+                    me_unity[i] += scaled;
+                }
+            }
+
             if (slot_active) {
                 /* Phase 2 idle gate: skip FX when synth AND FX output are silent
-                 * AND no Link Audio track data is flowing for this slot */
-                if (shadow_slot_fx_idle[s] && shadow_slot_idle[s] && !have_move_track) continue;
+                 * AND either no Link Audio track is flowing OR it's been peeled to
+                 * the Move FX slot (handled above), so the synth has nothing to do. */
+                if (shadow_slot_fx_idle[s] && shadow_slot_idle[s] &&
+                    (!have_move_track || !route_to_synth)) continue;
 
                 /* Latency comp: delay the local synth output to match the
                  * Link Audio path before combining. The nudge in
@@ -2153,11 +2195,14 @@ static void shadow_inprocess_mix_from_buffer(void) {
                     }
                 }
 
-                /* Active slot: combine synth + Link Audio, run through FX */
+                /* Active slot: combine synth + Link Audio, run through FX.
+                 * The Move track is summed in only when Move>Slot routes it
+                 * here (route_to_synth); otherwise the synth is processed alone
+                 * and the Move track goes through its Move FX slot below. */
                 int16_t fx_buf[FRAMES_PER_BLOCK * 2];
                 for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
                     int32_t combined = (int32_t)synth_src[i];
-                    if (have_move_track)
+                    if (have_move_track && route_to_synth)
                         combined += (int32_t)move_track[i];
                     if (combined > 32767) combined = 32767;
                     if (combined < -32768) combined = -32768;
@@ -2266,9 +2311,11 @@ static void shadow_inprocess_mix_from_buffer(void) {
                     me_unity[i] += (int32_t)lroundf((float)fx_buf[i] * vol);
                     if (i & 1) shadow_fade_advance(s);
                 }
-            } else if (have_move_track) {
-                /* Inactive slot: pass Link Audio through at unity level.
-                 * Master volume is applied after capture at the end. */
+            } else if (have_move_track && route_to_synth) {
+                /* Inactive slot, Move>Slot on: pass Link Audio through at unity
+                 * level. Master volume is applied after capture at the end.
+                 * (When Move>Slot is off the track is handled by the Move FX
+                 * block below instead.) */
                 for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
                     int32_t mixed = (int32_t)mailbox_audio[i] + (int32_t)move_track[i];
                     if (mixed > 32767) mixed = 32767;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -4259,9 +4259,13 @@ function loadChainConfigFromDir(dir) {
             if (typeof s.forward_channel === "number") setSlotParamWithTimeout(i, "slot:forward_channel", String(s.forward_channel), 500);
             if (typeof s.muted === "number") setSlotParamWithTimeout(i, "slot:muted", String(s.muted), 500);
             if (typeof s.soloed === "number") setSlotParamWithTimeout(i, "slot:soloed", String(s.soloed), 500);
-            /* Move>Slot routing (missing in older configs → leave shim default 1,
-             * i.e. Move track rides the synth slot). */
-            if (typeof s.move_to_slot === "number") setSlotParamWithTimeout(i, "slot:move_to_slot", String(s.move_to_slot), 500);
+            /* Move>Slot routing (Move>SchwFX): ALWAYS write — saved value if
+             * present, else default 1 (Move track rides the synth slot, the
+             * preexisting behavior). The shim's move_to_slot is global and NOT
+             * reset per set, so skipping a missing field leaves it stale from the
+             * prior set (e.g. a peeled 0), exactly like receive_channel above. */
+            const mts = (typeof s.move_to_slot === "number") ? s.move_to_slot : 1;
+            setSlotParamWithTimeout(i, "slot:move_to_slot", String(mts), 500);
         }
         debugLog("SET_CHANGED: loaded chain config from " + path);
     } catch (e) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -312,7 +312,8 @@ const VIEWS = {
     LFO_EDIT: "lfoedit",                      // LFO sub-menu editor
     ANALYTICS_PROMPT: "analyticsprompt",       // First-run analytics opt-out prompt
     LFO_TARGET_COMPONENT: "lfotargetcomp",    // LFO target picker step 1: component
-    LFO_TARGET_PARAM: "lfotargetparam"        // LFO target picker step 2: parameter
+    LFO_TARGET_PARAM: "lfotargetparam",       // LFO target picker step 2: parameter
+    FX_BUS_PICKER: "fxbuspicker"              // Pick Master FX / Move FX bus
 };
 
 /* Special action key for swap module option */
@@ -337,10 +338,10 @@ const moduleAbbrevCache = {
 /* In-memory chain configuration (for future save/load) */
 function createEmptyChainConfig() {
     return {
-        midiFx: null,    // { module: "chord", params: {} } or null
-        synth: null,     // { module: "dexed", params: {} } or null
-        fx1: null,       // { module: "freeverb", params: {} } or null
-        fx2: null        // { module: "cloudseed", params: {} } or null
+        midiFx: null,
+        synth: null,
+        fx1: null,
+        fx2: null
     };
 }
 
@@ -846,6 +847,12 @@ let selectedMasterFx = 0;    // Index into MASTER_FX_OPTIONS
 let currentMasterFxId = "";  // Currently loaded master FX module ID
 let currentMasterFxPath = ""; // Full path to currently loaded DSP
 
+/* Move FX dimensions. MOVE_FX_BLOCKS_JS must match the C #define MOVE_FX_BLOCKS;
+ * the fork raises both together (e.g. to 4). Defined here (above FX_BUS) because
+ * the Move FX bus descriptors are built from them just below. */
+const MOVE_FX_SLOTS_JS = 4;
+const MOVE_FX_BLOCKS_JS = 2;
+
 /* Master FX chain components (4 FX slots + settings) */
 const MASTER_FX_CHAIN_COMPONENTS = [
     { key: "fx1", label: "FX 1", position: 0, paramPrefix: "master_fx:fx1:" },
@@ -854,6 +861,71 @@ const MASTER_FX_CHAIN_COMPONENTS = [
     { key: "fx4", label: "FX 4", position: 3, paramPrefix: "master_fx:fx4:" },
     { key: "settings", label: "Settings", position: 4, paramPrefix: "" }
 ];
+
+/* ---- FX bus descriptors -------------------------------------------------- *
+ * One editor (shadow_ui_master_fx.mjs + the helpers below) serves Master FX
+ * and the per-track Move FX mini-buses. The FX bus picker selects the active
+ * bus before entry. Descriptors are plain object literals (QuickJS: no
+ * member-expression keys). Only one editor is open at a time, so the editor's
+ * transient state (selection, masterFxConfig, preset list) is shared and
+ * repopulated per bus on entry — no per-bus copies needed. */
+const FX_BUS = {
+    master: {
+        id: "master", title: "Master FX", paramPrefix: "master_fx:",
+        slotCount: 4, hasLfo: true, persistConfig: true,
+        volumeKey: "master_fx:volume", components: MASTER_FX_CHAIN_COMPONENTS,
+        presetPickerTitle: "Master Presets",
+        presetJsonRoot: "master_fx",
+        presetCountKey: "master_preset_count",
+        presetNamePrefix: "master_preset_name_",
+        presetJsonPrefix: "master_preset_json_",
+        presetSaveKey: "save_master_preset",
+        presetUpdateKey: "update_master_preset",
+        presetDeleteKey: "delete_master_preset"
+    }
+};
+/* Move FX buses — one per Move track (channel). Audio-FX-only mini-buses with
+ * MOVE_FX_BLOCKS_JS insert slots, surfaced in the FX bus picker. No LFO; the
+ * settings page exposes volume + the shared Move FX preset actions. Built
+ * programmatically so raising MOVE_FX_BLOCKS_JS needs no further edits here. */
+for (let mvSlot = 1; mvSlot <= MOVE_FX_SLOTS_JS; mvSlot++) {
+    const prefix = "move_fx:" + mvSlot + ":";
+    const comps = [];
+    for (let b = 1; b <= MOVE_FX_BLOCKS_JS; b++) {
+        comps.push({ key: "fx" + b, label: "FX " + b, position: b - 1, paramPrefix: prefix + "fx" + b + ":" });
+    }
+    comps.push({ key: "settings", label: "Settings", position: MOVE_FX_BLOCKS_JS, paramPrefix: "" });
+    FX_BUS["moveFx" + mvSlot] = {
+        id: "moveFx" + mvSlot, title: "Move " + mvSlot + " FX", paramPrefix: prefix,
+        slotCount: MOVE_FX_BLOCKS_JS, hasLfo: false, persistConfig: false,
+        isMoveFx: true, moveSlot: mvSlot - 1,
+        volumeKey: prefix + "volume", components: comps,
+        /* Shared Move FX preset store — identical keys on all 4 buses, so one
+         * list saved/loaded from any bus. Wraps the 2 insert FX (not volume).
+         * Mirrors the master/send descriptor preset config. */
+        presetPickerTitle: "Move FX Presets",
+        presetJsonRoot: "move_fx",
+        presetCountKey: "move_preset_count",
+        presetNamePrefix: "move_preset_name_",
+        presetJsonPrefix: "move_preset_json_",
+        presetSaveKey: "save_move_preset",
+        presetUpdateKey: "update_move_preset",
+        presetDeleteKey: "delete_move_preset",
+        settingsItems: [
+            { key: "move_volume", label: "Volume", type: "float", min: 0, max: 4, step: 0.05, param: prefix + "volume" },
+        ]
+    };
+}
+
+/* Active bus for the FX editor. Set by the FX bus picker; persists through the
+ * editor's sub-views. Defaults to master. */
+let activeFxBus = FX_BUS.master;
+
+/* Build a slot param key for the active bus, e.g.
+ *   master: master_fx:fx2:bypassed   moveFx1: move_fx:1:fx2:bypassed */
+function fxBusSlotKey(slotIdx, leaf) {
+    return activeFxBus.paramPrefix + "fx" + (slotIdx + 1) + ":" + leaf;
+}
 
 /* Master FX chain editing state */
 let masterFxConfig = {
@@ -1142,6 +1214,20 @@ function parseResampleBridgeMode(raw) {
 
 /* Get dynamic settings items based on whether preset is loaded */
 function getMasterFxSettingsItems() {
+    /* Move FX buses define their own settings (volume, no LFO). If the bus has a
+     * shared preset store, append the preset actions (Save / Save As / Delete),
+     * gating Save As + Delete on a loaded preset — same rule as the master path.
+     * The action handlers are generic (keyed on activeFxBus.preset*Key). */
+    if (activeFxBus.settingsItems) {
+        if (!activeFxBus.presetCountKey) return activeFxBus.settingsItems;
+        const items = activeFxBus.settingsItems.slice();
+        items.push({ key: "save", label: "[Save Preset]", type: "action" });
+        if (currentMasterPresetName) {
+            items.push({ key: "save_as", label: "[Save As]", type: "action" });
+            items.push({ key: "delete", label: "[Delete]", type: "action" });
+        }
+        return items;
+    }
     if (currentMasterPresetName) {
         /* Existing preset: show all items */
         return MASTER_FX_SETTINGS_ITEMS_BASE;
@@ -1602,6 +1688,7 @@ function processAllUpdates() {
 const CHAIN_SETTINGS_ITEMS = [
     { key: "knobs", label: "Knobs", type: "action" },  // Opens knob assignment editor
     { key: "slot:volume", label: "Volume", type: "float", min: 0, max: 4, step: 0.05 },
+    { key: "slot:move_to_slot", label: "Move>SchwFX", type: "int", min: 0, max: 1, step: 1 },  // On = Move track rides this synth slot (shares its SchwFX chain); Off = peel to Move FX slot
     { key: "slot:muted", label: "Muted", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:soloed", label: "Soloed", type: "int", min: 0, max: 1, step: 1 },
     { key: "slot:receive_channel", label: "Recv Ch", type: "int", min: 0, max: 16, step: 1 },
@@ -1617,6 +1704,7 @@ const CHAIN_SETTINGS_ITEMS = [
 ];
 let selectedChainSetting = 0;
 let editingChainSettingValue = false;
+let hierEditorReturnView = null;
 
 /* LFO editor state — generic context drives slot or MFX LFO */
 let lfoCtx = null;  /* Active LFO context: { lfoIdx, getParam, setParam, getTargetComponents, getTargetParams, title, returnView, returnAnnounce } */
@@ -2762,7 +2850,6 @@ function loadChainConfigFromSlot(slotIndex) {
     cfg.fx1 = fx1Module && fx1Module !== "" ? { module: fx1Module.toLowerCase(), params: {} } : null;
     cfg.fx2 = fx2Module && fx2Module !== "" ? { module: fx2Module.toLowerCase(), params: {} } : null;
 
-    /* Clear display_name cache when FX modules change (prevents stale announcement on swap) */
     const newFx1 = cfg.fx1 ? cfg.fx1.module : null;
     const newFx2 = cfg.fx2 ? cfg.fx2.module : null;
     if (newFx1 !== oldFx1) delete fxDisplayNameCache[`${slotIndex}:fx1`];
@@ -3881,9 +3968,8 @@ function getComponentHierarchy(slot, componentKey) {
 
 /* Fetch chain_params metadata from a Master FX slot */
 function getMasterFxChainParams(fxSlot) {
-    if (fxSlot < 0 || fxSlot >= 4) return [];
-    const fxKey = `fx${fxSlot + 1}`;
-    const key = `master_fx:${fxKey}:chain_params`;
+    if (fxSlot < 0 || fxSlot >= activeFxBus.slotCount) return [];
+    const key = fxBusSlotKey(fxSlot, "chain_params");
     const json = shadow_get_param(0, key);
     if (!json) return [];
     try {
@@ -3895,9 +3981,8 @@ function getMasterFxChainParams(fxSlot) {
 
 /* Fetch ui_hierarchy from a Master FX slot */
 function getMasterFxHierarchy(fxSlot) {
-    if (fxSlot < 0 || fxSlot >= 4) return null;
-    const fxKey = `fx${fxSlot + 1}`;
-    const key = `master_fx:${fxKey}:ui_hierarchy`;
+    if (fxSlot < 0 || fxSlot >= activeFxBus.slotCount) return null;
+    const key = fxBusSlotKey(fxSlot, "ui_hierarchy");
     const json = shadow_get_param(0, key);
     if (!json) return null;
     try {
@@ -3992,7 +4077,8 @@ function saveChainConfigToDir(dir) {
             const fwd = parseInt(getSlotParam(i, "slot:forward_channel") || "-1");
             const muted = parseInt(getSlotParam(i, "slot:muted") || "0");
             const soloed = parseInt(getSlotParam(i, "slot:soloed") || "0");
-            cfgSlots.push({ name: slots[i] ? slots[i].name : "", channel: ch, volume: vol, forward_channel: fwd, muted: muted, soloed: soloed });
+            const moveToSlot = parseInt(getSlotParam(i, "slot:move_to_slot") || "1");
+            cfgSlots.push({ name: slots[i] ? slots[i].name : "", channel: ch, volume: vol, forward_channel: fwd, muted: muted, soloed: soloed, move_to_slot: moveToSlot });
         }
         host_write_file(path, JSON.stringify({ slots: cfgSlots }, null, 2) + "\n");
     } catch (e) {
@@ -4173,6 +4259,9 @@ function loadChainConfigFromDir(dir) {
             if (typeof s.forward_channel === "number") setSlotParamWithTimeout(i, "slot:forward_channel", String(s.forward_channel), 500);
             if (typeof s.muted === "number") setSlotParamWithTimeout(i, "slot:muted", String(s.muted), 500);
             if (typeof s.soloed === "number") setSlotParamWithTimeout(i, "slot:soloed", String(s.soloed), 500);
+            /* Move>Slot routing (missing in older configs → leave shim default 1,
+             * i.e. Move track rides the synth slot). */
+            if (typeof s.move_to_slot === "number") setSlotParamWithTimeout(i, "slot:move_to_slot", String(s.move_to_slot), 500);
         }
         debugLog("SET_CHANGED: loaded chain config from " + path);
     } catch (e) {
@@ -4656,12 +4745,12 @@ function announceSavePreview(name, selectedIndex, full = true) {
 
 function loadMasterPresetList() {
     masterPresets = [];
-    const countStr = getSlotParam(0, "master_preset_count");
+    const countStr = getSlotParam(0, activeFxBus.presetCountKey);
     const count = parseInt(countStr, 10) || 0;
     debugLog(`loadMasterPresetList: countStr='${countStr}' count=${count}`);
 
     for (let i = 0; i < count; i++) {
-        const name = getSlotParam(0, `master_preset_name_${i}`) || `Preset ${i + 1}`;
+        const name = getSlotParam(0, `${activeFxBus.presetNamePrefix}${i}`) || `Preset ${i + 1}`;
         /* Hex dump first 20 chars to debug garbage issue */
         let hex = "";
         for (let j = 0; j < Math.min(20, name.length); j++) {
@@ -4679,7 +4768,7 @@ function enterMasterPresetPicker() {
     needsRedraw = true;
 
     /* Announce menu title + initial selection */
-    announce("Master Presets, [New]");
+    announce(`${activeFxBus.presetPickerTitle}, [New]`);
 }
 
 function exitMasterPresetPicker() {
@@ -4700,7 +4789,7 @@ function findMasterPresetByName(name) {
 
 function generateMasterPresetName() {
     const parts = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         const key = `fx${i + 1}`;
         const moduleId = masterFxConfig[key]?.module;
         if (moduleId) {
@@ -4708,12 +4797,12 @@ function generateMasterPresetName() {
             parts.push(abbrev);
         }
     }
-    return parts.length > 0 ? parts.join(" + ") : "Master FX";
+    return parts.length > 0 ? parts.join(" + ") : activeFxBus.title;
 }
 
 function clearMasterFx() {
-    /* Clear all 4 FX slots */
-    for (let i = 0; i < 4; i++) {
+    /* Clear all FX slots on the active bus */
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         setMasterFxSlotModule(i, "");
         masterFxConfig[`fx${i + 1}`].module = "";
     }
@@ -4724,15 +4813,15 @@ function clearMasterFx() {
 
 function loadMasterPreset(index, presetName) {
     /* Get preset JSON from DSP */
-    const json = getSlotParam(0, `master_preset_json_${index}`);
+    const json = getSlotParam(0, `${activeFxBus.presetJsonPrefix}${index}`);
     if (!json) return;
 
     try {
         const preset = JSON.parse(json);
-        const fx = preset.master_fx || {};
+        const fx = preset[activeFxBus.presetJsonRoot] || {};
 
         /* Apply each FX slot */
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < activeFxBus.slotCount; i++) {
             const key = `fx${i + 1}`;
             const fxConfig = fx[key];
             if (fxConfig && fxConfig.type) {
@@ -4745,12 +4834,12 @@ function loadMasterPreset(index, presetName) {
                     /* Restore plugin_id first (CLAP sub-plugin selection) */
                     if (fxConfig.params && typeof shadow_set_param === "function") {
                         if (fxConfig.params.plugin_id) {
-                            shadow_set_param(0, `master_fx:${key}:plugin_id`, fxConfig.params.plugin_id);
+                            shadow_set_param(0, fxBusSlotKey(i, "plugin_id"), fxConfig.params.plugin_id);
                         }
                         /* Restore remaining params */
                         for (const [pkey, pval] of Object.entries(fxConfig.params)) {
                             if (pkey !== "plugin_id") {
-                                shadow_set_param(0, `master_fx:${key}:${pkey}`, String(pval));
+                                shadow_set_param(0, fxBusSlotKey(i, pkey), String(pval));
                             }
                         }
                     }
@@ -4765,17 +4854,19 @@ function loadMasterPreset(index, presetName) {
             }
         }
 
-        /* Restore master FX LFO configs */
-        for (let li = 1; li <= 2; li++) {
-            const lfoConfig = preset["lfo" + li];
-            if (lfoConfig && typeof shadow_set_param === "function") {
-                restoreMasterFxLfo(li, lfoConfig);
-            } else {
-                /* No LFO in preset — disable */
-                if (typeof shadow_set_param === "function") {
-                    shadow_set_param(0, "master_fx:lfo" + li + ":enabled", "0");
-                    shadow_set_param(0, "master_fx:lfo" + li + ":target", "");
-                    shadow_set_param(0, "master_fx:lfo" + li + ":target_param", "");
+        /* Restore FX LFO configs (master bus only — sends have no LFOs) */
+        if (activeFxBus.hasLfo) {
+            for (let li = 1; li <= 2; li++) {
+                const lfoConfig = preset["lfo" + li];
+                if (lfoConfig && typeof shadow_set_param === "function") {
+                    restoreMasterFxLfo(li, lfoConfig);
+                } else {
+                    /* No LFO in preset — disable */
+                    if (typeof shadow_set_param === "function") {
+                        shadow_set_param(0, "master_fx:lfo" + li + ":enabled", "0");
+                        shadow_set_param(0, "master_fx:lfo" + li + ":target", "");
+                        shadow_set_param(0, "master_fx:lfo" + li + ":target_param", "");
+                    }
                 }
             }
         }
@@ -4793,15 +4884,15 @@ function loadMasterPreset(index, presetName) {
 
 /* Build JSON for saving master preset */
 function buildMasterPresetJson(name) {
-    const preset = {
-        custom_name: name,
-        fx1: null,
-        fx2: null,
-        fx3: null,
-        fx4: null
-    };
+    /* Flat fx1..N + custom_name. The DSP side re-roots this under the bus's
+     * presetJsonRoot ("master_fx") on save; loadMasterPreset reads it back
+     * from that root. */
+    const preset = { custom_name: name };
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
+        preset[`fx${i + 1}`] = null;
+    }
 
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < activeFxBus.slotCount; i++) {
         const key = `fx${i + 1}`;
         const moduleId = masterFxConfig[key]?.module;
         if (moduleId) {
@@ -4813,7 +4904,7 @@ function buildMasterPresetJson(name) {
             /* Capture plugin_id (for CLAP sub-plugin selection) */
             if (typeof shadow_get_param === "function") {
                 try {
-                    const pluginId = shadow_get_param(0, `master_fx:${key}:plugin_id`);
+                    const pluginId = shadow_get_param(0, fxBusSlotKey(i, "plugin_id"));
                     if (pluginId) {
                         slotPreset.params["plugin_id"] = pluginId;
                     }
@@ -4824,7 +4915,7 @@ function buildMasterPresetJson(name) {
                     const chainParams = getMasterFxChainParams(i);
                     if (chainParams && chainParams.length > 0) {
                         for (const p of chainParams) {
-                            const val = shadow_get_param(0, `master_fx:${key}:${p.key}`);
+                            const val = shadow_get_param(0, fxBusSlotKey(i, p.key));
                             if (val !== null && val !== undefined && val !== "") {
                                 slotPreset.params[p.key] = val;
                             }
@@ -4837,14 +4928,16 @@ function buildMasterPresetJson(name) {
         }
     }
 
-    /* Include master FX LFO configs */
-    for (let li = 1; li <= 2; li++) {
-        try {
-            const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
-            if (configJson) {
-                preset["lfo" + li] = JSON.parse(configJson);
-            }
-        } catch (e) {}
+    /* Include FX LFO configs (master bus only) */
+    if (activeFxBus.hasLfo) {
+        for (let li = 1; li <= 2; li++) {
+            try {
+                const configJson = shadow_get_param(0, "master_fx:lfo" + li + ":config");
+                if (configJson) {
+                    preset["lfo" + li] = JSON.parse(configJson);
+                }
+            } catch (e) {}
+        }
     }
 
     return JSON.stringify(preset);
@@ -4856,10 +4949,10 @@ function doSaveMasterPreset(name) {
 
     if (masterOverwriteTargetIndex >= 0) {
         /* Overwriting existing preset */
-        setSlotParam(0, "update_master_preset", masterOverwriteTargetIndex + ":" + json);
+        setSlotParam(0, activeFxBus.presetUpdateKey, masterOverwriteTargetIndex + ":" + json);
     } else {
         /* Creating new preset */
-        setSlotParam(0, "save_master_preset", json);
+        setSlotParam(0, activeFxBus.presetSaveKey, json);
     }
 
     currentMasterPresetName = name;
@@ -5085,7 +5178,7 @@ function handleMasterFxSettingsAction(key) {
 function doDeleteMasterPreset() {
     const index = findMasterPresetByName(currentMasterPresetName);
     if (index >= 0) {
-        setSlotParam(0, "delete_master_preset", String(index));
+        setSlotParam(0, activeFxBus.presetDeleteKey, String(index));
     }
 
     /* Clear current preset and return to picker */
@@ -5951,15 +6044,15 @@ function handleGlobalSettingsAction(key) {
 
 /* Load master FX chain configuration from DSP */
 function loadMasterFxChainConfig() {
-    masterFxConfig = {
-        fx1: { module: "" },
-        fx2: { module: "" },
-        fx3: { module: "" },
-        fx4: { module: "" }
-    };
+    /* Rebuild masterFxConfig for the active bus's slot count. Shared object,
+     * repopulated on each editor entry (only one bus open at a time). */
+    masterFxConfig = {};
+    for (let i = 1; i <= activeFxBus.slotCount; i++) {
+        masterFxConfig[`fx${i}`] = { module: "" };
+    }
 
     /* Query each slot's module from DSP */
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= activeFxBus.slotCount; i++) {
         const key = `fx${i}`;
         const moduleId = getMasterFxSlotModule(i - 1);
         masterFxConfig[key].module = moduleId || "";
@@ -5970,30 +6063,30 @@ function loadMasterFxChainConfig() {
 function getMasterFxParam(slotIndex, key) {
     if (typeof shadow_get_param !== "function") return "";
     try {
-        return shadow_get_param(0, `master_fx:fx${slotIndex + 1}:${key}`) || "";
+        return shadow_get_param(0, fxBusSlotKey(slotIndex, key)) || "";
     } catch (e) {
         return "";
     }
 }
 
-/* Get module ID loaded in a master FX slot (0-3) */
+/* Get module ID loaded in an FX slot (0-based) on the active bus */
 function getMasterFxSlotModule(slotIndex) {
     if (typeof shadow_get_param !== "function") return "";
     try {
         /* Query returns the module_id from the shim */
-        return shadow_get_param(0, `master_fx:fx${slotIndex + 1}:name`) || "";
+        return shadow_get_param(0, fxBusSlotKey(slotIndex, "name")) || "";
     } catch (e) {
         return "";
     }
 }
 
-/* Set module for a master FX slot */
+/* Set module for an FX slot on the active bus */
 function setMasterFxSlotModule(slotIndex, dspPath) {
     if (typeof shadow_set_param !== "function") return false;
     /* Clear warning tracking for this slot so warning can show again for new module */
     warningShownForMasterFx.delete(slotIndex);
     try {
-        return shadow_set_param(0, `master_fx:fx${slotIndex + 1}:module`, dspPath || "");
+        return shadow_set_param(0, fxBusSlotKey(slotIndex, "module"), dspPath || "");
     } catch (e) {
         return false;
     }
@@ -6001,7 +6094,7 @@ function setMasterFxSlotModule(slotIndex, dspPath) {
 
 /* Enter module selection for a Master FX slot */
 function enterMasterFxModuleSelect(componentIndex) {
-    const comp = MASTER_FX_CHAIN_COMPONENTS[componentIndex];
+    const comp = activeFxBus.components[componentIndex];
     if (!comp || comp.key === "settings") return;
 
     /* Set selection index to current module if any */
@@ -6019,7 +6112,7 @@ function enterMasterFxModuleSelect(componentIndex) {
 
 /* Apply module selection for Master FX slot */
 function applyMasterFxModuleSelection() {
-    const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+    const comp = activeFxBus.components[selectedMasterFxComponent];
     if (!comp || comp.key === "settings") return;
 
     const selected = MASTER_FX_OPTIONS[selectedMasterFxModuleIndex];
@@ -6044,6 +6137,12 @@ function applyMasterFxModuleSelection() {
 
 /* Save master FX chain configuration */
 function saveMasterFxChainConfig() {
+    /* Master-bus-only below. Move buses persist via their own per-set file
+     * instead — dispatch so in-editor edits are saved. */
+    if (!activeFxBus.persistConfig) {
+        if (activeFxBus.isMoveFx) saveMoveFxChainConfig();
+        return;
+    }
     /* The shim persists the state, but we also save to shadow config */
     try {
         const configPath = "/data/UserData/schwung/shadow_config.json";
@@ -6573,6 +6672,131 @@ function loadMasterFxChainFromConfig() {
         }
     } catch (e) {
         /* Ignore errors */
+    }
+}
+
+/* Move FX per-set persistence (auto-recall across set changes). Each Move FX
+ * slot's blocks persist to move_fx_<slot>_<block>.json; per-slot strip volume
+ * goes in move_fx_meta.json. MOVE_FX_SLOTS_JS / MOVE_FX_BLOCKS_JS are defined
+ * near the FX bus descriptors above. Format mirrors the master slot files:
+ * { id, path, state | params, bypassed }. Uses explicit move_fx:* keys (NOT
+ * activeFxBus), so safe to call regardless of which FX editor is open.
+ * (Send A/B routing for Move buses is a planned follow-up — see docs/MOVE_FX.md.) */
+function saveMoveFxChainConfig() {
+    if (typeof shadow_get_param !== "function") return;
+    try {
+        for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+            for (let b = 0; b < MOVE_FX_BLOCKS_JS; b++) {
+                const key = "move_fx:" + (sl + 1) + ":fx" + (b + 1);
+                const filePath = activeSlotStateDir + "/move_fx_" + sl + "_" + b + ".json";
+                const moduleId = shadow_get_param(0, key + ":name") || "";
+                if (!moduleId) { host_write_file(filePath, "{}\n"); continue; }
+
+                const opt = (MASTER_FX_OPTIONS || []).find(o => o.id === moduleId);
+                const slotConfig = {
+                    id: moduleId,
+                    module_id: moduleId,
+                    path: opt?.dspPath || "",
+                    bypassed: parseInt(shadow_get_param(0, key + ":bypassed") || "0", 10) === 1 ? 1 : 0
+                };
+
+                let stateObj = null;
+                let paramsObj = null;
+                try {
+                    const stateJson = shadow_get_param(0, key + ":state");
+                    if (stateJson) {
+                        try { stateObj = JSON.parse(stateJson); } catch (pe) { stateObj = stateJson; }
+                        slotConfig.state = stateObj;
+                    }
+                } catch (e) {}
+                if (!stateObj) {
+                    try {
+                        paramsObj = {};
+                        const pid = shadow_get_param(0, key + ":plugin_id");
+                        if (pid) paramsObj["plugin_id"] = pid;
+                        const cpJson = shadow_get_param(0, key + ":chain_params");
+                        if (cpJson) {
+                            const cps = JSON.parse(cpJson);
+                            if (Array.isArray(cps)) {
+                                for (const p of cps) {
+                                    if (p && p.key) {
+                                        const v = shadow_get_param(0, key + ":" + p.key);
+                                        if (v !== null && v !== undefined && v !== "") paramsObj[p.key] = v;
+                                    }
+                                }
+                            }
+                        }
+                        if (Object.keys(paramsObj).length > 0) slotConfig.params = paramsObj;
+                    } catch (e) {}
+                }
+
+                const realParamKeys = paramsObj ? Object.keys(paramsObj).filter(k => k !== "plugin_id") : [];
+                if (!stateObj && realParamKeys.length === 0) continue;
+                host_write_file(filePath, JSON.stringify(slotConfig, null, 2) + "\n");
+            }
+        }
+        /* Per-slot strip volume. */
+        const strips = [];
+        for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+            const v  = parseFloat(shadow_get_param(0, "move_fx:" + (sl + 1) + ":volume") || "1.0");
+            strips.push({ volume: isNaN(v) ? 1.0 : v });
+        }
+        host_write_file(activeSlotStateDir + "/move_fx_meta.json",
+            JSON.stringify({ strips: strips }, null, 2) + "\n");
+    } catch (e) {
+        debugLog("saveMoveFxChainConfig error: " + e);
+    }
+}
+
+function restoreMoveFxFromFiles() {
+    if (typeof shadow_set_param !== "function") return;
+    try {
+        for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+            for (let b = 0; b < MOVE_FX_BLOCKS_JS; b++) {
+                const key = "move_fx:" + (sl + 1) + ":fx" + (b + 1);
+                const filePath = activeSlotStateDir + "/move_fx_" + sl + "_" + b + ".json";
+                let data = null;
+                try {
+                    const raw = host_read_file(filePath);
+                    if (raw && raw.length > 3) data = JSON.parse(raw);
+                } catch (e) {}
+
+                const dspPath = (data && data.path) ? data.path : "";
+                shadow_set_param(0, key + ":module", dspPath);
+                if (!dspPath) continue;
+
+                if (data.state) {
+                    const stateStr = (typeof data.state === "string") ? data.state : JSON.stringify(data.state);
+                    shadow_set_param(0, key + ":state", stateStr);
+                } else if (data.params) {
+                    if (data.params.plugin_id) shadow_set_param(0, key + ":plugin_id", data.params.plugin_id);
+                    for (const [pk, pv] of Object.entries(data.params)) {
+                        if (pk !== "plugin_id") shadow_set_param(0, key + ":" + pk, String(pv));
+                    }
+                }
+                if (data.bypassed) shadow_set_param(0, key + ":bypassed", "1");
+            }
+        }
+        /* Restore per-slot strip volume. Apply ALL slots every time, defaulting
+         * to unity when the meta file or a slot entry is absent. The shim's
+         * shadow_move_fx_strip[] is global and never reset on set change, so a
+         * new/older set with no meta would otherwise inherit the previous set's
+         * Move FX volume — explicitly writing defaults here resets them. */
+        let moveStrips = null;
+        try {
+            const raw = host_read_file(activeSlotStateDir + "/move_fx_meta.json");
+            if (raw) {
+                const meta = JSON.parse(raw);
+                if (meta && Array.isArray(meta.strips)) moveStrips = meta.strips;
+            }
+        } catch (e) {}
+        for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+            const st = (moveStrips && moveStrips[sl]) ? moveStrips[sl] : null;
+            const vol = (st && typeof st.volume === "number") ? st.volume : 1.0;
+            shadow_set_param(0, "move_fx:" + (sl + 1) + ":volume", vol.toFixed(3));
+        }
+    } catch (e) {
+        debugLog("restoreMoveFxFromFiles error: " + e);
     }
 }
 
@@ -7476,6 +7700,11 @@ function getChainSettingValue(slot, setting) {
     if (setting.key === "midi_fx_pre_mode") {
         return parseInt(val) ? "Schw+Move" : "Schw";
     }
+    if (setting.key === "slot:move_to_slot") {
+        /* On = Move track rides this synth slot (shares FX + sends);
+         * Off = Move track is peeled to its own Move FX slot. */
+        return parseInt(val) ? "On" : "Off";
+    }
     return String(val);
 }
 
@@ -8356,6 +8585,62 @@ function enterMasterFxHierarchyEditor(fxSlot) {
     }
 }
 
+/* Move FX hierarchy editor. The compKey
+ * (move_fx:<slot+1>:fx<block+1>) IS the param prefix the generic editor uses, so
+ * everything else resolves the same way as Master/Send FX. */
+function enterMoveFxHierarchyEditor(moveSlot, fxSlot) {
+    if (moveSlot < 0 || moveSlot >= MOVE_FX_SLOTS_JS) return;
+    if (fxSlot < 0 || fxSlot >= MOVE_FX_BLOCKS_JS) return;
+    const busLabel = "Move " + (moveSlot + 1) + " FX";
+    const compKey = `move_fx:${moveSlot + 1}:fx${fxSlot + 1}`;
+
+    const hierJson = shadow_get_param(0, `${compKey}:ui_hierarchy`);
+    let hierarchy = null;
+    if (hierJson) {
+        try { hierarchy = JSON.parse(hierJson); } catch (e) { /* ignore */ }
+    }
+    if (!hierarchy) return;
+
+    hideOverlay();
+    invalidateKnobContextCache();
+    pendingHierKnobIndex = -1;
+    pendingHierKnobDelta = 0;
+
+    hierEditorSlot = 0;
+    hierEditorComponent = compKey;
+    hierEditorHierarchy = hierarchy;
+    hierEditorLevel = hierarchy.modes ? null : "root";
+    hierEditorPath = [];
+    hierEditorChildIndex = -1;
+    hierEditorChildCount = 0;
+    hierEditorChildLabel = "";
+    hierEditorSelectedIdx = 0;
+    hierEditorEditMode = false;
+    resetHierarchyEditState();
+    /* Same as Master/Send FX: treat as an FX-bus component so the param engine
+     * builds keys as `${component}:key` (here move_fx:N:fxM:key). */
+    hierEditorIsMasterFx = true;
+    hierEditorMasterFxSlot = fxSlot;
+    resetDynamicParamPickerState();
+
+    hierEditorChainParams = getMasterFxChainParams(fxSlot);
+
+    setupModuleParamShims(0, compKey);
+    loadHierarchyLevel();
+
+    hierEditorReturnView = VIEWS.MASTER_FX;
+    setView(VIEWS.HIERARCHY_EDITOR);
+    needsRedraw = true;
+
+    const moduleName = shadow_get_param(0, `${compKey}:name`) || `FX ${fxSlot + 1}`;
+    if (hierEditorParams.length > 0) {
+        const param = hierEditorParams[0];
+        announce(`${busLabel} ${moduleName}, ${param.label || param.key}: ${param.value || ""}`);
+    } else {
+        announce(`${busLabel} ${moduleName}, No parameters`);
+    }
+}
+
 /* Load params and knobs for current hierarchy level */
 function loadHierarchyLevel() {
     if (!hierEditorHierarchy) return;
@@ -8555,7 +8840,12 @@ function exitHierarchyEditor() {
     filepathBrowserParamKey = "";
     resetDynamicParamPickerState();
 
-    view = returnToMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT;
+    if (hierEditorReturnView) {
+        view = hierEditorReturnView;
+        hierEditorReturnView = null;
+    } else {
+        view = returnToMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT;
+    }
     needsRedraw = true;
 }
 
@@ -9059,12 +9349,21 @@ function buildKnobContextForKnob(knobIndex) {
         }
     }
 
-    /* Master FX view with FX slot selected */
-    if (view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
-        const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+    /* FX-bus overview with an FX slot selected: home-screen knobs (71-78) edit
+     * that slot's params for ANY bus (Master / Send A-B / Move FX), using the
+     * bus's own per-component paramPrefix. Previously master-only ("for now");
+     * generalized so every bus behaves like upstream's master — the param engine
+     * (isMasterFx path) + getMasterFx* helpers are already bus-aware via
+     * activeFxBus, so only the component list + key prefixes needed unpinning. */
+    if (view === VIEWS.MASTER_FX &&
+        selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
+        const comp = activeFxBus.components[selectedMasterFxComponent];
         if (comp && comp.key !== "settings") {
+            /* Bus-aware overlay tag (master keeps its compact "MFX"; other buses
+             * show their own title) — replaces the old hardcoded master label. */
+            const busTag = activeFxBus.id === "master" ? "MFX" : (activeFxBus.title || "FX");
             const chainParams = getMasterFxChainParams(selectedMasterFxComponent);
-            const pluginName = shadow_get_param(0, `master_fx:${comp.key}:name`) || "";
+            const pluginName = shadow_get_param(0, comp.paramPrefix + "name") || "";
             const hasModule = pluginName && pluginName.length > 0;
 
             /* No module loaded in this slot */
@@ -9076,7 +9375,7 @@ function buildKnobContextForKnob(knobIndex) {
                     meta: null,
                     pluginName: comp.label,
                     displayName: `Knob ${knobIndex + 1}`,
-                    title: `MFX ${comp.label}`,
+                    title: `${busTag} ${comp.label}`,
                     noModule: true,
                     isMasterFx: true,
                     masterFxSlot: selectedMasterFxComponent
@@ -9096,7 +9395,7 @@ function buildKnobContextForKnob(knobIndex) {
                 }
                 if (levelDef && levelDef.knobs && knobIndex < levelDef.knobs.length) {
                     const key = levelDef.knobs[knobIndex];
-                    const fullKey = `master_fx:${comp.key}:${key}`;
+                    const fullKey = comp.paramPrefix + key;
                     const rawMeta = chainParams.find(p => p.key === key);
                     const meta = normalizeExpandedParamMeta(key, rawMeta);
                     const displayName = meta && meta.name ? meta.name : key.replace(/_/g, " ");
@@ -9107,7 +9406,7 @@ function buildKnobContextForKnob(knobIndex) {
                         meta,
                         pluginName,
                         displayName,
-                        title: `MFX ${pluginName} ${displayName}`,
+                        title: `${busTag} ${pluginName} ${displayName}`,
                         isMasterFx: true,
                         masterFxSlot: selectedMasterFxComponent
                     };
@@ -9127,7 +9426,7 @@ function buildKnobContextForKnob(knobIndex) {
                     meta: normalizeExpandedParamMeta(key, param),
                     pluginName,
                     displayName,
-                    title: `MFX ${pluginName} ${displayName}`,
+                    title: `${busTag} ${pluginName} ${displayName}`,
                     isMasterFx: true,
                     masterFxSlot: selectedMasterFxComponent
                 };
@@ -9141,7 +9440,7 @@ function buildKnobContextForKnob(knobIndex) {
                 meta: null,
                 pluginName,
                 displayName: `Knob ${knobIndex + 1}`,
-                title: `MFX ${pluginName}`,
+                title: `${busTag} ${pluginName}`,
                 noMapping: true,
                 isMasterFx: true,
                 masterFxSlot: selectedMasterFxComponent
@@ -9174,6 +9473,11 @@ function rebuildKnobContextCache() {
  * Uses caching to avoid IPC calls on every CC message
  */
 let cachedKnobContextsMasterFxComp = -1;  /* Track Master FX component for cache */
+let cachedKnobContextsFxBus = "";         /* Track active FX bus id for cache —
+                                           * now that every bus (not just master)
+                                           * uses FX-overview knob contexts, a bus
+                                           * switch with the same view/slot must
+                                           * invalidate or knobs leak across buses. */
 
 function getKnobContext(knobIndex) {
     /* Check if cache is valid */
@@ -9182,6 +9486,7 @@ function getKnobContext(knobIndex) {
     const currentLevel = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorLevel : "";
     const currentChildIndex = (view === VIEWS.HIERARCHY_EDITOR) ? hierEditorChildIndex : -1;
     const currentMasterFxComp = (view === VIEWS.MASTER_FX) ? selectedMasterFxComponent : -1;
+    const currentFxBus = activeFxBus ? activeFxBus.id : "";
 
     const cacheValid = (
         cachedKnobContexts.length === NUM_KNOBS &&
@@ -9190,12 +9495,14 @@ function getKnobContext(knobIndex) {
         cachedKnobContextsComp === currentComp &&
         cachedKnobContextsLevel === currentLevel &&
         cachedKnobContextsChildIndex === currentChildIndex &&
-        cachedKnobContextsMasterFxComp === currentMasterFxComp
+        cachedKnobContextsMasterFxComp === currentMasterFxComp &&
+        cachedKnobContextsFxBus === currentFxBus
     );
 
     if (!cacheValid) {
         rebuildKnobContextCache();
         cachedKnobContextsMasterFxComp = currentMasterFxComp;
+        cachedKnobContextsFxBus = currentFxBus;
     }
 
     return cachedKnobContexts[knobIndex] || null;
@@ -11054,8 +11361,15 @@ function changeComponentPreset(delta) {
 
 /* Get Master FX setting current value for display */
 function getMasterFxSettingValue(setting) {
+    /* Generic param-backed setting (Move FX volume/sends). Shown as a percentage. */
+    if (setting.param) {
+        const val = shadow_get_param(0, setting.param);
+        if (val === null || val === undefined || val === "") return "0%";
+        const num = parseFloat(val);
+        return isNaN(num) ? val : `${Math.round(num * 100)}%`;
+    }
     if (setting.key === "master_volume") {
-        const val = shadow_get_param(0, "master_fx:volume");
+        const val = shadow_get_param(0, activeFxBus.volumeKey);
         if (!val) return "100%";
         const num = parseFloat(val);
         return isNaN(num) ? val : `${Math.round(num * 100)}%`;
@@ -11167,11 +11481,20 @@ function getMasterFxSettingValue(setting) {
 function adjustMasterFxSetting(setting, delta) {
     if (setting.type === "action") return;
 
-    if (setting.key === "master_volume") {
-        let val = parseFloat(shadow_get_param(0, "master_fx:volume") || "1.0");
+    /* Generic param-backed setting (Move FX volume/sends). */
+    if (setting.param) {
+        let val = parseFloat(shadow_get_param(0, setting.param) || "0");
         val += delta * setting.step;
         val = Math.max(setting.min, Math.min(setting.max, val));
-        shadow_set_param(0, "master_fx:volume", val.toFixed(2));
+        shadow_set_param(0, setting.param, val.toFixed(2));
+        return;
+    }
+
+    if (setting.key === "master_volume") {
+        let val = parseFloat(shadow_get_param(0, activeFxBus.volumeKey) || "1.0");
+        val += delta * setting.step;
+        val = Math.max(setting.min, Math.min(setting.max, val));
+        shadow_set_param(0, activeFxBus.volumeKey, val.toFixed(2));
         return;
     }
 
@@ -11502,12 +11825,14 @@ function handleJog(delta) {
                 announceMenuItem("Module", module.name);
             } else {
                 /* Navigate chain components (-1 = preset selection, like instrument slots)
-                 * Preset picker is only accessible via click, not scroll */
-                selectedMasterFxComponent = Math.max(-1, Math.min(MASTER_FX_CHAIN_COMPONENTS.length - 1, selectedMasterFxComponent + delta));
+                 * Preset picker is only accessible via click, not scroll.
+                 * Buses with a preset store (master + Move FX) reach the -1 column. */
+                const minComp = activeFxBus.presetCountKey ? -1 : 0;
+                selectedMasterFxComponent = Math.max(minComp, Math.min(activeFxBus.components.length - 1, selectedMasterFxComponent + delta));
                 if (selectedMasterFxComponent === -1) {
                     announce("Preset Selection");
                 } else {
-                    const comp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+                    const comp = activeFxBus.components[selectedMasterFxComponent];
                     const compKey = comp.key;
                     const moduleName = masterFxConfig?.[compKey]?.module || "Empty";
                     announceMenuItem(comp.label, moduleName);
@@ -11516,6 +11841,15 @@ function handleJog(delta) {
             break;
         case VIEWS.SLOT_SETTINGS:
             handleSlotSettingsJog(delta);
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            if (pendingMoveFxRouteConfirm >= 0) {
+                moveFxRouteConfirmSel = moveFxRouteConfirmSel === 0 ? 1 : 0;
+                announce(moveFxRouteConfirmSel === 0 ? "No" : "Yes");
+                needsRedraw = true;
+            } else {
+                fxBusPickerIndex = Math.max(0, Math.min(MOVE_FX_SLOTS_JS, fxBusPickerIndex + delta));
+            }
             break;
         case VIEWS.PATCHES:
             handlePatchesJog(delta);
@@ -11966,7 +12300,7 @@ function handleSelect() {
                 /* Preset selected - enter preset picker */
                 enterMasterPresetPicker();
             } else {
-                const selectedComp = MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+                const selectedComp = activeFxBus.components[selectedMasterFxComponent];
                 if (selectedComp.key === "settings") {
                     /* Enter settings submenu */
                     inMasterFxSettingsMenu = true;
@@ -11978,15 +12312,15 @@ function handleSelect() {
                     if (items.length > 0) {
                         const item = items[0];
                         const value = getMasterFxSettingValue(item);
-                        announce(`Master FX Settings, ${item.label}: ${value}`);
+                        announce(`${activeFxBus.title} Settings, ${item.label}: ${value}`);
                     }
                 } else {
                     /* FX slot - check if module is loaded with hierarchy */
                     const moduleData = masterFxConfig[selectedComp.key];
 
-                    /* Mute+JogClick: toggle bypass on a populated MFX slot */
+                    /* Mute+JogClick: toggle bypass on a populated slot */
                     if (hostMuteHeld && moduleData && moduleData.module) {
-                        const fullKey = `master_fx:${selectedComp.key}:bypassed`;
+                        const fullKey = activeFxBus.paramPrefix + selectedComp.key + ":bypassed";
                         const cur = parseInt(shadow_get_param(0, fullKey) || "0", 10);
                         const next = cur ? 0 : 1;
                         shadow_set_param(0, fullKey, String(next));
@@ -11996,13 +12330,22 @@ function handleSelect() {
                     }
 
                     if (moduleData && moduleData.module) {
-                        /* Module is loaded - try hierarchy editor first */
-                        const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
-                        if (hierarchy) {
-                            enterMasterFxHierarchyEditor(selectedMasterFxComponent);
+                        /* Module is loaded - open the param editor. Move FX uses
+                         * its own hierarchy editor; master uses its own. */
+                        if (activeFxBus.isMoveFx) {
+                            const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
+                            if (hierarchy) {
+                                enterMoveFxHierarchyEditor(activeFxBus.moveSlot, selectedMasterFxComponent);
+                            } else {
+                                enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            }
                         } else {
-                            /* No hierarchy - enter module selection to swap */
-                            enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
+                            if (hierarchy) {
+                                enterMasterFxHierarchyEditor(selectedMasterFxComponent);
+                            } else {
+                                enterMasterFxModuleSelect(selectedMasterFxComponent);
+                            }
                         }
                     } else {
                         /* No module loaded - enter module selection */
@@ -12013,6 +12356,34 @@ function handleSelect() {
             break;
         case VIEWS.SLOT_SETTINGS:
             handleSlotSettingsSelect();
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            if (pendingMoveFxRouteConfirm >= 0) {
+                /* Commit the route confirm. */
+                const cs = pendingMoveFxRouteConfirm;
+                pendingMoveFxRouteConfirm = -1;
+                if (moveFxRouteConfirmSel === 1) {
+                    /* Yes: peel the track to its own Move FX bus (persists per-set),
+                     * then open it. Single write → co-run-safe. */
+                    setSlotParam(cs, "slot:move_to_slot", "0");
+                    enterFxBusEditor("moveFx" + (cs + 1));
+                } else {
+                    needsRedraw = true;  /* No: dismiss, stay in picker. */
+                }
+            } else if (fxBusPickerIndex === 0) {
+                enterFxBusEditor("master");
+            } else {
+                /* 1..MOVE_FX_SLOTS_JS → Move FX 1..N. Routed tracks (move_to_slot
+                 * still on) prompt to peel before opening; peeled open directly. */
+                const ms = fxBusPickerIndex - 1;   /* 0-based Move slot/track */
+                if (moveFxRouted[ms]) {
+                    pendingMoveFxRouteConfirm = ms;
+                    moveFxRouteConfirmSel = 0;
+                    needsRedraw = true;
+                } else {
+                    enterFxBusEditor("moveFx" + (ms + 1));
+                }
+            }
             break;
         case VIEWS.PATCHES:
             handlePatchesSelect();
@@ -12871,22 +13242,39 @@ function handleBack() {
         case VIEWS.COMPONENT_PARAMS:
             handleComponentParamsBack();
             break;
+        case VIEWS.FX_BUS_PICKER:
+            if (pendingMoveFxRouteConfirm >= 0) {
+                pendingMoveFxRouteConfirm = -1;   /* cancel confirm, stay in picker */
+                needsRedraw = true;
+                break;
+            }
+            if (coRunChainEditSlot >= 0) {
+                view = VIEWS.CHAIN_EDIT;
+                coRunView = VIEWS.CHAIN_EDIT;
+            } else {
+                /* Back exits the shadow UI back to Move native. (The series'
+                 * exitShadowUI() was undefined and threw, so Back did nothing.) */
+                if (typeof shadow_request_exit === "function") {
+                    shadow_request_exit();
+                }
+            }
+            break;
         case VIEWS.MASTER_FX:
             if (masterShowingNamePreview) {
                 /* Cancel name preview */
                 masterShowingNamePreview = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (masterConfirmingOverwrite) {
                 /* Cancel overwrite - return to settings */
                 masterConfirmingOverwrite = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (masterConfirmingDelete) {
                 /* Cancel delete */
                 masterConfirmingDelete = false;
                 needsRedraw = true;
-                announce("Master FX Settings");
+                announce(`${activeFxBus.title} Settings`);
             } else if (helpDetailScrollState) {
                 helpDetailScrollState = null;
                 needsRedraw = true;
@@ -12902,28 +13290,25 @@ function handleBack() {
                     helpReturnView = null;
                     enterGlobalSettings();
                 } else {
-                    announce("Master FX Settings");
+                    announce(`${activeFxBus.title} Settings`);
                 }
             } else if (inMasterPresetPicker) {
                 /* Exit preset picker, return to FX list */
                 exitMasterPresetPicker();
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else if (inMasterFxSettingsMenu) {
                 /* Exit settings menu */
                 inMasterFxSettingsMenu = false;
                 editingMasterFxSetting = false;
                 needsRedraw = true;
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else if (selectingMasterFxModule) {
                 /* Cancel module selection, return to chain view */
                 selectingMasterFxModule = false;
                 needsRedraw = true;
-                announce("Master FX");
+                announce(activeFxBus.title);
             } else {
-                /* Exit shadow mode and return to Move */
-                if (typeof shadow_request_exit === "function") {
-                    shadow_request_exit();
-                }
+                enterFxBusPicker();
             }
             break;
         case VIEWS.CHAIN_EDIT:
@@ -13073,8 +13458,9 @@ function handleBack() {
             } else {
                 /* At root level - exit hierarchy editor */
                 const wasMasterFx = hierEditorIsMasterFx;
+                const returnView = hierEditorReturnView;
                 exitHierarchyEditor();
-                announce(wasMasterFx ? "Master FX" : "Chain Editor");
+                announce(returnView === VIEWS.MASTER_FX ? activeFxBus.title : wasMasterFx ? "Master FX" : "Chain Editor");
             }
             break;
         }
@@ -13392,12 +13778,12 @@ function drawChainEdit() {
     const cfg = chainConfigs[selectedSlot] || createEmptyChainConfig();
     const chainSelected = selectedChainComponent === -1;
 
-    /* Calculate box layout - 5 components, offset right to make room for slot indicators */
-    const BOX_W = 22;
+    /* Calculate box layout - 7 components, offset right to make room for slot indicators */
+    const BOX_W = 16;
     const BOX_H = 16;
-    const GAP = 2;
-    const TOTAL_W = 5 * BOX_W + 4 * GAP;  // 118px
-    const START_X = 6 + Math.floor((SCREEN_WIDTH - 6 - TOTAL_W) / 2);  // centered right of indicators
+    const GAP = 1;
+    const TOTAL_W = CHAIN_COMPONENTS.length * BOX_W + (CHAIN_COMPONENTS.length - 1) * GAP;
+    const START_X = 6 + Math.floor((SCREEN_WIDTH - 6 - TOTAL_W) / 2);
     const BOX_Y = 20;  // Below header
 
     /* Draw slot indicators - 4 marks in left margin, spanning from below header to footer */
@@ -14042,7 +14428,14 @@ function drawHelpDetail() {
         get() { return masterConfirmIndex; }, enumerable: true
     });
 
-    _ctx.MASTER_FX_CHAIN_COMPONENTS = MASTER_FX_CHAIN_COMPONENTS;
+    /* Components follow the active bus (master: 4 slots, sends: 3). */
+    Object.defineProperty(_ctx, 'MASTER_FX_CHAIN_COMPONENTS', {
+        get() { return activeFxBus.components; }, enumerable: true
+    });
+    /* Active FX bus descriptor (master/moveFxN) for the generic editor. */
+    Object.defineProperty(_ctx, 'activeFxBus', {
+        get() { return activeFxBus; }, set(v) { if (v) activeFxBus = v; }, enumerable: true
+    });
 
     /* Utility functions */
     _ctx.setView = setView;
@@ -14238,6 +14631,8 @@ function drawHelpDetail() {
     _ctx.enterChainEdit = (...args) => enterChainEdit(...args);
     _ctx.enterPatchBrowser = (...args) => _enterPatchBrowser(...args);
     _ctx.enterMasterFxSettings = (...args) => enterMasterFxSettings(...args);
+    _ctx.enterFxBusEditor = (...args) => enterFxBusEditor(...args);
+    _ctx.enterFxBusPicker = () => enterFxBusPicker();
     _ctx.enterSlotSettings = (...args) => _enterSlotSettings(...args);
 })();
 
@@ -14255,6 +14650,89 @@ function applyPatchSelection() { _applyPatchSelection(); }
 function drawMasterFx() { _drawMasterFx(); }
 function getMasterFxDisplayName() { return _getMasterFxDisplayName(); }
 function enterMasterFxSettings() { _enterMasterFxSettings(); }
+
+/* Enter the generic FX editor for a bus (master/moveFxN). Sets the active
+ * bus descriptor, then runs the shared Master-FX-style editor entry. */
+function enterFxBusEditor(busId) {
+    activeFxBus = FX_BUS[busId] || FX_BUS.master;
+    enterMasterFxSettings();
+}
+
+let fxBusPickerIndex = 0;
+/* Per Move slot: true if its track is routed to the Schwung synth slot
+ * (slot:move_to_slot != "0" — the default). Refreshed in the render path
+ * (get_param is reliable there, not in input handlers) and read by the picker's
+ * select handler to decide direct-open vs route confirm. */
+let moveFxRouted = [];
+function refreshMoveFxRouted() {
+    moveFxRouted = [];
+    for (let s = 0; s < MOVE_FX_SLOTS_JS; s++) {
+        moveFxRouted.push(getSlotParam(s, "slot:move_to_slot") !== "0");
+    }
+}
+/* Route-to-chain confirm: -1 = none pending; else the 0-based slot/track index
+ * whose Move FX the user is trying to open while its track is still routed. */
+let pendingMoveFxRouteConfirm = -1;
+let moveFxRouteConfirmSel = 0;   /* 0 = No (default), 1 = Yes */
+function enterFxBusPicker() {
+    fxBusPickerIndex = 0;
+    pendingMoveFxRouteConfirm = -1;
+    refreshMoveFxRouted();
+    view = VIEWS.FX_BUS_PICKER;
+    if (coRunChainEditSlot >= 0) coRunView = VIEWS.FX_BUS_PICKER;
+    needsRedraw = true;
+}
+function drawFxBusPicker() {
+    clear_screen();
+    /* Route-to-chain confirm overlay. Highlighted No/Yes buttons (filled =
+     * selected, outlined = not) in the davebox dialog style; no footer. */
+    if (pendingMoveFxRouteConfirm >= 0) {
+        const n = pendingMoveFxRouteConfirm + 1;
+        const lines = wrapText("Move track " + n + " routed to Schwung slot " + n + ".", 21)
+            .concat(wrapText("Route to this chain instead?", 21));
+        let y = 4;
+        for (let i = 0; i < lines.length && y <= 40; i++) { print(2, y, lines[i], 1); y += 9; }
+        const noX = 6, yesX = 74, btnY = 44, btnW = 46, btnH = 13;
+        if (moveFxRouteConfirmSel === 0) {
+            fill_rect(noX, btnY, btnW, btnH, 1);
+            print(noX + 17, btnY + 3, "No", 0);
+        } else {
+            fill_rect(noX, btnY, btnW, 1, 1);
+            fill_rect(noX, btnY + btnH - 1, btnW, 1, 1);
+            fill_rect(noX, btnY, 1, btnH, 1);
+            fill_rect(noX + btnW - 1, btnY, 1, btnH, 1);
+            print(noX + 17, btnY + 3, "No", 1);
+        }
+        if (moveFxRouteConfirmSel === 1) {
+            fill_rect(yesX, btnY, btnW, btnH, 1);
+            print(yesX + 14, btnY + 3, "Yes", 0);
+        } else {
+            fill_rect(yesX, btnY, btnW, 1, 1);
+            fill_rect(yesX, btnY + btnH - 1, btnW, 1, 1);
+            fill_rect(yesX, btnY, 1, btnH, 1);
+            fill_rect(yesX + btnW - 1, btnY, 1, btnH, 1);
+            print(yesX + 14, btnY + 3, "Yes", 1);
+        }
+        return;
+    }
+    drawHeader("FX Buses");
+    refreshMoveFxRouted();
+    const items = [
+        { label: "Master FX", value: getMasterFxDisplayName() },
+    ];
+    for (let mv = 1; mv <= MOVE_FX_SLOTS_JS; mv++) {
+        items.push({ label: "Move " + mv + " FX", value: "" });
+    }
+    drawMenuList({
+        items,
+        selectedIndex: fxBusPickerIndex,
+        listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
+        getLabel: (item) => item.label,
+        getValue: (item) => item.value,
+        valueAlignRight: true
+    });
+    drawFooter("Back: exit");
+}
 function scanForToolModules() { return _scanForToolModules(); }
 function enterToolsMenu() {
     _enterToolsMenu();
@@ -14689,6 +15167,8 @@ globalThis.init = function() {
     }
     /* Re-apply Master FX sync after activeSlotStateDir resolves to the active set. */
     loadMasterFxChainFromConfig();
+    /* Move FX has no shim-side boot restore — load the active set's Move chains here. */
+    restoreMoveFxFromFiles();
 
     /* Sync dirty cache and slot names from autosave files (shim loaded them on startup) */
     for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
@@ -14803,6 +15283,7 @@ globalThis.init = function() {
 globalThis.shadow_save_state_now = function() {
     autosaveAllSlots();
     saveMasterFxChainConfig();
+    saveMoveFxChainConfig();  /* persist Move FX chains + strip volume per set */
     /* Also persist volumes/channels/mute/solo — otherwise the set's
      * shadow_chain_config.json drifts from slot_N.json across reboots,
      * e.g. toggling MPE (recv=All) before shutdown would revert on boot. */
@@ -14874,6 +15355,8 @@ function dispatchCoRunDraw() {
             drawMessageOverlay('Install Complete', storePostInstallLines);
             break;
         case VIEWS.FILEPATH_BROWSER:     drawFilepathBrowser(); break;
+        case VIEWS.FX_BUS_PICKER:        drawFxBusPicker(); break;
+        case VIEWS.MASTER_FX:            drawMasterFx(); break;
         default:
             /* Unknown view in co-run — render slot list as a recoverable
              * fallback so user can navigate back. */
@@ -15094,9 +15577,11 @@ globalThis.tick = function() {
                 }
             }
             if (flags & SHADOW_UI_FLAG_JUMP_TO_MASTER_FX) {
-                /* Always jump to Master FX view */
-                enterMasterFxSettings();
-                /* Clear the flag */
+                if (coRunChainEditSlot >= 0) {
+                    coRunView = VIEWS.FX_BUS_PICKER;
+                } else {
+                    enterFxBusPicker();
+                }
                 if (typeof shadow_clear_ui_flags === "function") {
                     shadow_clear_ui_flags(SHADOW_UI_FLAG_JUMP_TO_MASTER_FX);
                 }
@@ -15195,6 +15680,16 @@ globalThis.tick = function() {
                         const mfx = host_read_file(copySourceDir + "/master_fx_" + i + ".json");
                         if (mfx) host_write_file(newDir + "/master_fx_" + i + ".json", mfx);
                     }
+                    /* Copy Move FX per-set files (4 slots × blocks) + strip meta */
+                    for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+                        for (let b = 0; b < MOVE_FX_BLOCKS_JS; b++) {
+                            const mvName = "/move_fx_" + sl + "_" + b + ".json";
+                            const mv = host_read_file(copySourceDir + mvName);
+                            if (mv) host_write_file(newDir + mvName, mv);
+                        }
+                    }
+                    const mvMeta = host_read_file(copySourceDir + "/move_fx_meta.json");
+                    if (mvMeta) host_write_file(newDir + "/move_fx_meta.json", mvMeta);
                     /* Also copy chain config */
                     const chainCfg = host_read_file(copySourceDir + "/shadow_chain_config.json");
                     if (chainCfg) host_write_file(newDir + "/shadow_chain_config.json", chainCfg);
@@ -15204,6 +15699,12 @@ globalThis.tick = function() {
                     for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                         host_write_file(newDir + "/slot_" + i + ".json", "{}\n");
                         host_write_file(newDir + "/master_fx_" + i + ".json", "{}\n");
+                    }
+                    /* Empty Move FX files so a new set starts with no Move FX chains. */
+                    for (let sl = 0; sl < MOVE_FX_SLOTS_JS; sl++) {
+                        for (let b = 0; b < MOVE_FX_BLOCKS_JS; b++) {
+                            host_write_file(newDir + "/move_fx_" + sl + "_" + b + ".json", "{}\n");
+                        }
                     }
                     /* Seed a default chain config so receive channels reset to
                      * per-track defaults (Ch 1-4). Without this, the upcoming
@@ -15327,6 +15828,11 @@ globalThis.tick = function() {
                 }
                 debugLog("SET_CHANGED: MFX " + mfxi + " -> " + (mfxModuleId || "(none)"));
             }
+
+            /* 7b. Reload Move FX chains + strip volume for the new set. Uses
+             * explicit move_fx:* keys, so it's independent of activeFxBus. */
+            restoreMoveFxFromFiles();
+
             /* 8. Refresh slot names from new autosave files */
             for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
                 slots[i].name = "";
@@ -15661,6 +16167,9 @@ globalThis.tick = function() {
             break;
         case VIEWS.MASTER_FX:
             drawMasterFx();
+            break;
+        case VIEWS.FX_BUS_PICKER:
+            drawFxBusPicker();
             break;
         case VIEWS.CHAIN_EDIT:
             drawChainEdit();
@@ -16109,7 +16618,7 @@ globalThis.onMidiMessageInternal = function(data) {
                 runCoRunChainEdit(function() {
                     if (hostShiftHeld && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
                         handleShiftSelect();
-                    } else if (hostShiftHeld && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
+                    } else if (hostShiftHeld && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
                         enterMasterFxModuleSelect(selectedMasterFxComponent);
                     } else {
                         handleSelect();
@@ -16147,6 +16656,13 @@ globalThis.onMidiMessageInternal = function(data) {
              * Eating it here prevents the tool from reacting (e.g. its own
              * Shift+button shortcuts while you're navigating the editor). */
             if (d1 === 49 && coRunCedes(CORUN_GRP_SHIFT)) {
+                needsRedraw = true;
+                return;
+            }
+            /* Menu (CC 50): open FX bus picker during co-run */
+            if (d1 === 50 && d2 > 0) {
+                coRunView = VIEWS.FX_BUS_PICKER;
+                runCoRunChainEdit(function() { enterFxBusPicker(); });
                 needsRedraw = true;
                 return;
             }
@@ -16277,8 +16793,8 @@ globalThis.onMidiMessageInternal = function(data) {
             /* Shift+Click in chain edit enters component edit mode */
             if (isShiftHeld() && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
                 handleShiftSelect();
-            } else if (isShiftHeld() && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < 4) {
-                /* Shift+Click in Master FX view enters module selector for the slot */
+            } else if (isShiftHeld() && view === VIEWS.MASTER_FX && selectedMasterFxComponent >= 0 && selectedMasterFxComponent < activeFxBus.slotCount) {
+                /* Shift+Click in FX editor enters module selector for the slot */
                 enterMasterFxModuleSelect(selectedMasterFxComponent);
             } else {
                 handleSelect();

--- a/src/shadow/shadow_ui_master_fx.mjs
+++ b/src/shadow/shadow_ui_master_fx.mjs
@@ -21,12 +21,20 @@ import {
     announce, announceMenuItem
 } from '/data/UserData/schwung/shared/screen_reader.mjs';
 
+/* FX-overview per-slot bypass markers are polled into a small cache and
+ * refreshed every FX_STATE_POLL_EVERY draws (and immediately on a bus switch)
+ * rather than every periodic redraw, to bound get_param IPC. */
+const FX_STATE_POLL_EVERY = 8;
+let _fxStateDrawCount = 0;
+let _fxStateCacheBus = "";
+let _fxBypassCache = {};
+
 /* ---- Enter -------------------------------------------------------------- */
 
 export function enterMasterFxSettings() {
     const { scanForAudioFxModules, loadMasterFxChainConfig,
             getMasterFxSlotModule, MASTER_FX_CHAIN_COMPONENTS,
-            setView, VIEWS } = ctx;
+            activeFxBus, setView, VIEWS } = ctx;
 
     ctx.MASTER_FX_OPTIONS = scanForAudioFxModules();
     loadMasterFxChainConfig();
@@ -37,15 +45,16 @@ export function enterMasterFxSettings() {
 
     const comp = MASTER_FX_CHAIN_COMPONENTS[0];
     const moduleName = getMasterFxSlotModule(0) || "Empty";
-    announce(`Master FX, ${comp.label} ${moduleName}`);
+    announce(`${activeFxBus.title}, ${comp.label} ${moduleName}`);
 }
 
 /* ---- Display name (used in slot list) ----------------------------------- */
 
 export function getMasterFxDisplayName() {
-    const { masterFxConfig } = ctx;
+    const { masterFxConfig, activeFxBus } = ctx;
+    const slotCount = activeFxBus ? activeFxBus.slotCount : 4;
     const parts = [];
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= slotCount; i++) {
         const key = `fx${i}`;
         if (masterFxConfig[key]?.module) {
             parts.push(masterFxConfig[key].module);
@@ -62,7 +71,7 @@ export function drawMasterFx() {
             inMasterPresetPicker, inMasterFxSettingsMenu,
             selectingMasterFxModule, selectedMasterFxComponent,
             masterFxConfig, MASTER_FX_CHAIN_COMPONENTS, MASTER_FX_OPTIONS,
-            currentMasterPresetName, getMasterFxParam,
+            currentMasterPresetName, getMasterFxParam, activeFxBus,
             getModuleAbbrev, isTextEntryActive, drawTextEntry,
             drawHelpDetail, drawHelpList } = ctx;
 
@@ -112,19 +121,24 @@ export function drawMasterFx() {
         return;
     }
 
-    drawHeader("Master FX");
+    drawHeader(activeFxBus.title);
+
+    /* Render the active bus's own components (Master/Send have 4 FX + settings;
+     * Move FX has MOVE_FX_BLOCKS + settings). Behaviour-identical for the 5-box
+     * buses; correct box count + settings position for the shorter Move buses. */
+    const comps = activeFxBus.components || MASTER_FX_CHAIN_COMPONENTS;
 
     const BOX_W = 22;
     const BOX_H = 16;
     const GAP = 2;
-    const TOTAL_W = 5 * BOX_W + 4 * GAP;
+    const TOTAL_W = comps.length * BOX_W + (comps.length - 1) * GAP;
     const START_X = Math.floor((SCREEN_WIDTH - TOTAL_W) / 2);
     const BOX_Y = 20;
 
     const presetSelected = selectedMasterFxComponent === -1;
 
-    for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
-        const comp = MASTER_FX_CHAIN_COMPONENTS[i];
+    for (let i = 0; i < comps.length; i++) {
+        const comp = comps[i];
         const x = START_X + i * (BOX_W + GAP);
         const isSelected = i === selectedMasterFxComponent;
 
@@ -153,26 +167,39 @@ export function drawMasterFx() {
      * editor: 3-wide × 4-tall glyph at iy=BOX_Y-6. Sits left of where the LFO
      * indicator is centered, so they coexist without overlap. */
     if (typeof shadow_get_param === "function") {
-        for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
-            const comp = MASTER_FX_CHAIN_COMPONENTS[i];
-            if (comp.key === "settings") continue;
-            const bypassed = parseInt(
-                shadow_get_param(0, `master_fx:${comp.key}:bypassed`) || "0", 10
-            ) === 1;
-            if (!bypassed) continue;
-            const x = START_X + i * (BOX_W + GAP);
-            const bx = x + 1;
-            const by = BOX_Y - 6;
-            /* "B" glyph: ##. / #.# / ##. / ### */
-            set_pixel(bx,     by,     1); set_pixel(bx + 1, by,     1);
-            set_pixel(bx,     by + 1, 1); set_pixel(bx + 2, by + 1, 1);
-            set_pixel(bx,     by + 2, 1); set_pixel(bx + 1, by + 2, 1);
-            set_pixel(bx,     by + 3, 1); set_pixel(bx + 1, by + 3, 1); set_pixel(bx + 2, by + 3, 1);
+        _fxStateDrawCount++;
+        if (_fxStateCacheBus !== activeFxBus.id ||
+            (_fxStateDrawCount % FX_STATE_POLL_EVERY) === 0) {
+            _fxStateCacheBus = activeFxBus.id;
+            _fxBypassCache = {};
+            for (let i = 0; i < comps.length; i++) {
+                const comp = comps[i];
+                if (comp.key === "settings") continue;
+                _fxBypassCache[comp.key] = parseInt(
+                    shadow_get_param(0, activeFxBus.paramPrefix + comp.key + ":bypassed") || "0", 10
+                ) === 1;
+            }
         }
     }
 
-    /* Draw LFO indicators above targeted FX boxes */
-    if (typeof shadow_get_param === "function") {
+    /* Draw bypass 'B' markers from cache. */
+    for (let i = 0; i < comps.length; i++) {
+        const comp = comps[i];
+        if (comp.key === "settings") continue;
+        if (!_fxBypassCache[comp.key]) continue;
+        const x = START_X + i * (BOX_W + GAP);
+        const bx = x + 1;
+        const by = BOX_Y - 6;
+        /* "B" glyph: ##. / #.# / ##. / ### */
+        set_pixel(bx,     by,     1); set_pixel(bx + 1, by,     1);
+        set_pixel(bx,     by + 1, 1); set_pixel(bx + 2, by + 1, 1);
+        set_pixel(bx,     by + 2, 1); set_pixel(bx + 1, by + 2, 1);
+        set_pixel(bx,     by + 3, 1); set_pixel(bx + 1, by + 3, 1); set_pixel(bx + 2, by + 3, 1);
+    }
+
+    /* Draw LFO indicators above targeted FX boxes (master bus only — sends
+     * have no LFOs). */
+    if (activeFxBus.hasLfo && typeof shadow_get_param === "function") {
         const mfxLfoTargets = {};
         for (let li = 1; li <= 2; li++) {
             const enabled = shadow_get_param(0, "master_fx:lfo" + li + ":enabled");
@@ -191,8 +218,8 @@ export function drawMasterFx() {
         const DIGIT_1_4PX = [0x2, 0x6, 0x2, 0x2]; /* .#. / ##. / .#. / .#. */
         const DIGIT_2_4PX = [0x6, 0x1, 0x2, 0x7]; /* ##. / ..# / .#. / ### */
 
-        for (let i = 0; i < MASTER_FX_CHAIN_COMPONENTS.length; i++) {
-            const comp = MASTER_FX_CHAIN_COMPONENTS[i];
+        for (let i = 0; i < comps.length; i++) {
+            const comp = comps[i];
             if (comp.key === "settings") continue;
             const targets = mfxLfoTargets[comp.key];
             if (!targets) continue;
@@ -249,7 +276,7 @@ export function drawMasterFx() {
         }
     }
 
-    const selectedComp = presetSelected ? null : MASTER_FX_CHAIN_COMPONENTS[selectedMasterFxComponent];
+    const selectedComp = presetSelected ? null : comps[selectedMasterFxComponent];
     const labelY = BOX_Y + BOX_H + 4;
     const label = presetSelected ? "Preset" : (selectedComp ? selectedComp.label : "");
     const labelX = Math.floor((SCREEN_WIDTH - label.length * 5) / 2);
@@ -271,7 +298,10 @@ export function drawMasterFx() {
             infoLine = "(empty)";
         }
     } else if (selectedComp && selectedComp.key === "settings") {
-        infoLine = "Configure master FX";
+        let what;
+        if (activeFxBus.isMoveFx) what = `Move ${activeFxBus.moveSlot + 1}`;
+        else what = "Master";
+        infoLine = `Configure ${what} FX`;
     }
     infoLine = truncateText(infoLine, 24);
     const infoX = Math.floor((SCREEN_WIDTH - infoLine.length * 5) / 2);
@@ -280,9 +310,9 @@ export function drawMasterFx() {
 
 function drawMasterFxSettingsMenu() {
     const { currentMasterPresetName, selectedMasterFxSetting,
-            getMasterFxSettingsItems, getMasterFxSettingValue } = ctx;
+            getMasterFxSettingsItems, getMasterFxSettingValue, activeFxBus } = ctx;
 
-    const title = currentMasterPresetName || "Master FX";
+    const title = currentMasterPresetName || activeFxBus.title;
     drawHeader(truncateText(title, 18));
 
     const items = getMasterFxSettingsItems();
@@ -330,9 +360,9 @@ function drawMasterFxModuleSelect() {
 
 function drawMasterPresetPicker() {
     const { masterPresets, selectedMasterPresetIndex,
-            currentMasterPresetName } = ctx;
+            currentMasterPresetName, activeFxBus } = ctx;
 
-    drawHeader("Master Presets");
+    drawHeader(activeFxBus.presetPickerTitle);
 
     const items = [{ name: "[New]", index: -1 }];
     for (let i = 0; i < masterPresets.length; i++) {

--- a/src/shadow/shadow_ui_slots.mjs
+++ b/src/shadow/shadow_ui_slots.mjs
@@ -41,6 +41,22 @@ export const SLOT_SETTINGS = [
 let selectedSetting = 0;
 let editingSettingValue = false;
 
+/* One Move FX mini-bus per Move track (channel). Show loaded block names.
+ * Probes up to 4 blocks so it works regardless of MOVE_FX_BLOCKS. */
+function getMoveFxDisplayName(slot) {
+    const { getSlotParam } = ctx;
+    const parts = [];
+    for (let i = 1; i <= 4; i++) {
+        const name = getSlotParam(0, `move_fx:${slot + 1}:fx${i}:name`);
+        if (name) parts.push(name);
+    }
+    return parts.length > 0 ? parts.join("+") : "None";
+}
+
+/* Number of Move FX slots (one per Move track). Matches MOVE_FX_SLOTS in C and
+ * MOVE_FX_SLOTS_JS in shadow_ui.js; fixed at 4 (Move has 4 tracks). */
+const MOVE_FX_SLOT_ROWS = 4;
+
 /* ---- Helpers ------------------------------------------------------------ */
 
 /* Check if a slot is in MPE mode (Recv=All + Fwd=THRU) */
@@ -183,7 +199,10 @@ export function drawSlots() {
                 isSlot: true
             };
         }),
-        { label: " Master FX", value: getMasterFxDisplayName(), isSlot: false }
+        { label: " Master FX", value: getMasterFxDisplayName(), isSlot: false },
+        ...Array.from({ length: MOVE_FX_SLOT_ROWS }, (_, i) => ({
+            label: " Move FX " + (i + 1), value: getMoveFxDisplayName(i), isSlot: false
+        }))
     ];
 
     drawMenuList({
@@ -256,7 +275,7 @@ export function drawSlotSettings() {
 
 export function handleSlotsJog(delta) {
     const { slots, updateFocusedSlot } = ctx;
-    ctx.selectedSlot = Math.max(0, Math.min(slots.length, ctx.selectedSlot + delta));
+    ctx.selectedSlot = Math.max(0, Math.min(slots.length + MOVE_FX_SLOT_ROWS, ctx.selectedSlot + delta));
     updateFocusedSlot(ctx.selectedSlot);
 }
 
@@ -278,11 +297,14 @@ export function handleSlotSettingsJog(delta) {
 /* ---- Select ------------------------------------------------------------- */
 
 export function handleSlotsSelect() {
-    const { selectedSlot, slots, enterChainEdit, enterMasterFxSettings } = ctx;
+    const { selectedSlot, slots, enterChainEdit, enterFxBusEditor } = ctx;
     if (selectedSlot < slots.length) {
         enterChainEdit(selectedSlot);
-    } else {
-        enterMasterFxSettings();
+    } else if (selectedSlot === slots.length) {
+        enterFxBusEditor("master");
+    } else if (selectedSlot >= slots.length + 1 &&
+               selectedSlot < slots.length + 1 + MOVE_FX_SLOT_ROWS) {
+        enterFxBusEditor("moveFx" + (selectedSlot - slots.length));
     }
 }
 


### PR DESCRIPTION
Adds per-**Move-track insert FX**: four Move FX buses (one per Move track), each its own FX chain (up to 2 effects), mixed to master at a per-bus volume, surfaced in the same generic **FX-bus picker** that hosts Master FX. Classic channel-insert model — an effect placed directly in one track's path.

## Highlights
- Four **Move FX buses** (one per Move track), 2 insert effects each, per-bus **volume**, **shared presets** across all 4 buses, full **per-set persistence**.
- **Move>SchwFX** per-track routing: a Move track normally rides its Schwung synth slot; peeling it (`Move>SchwFX` Off) routes it through its own Move FX bus. The picker always shows all 4 Move rows; opening a still-routed one prompts a **route-to-chain confirm** that peels it for you.
- The Master-FX editor is genericized into one **bus-descriptor-driven** editor serving Master + Move FX; Move buses hide LFO items; the home-screen knob-context cache is keyed per bus.
- Move buses are hosted like Master FX (`master_fx_slot_t[]`), so module hosting / presets / bypass are reused, not duplicated. The insert mix lives in the shim: peeled Move tracks run their bus chain → ×volume → master/ME bus (idle-gated, independent of the synth slot's mute/solo).

## Shared FX-bus picker — same as #115, bundled in both
The **FX-bus picker / generic multi-bus editor** here is the *same* foundation introduced in #115 (Send FX), included in **both** PRs so either can be merged independently — neither depends on the other. The picker / generic-editor hunks are **identical** between the two PRs, so if both land they merge cleanly with no conflict; the picker simply gains the Send buses or the Move buses depending on which is applied (or both).

## Carried fix (worth taking regardless)
- `json_get_section_bounds` now anchors on the key's colon and only reads an object when the value *is* one — a null-valued (empty) FX slot previously grabbed a *later* slot's object and corrupted saved presets (also fixes a latent **Master**-preset bug). Same hunk as #115.

## Docs
Full design — topology, parameters, mix path, persistence, and per-file roles — in **`docs/MOVE_FX.md`**.

## Testing
Built against `main` (v0.9.18). Device-verified on Move: FX-bus picker (Master + Move 1–4), 2-FX buses, route-to-chain confirm, shared Move FX presets (save on one bus / load on another), per-bus volume, knob popups + bypass indicators on the FX overview, Back exits the picker, and persistence across set changes.

## Follow-up
Per-track **Send A/B** routing for Move buses depends on the Send FX buses (#115) and is a planned follow-up once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
