### PR TITLE
fix(remote-ui): same-origin framing, preset sync, and slot settings for custom-UI modules

### DIFF
--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -3247,6 +3247,17 @@ func (app *App) handleModuleWebUIAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Module web UIs are intentionally embedded in the Remote UI page's
+	// same-origin iframe (see remote_ui.go / static/remote-ui.js). The global
+	// SecurityHeaders middleware sets X-Frame-Options: DENY, which would block
+	// that embed and leave a blank/error iframe. Relax it to SAMEORIGIN for
+	// these assets only — cross-origin framing (clickjacking) is still denied.
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+
+	// Module UIs change when a module is updated/reinstalled, and a stale cached
+	// response would also pin stale security headers in the browser. Never cache.
+	w.Header().Set("Cache-Control", "no-store")
+
 	http.ServeFile(w, r, fullPath)
 }
 

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -769,6 +769,11 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 	const presetResendThrottle = 120 * time.Millisecond
 	lastResend := make(map[uint8]time.Time)
 	pendingResend := make(map[uint8]map[string]bool) // slot -> comp -> needs full re-send
+	// Master FX lives at slot 0 but is delivered to a separate subscription
+	// (masterFxSub), so it gets its own pending set + throttle keyed by comp
+	// ("master_fx:fxN") rather than sharing the chain-slot maps above.
+	var lastResendMasterFx time.Time
+	pendingMasterFxResend := make(map[string]bool) // comp -> needs full re-send
 
 	for {
 		select {
@@ -783,7 +788,7 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		}
 
 		changes := ring.Drain()
-		if len(changes) == 0 && len(pendingResend) == 0 {
+		if len(changes) == 0 && len(pendingResend) == 0 && len(pendingMasterFxResend) == 0 {
 			continue
 		}
 
@@ -804,6 +809,12 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 			for _, c := range changes {
 				if c.Slot == 0 && strings.HasPrefix(c.Key, "master_fx:") {
 					masterFxChanges[c.Key] = c.Value
+					// A device-initiated master-FX preset load reshuffles every
+					// param internally; the notify ring carries only the index,
+					// so mark the comp ("master_fx:fxN") for a full re-send.
+					if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
+						pendingMasterFxResend[c.Key[:i]] = true
+					}
 					continue
 				}
 				m, ok := slotChanges[c.Slot]
@@ -848,6 +859,13 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		// Flush throttled full-state re-sends for components whose preset
 		// changed. sendInitialParamValues pushes name/count + every value, so
 		// the browser's knobs/sliders catch up to the new preset.
+		//
+		// The send is offloaded to a goroutine: for a param-heavy module
+		// without the :state fast path, sendInitialParamValues sleeps ~20ms
+		// per 8 params (hundreds of ms total). Running it inline would block
+		// this 5ms drain loop, overflowing the 64-entry shim ring and dropping
+		// live knob updates. The throttle keys off dispatch time (lastResend
+		// set before launch), so rapid preset scrolling still coalesces.
 		if len(pendingResend) > 0 {
 			now := time.Now()
 			for slot, comps := range pendingResend {
@@ -855,17 +873,39 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					continue
 				}
 				lastResend[slot] = now
+				compList := make([]string, 0, len(comps))
 				for comp := range comps {
-					for _, c := range clients {
-						c.mu.Lock()
-						subscribed := c.subs[slot]
-						c.mu.Unlock()
-						if subscribed {
+					compList = append(compList, comp)
+				}
+				delete(pendingResend, slot)
+				go func(slot uint8, comps []string) {
+					for _, comp := range comps {
+						for _, c := range ru.subscribedClients(slot) {
 							ru.sendInitialParamValues(ctx, c, slot, comp)
 						}
 					}
+				}(slot, compList)
+			}
+		}
+
+		// Same treatment for master-FX preset changes, delivered to the
+		// separate master-FX subscription and throttled independently.
+		if len(pendingMasterFxResend) > 0 {
+			now := time.Now()
+			if now.Sub(lastResendMasterFx) >= presetResendThrottle {
+				lastResendMasterFx = now
+				compList := make([]string, 0, len(pendingMasterFxResend))
+				for comp := range pendingMasterFxResend {
+					compList = append(compList, comp)
 				}
-				delete(pendingResend, slot)
+				pendingMasterFxResend = make(map[string]bool)
+				go func(comps []string) {
+					for _, comp := range comps {
+						for _, c := range ru.masterFxSubscribedClients() {
+							ru.sendInitialParamValues(ctx, c, 0, comp)
+						}
+					}
+				}(compList)
 			}
 		}
 	}

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -760,6 +760,16 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Millisecond)
 	defer ticker.Stop()
 
+	// When a component's preset (list_param) changes, the notify ring only
+	// carries the numeric index — not the new preset's param VALUES or its name
+	// string. So we re-push that component's full state (+ preset-browser
+	// params). Throttled per slot (leading edge fires immediately; trailing
+	// change still lands after the throttle) so quick preset scrolling doesn't
+	// flood the shared param channel and stall sync.
+	const presetResendThrottle = 120 * time.Millisecond
+	lastResend := make(map[uint8]time.Time)
+	pendingResend := make(map[uint8]map[string]bool) // slot -> comp -> needs full re-send
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -773,40 +783,11 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		}
 
 		changes := ring.Drain()
-		if len(changes) == 0 {
+		if len(changes) == 0 && len(pendingResend) == 0 {
 			continue
 		}
 
-		// Group changes by slot, splitting master FX keys (slot 0,
-		// "master_fx:" prefix) into their own bucket so master-FX-only
-		// subscribers receive them without needing a slot 0 subscription.
-		slotChanges := make(map[uint8]map[string]string)
-		masterFxChanges := make(map[string]string)
-		// Components whose preset (list_param) changed: the notify ring carries the
-		// numeric preset index but NOT the preset name string, so we must re-push the
-		// preset-browser params (name/count) for these afterwards.
-		presetDirty := make(map[uint8]map[string]bool)
-		for _, c := range changes {
-			if c.Slot == 0 && strings.HasPrefix(c.Key, "master_fx:") {
-				masterFxChanges[c.Key] = c.Value
-				continue
-			}
-			m, ok := slotChanges[c.Slot]
-			if !ok {
-				m = make(map[string]string)
-				slotChanges[c.Slot] = m
-			}
-			m[c.Key] = c.Value
-			if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
-				comp := c.Key[:i]
-				if presetDirty[c.Slot] == nil {
-					presetDirty[c.Slot] = make(map[string]bool)
-				}
-				presetDirty[c.Slot][comp] = true
-			}
-		}
-
-		// Broadcast to subscribed clients.
+		// Snapshot subscribers once per active tick.
 		ru.mu.Lock()
 		clients := make([]*ruClient, 0, len(ru.clients))
 		for c := range ru.clients {
@@ -814,42 +795,77 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		}
 		ru.mu.Unlock()
 
-		for slot, params := range slotChanges {
-			update := wsParamUpdate{Type: "param_update", Slot: slot, Params: params}
-			for _, c := range clients {
-				c.mu.Lock()
-				subscribed := c.subs[slot]
-				c.mu.Unlock()
-				if subscribed {
-					ru.writeJSON(ctx, c, update)
+		if len(changes) > 0 {
+			// Group changes by slot, splitting master FX keys (slot 0,
+			// "master_fx:" prefix) into their own bucket so master-FX-only
+			// subscribers receive them without needing a slot 0 subscription.
+			slotChanges := make(map[uint8]map[string]string)
+			masterFxChanges := make(map[string]string)
+			for _, c := range changes {
+				if c.Slot == 0 && strings.HasPrefix(c.Key, "master_fx:") {
+					masterFxChanges[c.Key] = c.Value
+					continue
+				}
+				m, ok := slotChanges[c.Slot]
+				if !ok {
+					m = make(map[string]string)
+					slotChanges[c.Slot] = m
+				}
+				m[c.Key] = c.Value
+				if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
+					if pendingResend[c.Slot] == nil {
+						pendingResend[c.Slot] = make(map[string]bool)
+					}
+					pendingResend[c.Slot][c.Key[:i]] = true
 				}
 			}
-		}
 
-		// Re-push preset-browser params (name/count) for any component whose
-		// preset changed — the notify ring only carries the numeric index.
-		for slot, comps := range presetDirty {
-			for comp := range comps {
+			for slot, params := range slotChanges {
+				update := wsParamUpdate{Type: "param_update", Slot: slot, Params: params}
 				for _, c := range clients {
 					c.mu.Lock()
 					subscribed := c.subs[slot]
 					c.mu.Unlock()
 					if subscribed {
-						ru.sendHierarchyParams(ctx, c, slot, comp)
+						ru.writeJSON(ctx, c, update)
+					}
+				}
+			}
+
+			if len(masterFxChanges) > 0 {
+				update := wsParamUpdate{Type: "param_update", Slot: 0, Params: masterFxChanges}
+				for _, c := range clients {
+					c.mu.Lock()
+					subscribed := c.masterFxSub
+					c.mu.Unlock()
+					if subscribed {
+						ru.writeJSON(ctx, c, update)
 					}
 				}
 			}
 		}
 
-		if len(masterFxChanges) > 0 {
-			update := wsParamUpdate{Type: "param_update", Slot: 0, Params: masterFxChanges}
-			for _, c := range clients {
-				c.mu.Lock()
-				subscribed := c.masterFxSub
-				c.mu.Unlock()
-				if subscribed {
-					ru.writeJSON(ctx, c, update)
+		// Flush throttled full-state re-sends for components whose preset
+		// changed. sendInitialParamValues pushes name/count + every value, so
+		// the browser's knobs/sliders catch up to the new preset.
+		if len(pendingResend) > 0 {
+			now := time.Now()
+			for slot, comps := range pendingResend {
+				if now.Sub(lastResend[slot]) < presetResendThrottle {
+					continue
 				}
+				lastResend[slot] = now
+				for comp := range comps {
+					for _, c := range clients {
+						c.mu.Lock()
+						subscribed := c.subs[slot]
+						c.mu.Unlock()
+						if subscribed {
+							ru.sendInitialParamValues(ctx, c, slot, comp)
+						}
+					}
+				}
+				delete(pendingResend, slot)
 			}
 		}
 	}

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -782,6 +782,10 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		// subscribers receive them without needing a slot 0 subscription.
 		slotChanges := make(map[uint8]map[string]string)
 		masterFxChanges := make(map[string]string)
+		// Components whose preset (list_param) changed: the notify ring carries the
+		// numeric preset index but NOT the preset name string, so we must re-push the
+		// preset-browser params (name/count) for these afterwards.
+		presetDirty := make(map[uint8]map[string]bool)
 		for _, c := range changes {
 			if c.Slot == 0 && strings.HasPrefix(c.Key, "master_fx:") {
 				masterFxChanges[c.Key] = c.Value
@@ -793,6 +797,13 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 				slotChanges[c.Slot] = m
 			}
 			m[c.Key] = c.Value
+			if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
+				comp := c.Key[:i]
+				if presetDirty[c.Slot] == nil {
+					presetDirty[c.Slot] = make(map[string]bool)
+				}
+				presetDirty[c.Slot][comp] = true
+			}
 		}
 
 		// Broadcast to subscribed clients.
@@ -811,6 +822,21 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 				c.mu.Unlock()
 				if subscribed {
 					ru.writeJSON(ctx, c, update)
+				}
+			}
+		}
+
+		// Re-push preset-browser params (name/count) for any component whose
+		// preset changed — the notify ring only carries the numeric index.
+		for slot, comps := range presetDirty {
+			for comp := range comps {
+				for _, c := range clients {
+					c.mu.Lock()
+					subscribed := c.subs[slot]
+					c.mu.Unlock()
+					if subscribed {
+						ru.sendHierarchyParams(ctx, c, slot, comp)
+					}
 				}
 			}
 		}

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -1912,6 +1912,12 @@
             slotContentEl.appendChild(section);
         }
 
+        // Slot settings (volume, sends, channels, LFO, …) are module-independent
+        // and must still render with a custom synth UI — the non-custom path
+        // appends them at the bottom, so do the same here.
+        var settingsSection = renderSlotSettings(s);
+        if (settingsSection) slotContentEl.appendChild(settingsSection);
+
         customUIIframe = iframe;
         customUISubscribed = false;
     }


### PR DESCRIPTION
Four generalized fixes to the Remote UI for modules that ship a custom `web_ui.html` (not specific to any module). All in `schwung-manager` (`main.go`, `remote_ui.go`, `static/remote-ui.js`).

## 1. Allow same-origin framing of module web UIs
The Remote UI loads a module's `web_ui.html` in a **same-origin iframe**, but the global `SecurityHeaders` middleware stamps `X-Frame-Options: DENY` on every response — including the `/api/remote-ui/module-assets/{id}/{file}` asset — so the iframe renders blank/broken for every custom-UI module. Relax to `SAMEORIGIN` for that endpoint only (cross-origin framing still denied), and add `Cache-Control: no-store` so an updated module UI / stale header can't be cached.

## 2. Re-push preset name/count when the preset changes
The notify ring carries the numeric preset index but not the preset-name string, and `sendHierarchyParams` only ran on subscribe — so after switching presets the browser kept showing the old name. Detect `<comp>:preset` changes in the notify drain and re-push the component's preset-browser params.

## 3. Re-push full state on preset change (throttled)
A device-initiated preset load changes params internally; the notify ring doesn't carry those values, so the browser's knobs/sliders stayed stale for a long time, and quick preset scrolling could stall sync by hammering the shared param channel. On a `<comp>:preset` change, re-push the component's **full state** (`sendInitialParamValues`), throttled per slot (120 ms, leading edge immediate; trailing change still lands) so rapid scrolling coalesces.

## 4. Render slot settings for slots with a custom web UI
`renderSlot()` early-returns after `renderCustomUI()`, which skipped `renderSlotSettings()` — so any slot using a custom-UI module lost its slot-settings panel (volume, sends, receive/forward channel, mute/solo, MPE, LFO). Append slot settings below the custom-UI layout, matching the non-custom path.

All four verified on an Ableton Move (with an OB-Xd module as the test custom-UI synth). The branch is based on the shared merge-base rather than the latest `main` only to keep the push free of workflow-file changes; happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)