### PR TITLE
Add onResume() module lifecycle hook for resumed overtake modules

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -88,7 +88,20 @@ globalThis.init = function() {
 globalThis.tick = function() {
     // Update display, handle animations
 }
+
+// Called once when an overtake module is being torn down (optional)
+globalThis.onUnload = function() {
+    // Release resources, persist state, etc.
+}
+
+// Called once each time a suspended `suspend_keeps_js` overtake module is
+// brought back to the foreground (optional)
+globalThis.onResume = function() {
+    // Invalidate LED delta-cache, force a full repaint, etc.
+}
 ```
+
+`onResume()` fires once each time a suspended `suspend_keeps_js` overtake module is brought back to the foreground — it is **not** called on first load (`init()` handles that). While the module is backgrounded its hardware LEDs were cleared, so the typical use is to invalidate any on-change LED delta-cache and force a full repaint on the next `tick()`. It is optional and opt-in: modules that do not define it are unaffected.
 
 ## Menu Layout Helpers
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1873,6 +1873,13 @@ When an overtake module is loaded:
 
 The progressive LED clearing prevents MIDI buffer overflow (the buffer holds ~64 packets).
 
+#### Optional lifecycle hooks
+
+Beyond `init()`, `tick()`, and `onMidiMessageInternal()`/`onMidiMessageExternal()`, overtake modules may define two optional hooks:
+
+- `globalThis.onUnload()` — called once when the module is being torn down. Use it to release resources or persist state.
+- `globalThis.onResume()` — called once each time a suspended `suspend_keeps_js` overtake module is brought back to the foreground. It is **not** called on first load (`init()` handles that). While the module was backgrounded its hardware LEDs were cleared, so the typical use is to invalidate any on-change LED delta-cache and force a full repaint on the next `tick()`. Both hooks are opt-in: modules that do not define them are unaffected.
+
 ### Host-Level Escape
 
 The host provides a built-in escape mechanism that always works, regardless of module implementation:

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -5388,11 +5388,18 @@ function startInteractiveTool(toolModule, filePath) {
             overtakeModuleCallbacks = {
                 init: (globalThis.init !== savedInit) ? globalThis.init : null,
                 tick: (globalThis.tick !== savedTick) ? globalThis.tick : null,
-                onMidiMessageInternal: (globalThis.onMidiMessageInternal !== savedMidi) ? globalThis.onMidiMessageInternal : null
+                onMidiMessageInternal: (globalThis.onMidiMessageInternal !== savedMidi) ? globalThis.onMidiMessageInternal : null,
+                onUnload: (typeof globalThis.onUnload === "function") ? globalThis.onUnload : null,
+                /* onResume(): optional. Called once each time the module is
+                 * resumed from suspend (init() is NOT re-run). See
+                 * invokeModuleOnResume for the module-facing contract. */
+                onResume: (typeof globalThis.onResume === "function") ? globalThis.onResume : null
             };
             globalThis.init = savedInit;
             globalThis.tick = savedTick;
             globalThis.onMidiMessageInternal = savedMidi;
+            if (typeof globalThis.onUnload === "function") delete globalThis.onUnload;
+            if (typeof globalThis.onResume === "function") delete globalThis.onResume;
             debugLog("startInteractiveTool reconnect: callbacks captured - init:" + !!overtakeModuleCallbacks.init +
                      " tick:" + !!overtakeModuleCallbacks.tick +
                      " midi:" + !!overtakeModuleCallbacks.onMidiMessageInternal);

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2786,6 +2786,29 @@ function invokeModuleOnUnload(callbacks, moduleId) {
     }
 }
 
+/* Invoke a module's optional onResume() callback once per suspend→resume.
+ *
+ * Module-facing contract: onResume() runs each time the user returns to
+ * an already-loaded overtake module that was suspended (another module or
+ * MoveOriginal had been brought to the front). It is NOT a second init()
+ * — init() ran once at load and is not repeated — it is the signal to
+ * re-establish whatever state does not survive being backgrounded. Notably
+ * the hardware LEDs are cleared while suspended, so a module that paints
+ * LEDs should force a full repaint here. Optional: a module that needs
+ * nothing on resume simply omits it.
+ *
+ * Wrapped in try/catch so a buggy module can't break the resume path. */
+function invokeModuleOnResume(callbacks, moduleId) {
+    if (callbacks && typeof callbacks.onResume === "function") {
+        try {
+            debugLog("invokeModuleOnResume: " + moduleId);
+            callbacks.onResume();
+        } catch (e) {
+            debugLog("invokeModuleOnResume(" + moduleId + ") threw: " + e);
+        }
+    }
+}
+
 /* Enter the overtake module selection menu */
 function enterOvertakeMenu() {
     /* Flush set state before entering overtake — periodic autosave is gated
@@ -3059,6 +3082,11 @@ function resumeOvertakeModule(moduleId) {
 
     setView(VIEWS.OVERTAKE_MODULE);
     needsRedraw = true;
+    /* Fire the module's onResume() hook (init() is NOT re-run on resume).
+     * Called after the full callback / LED-queue / shim restore above so
+     * the module sees its own globals in place. See invokeModuleOnResume
+     * for the module-facing contract. */
+    invokeModuleOnResume(overtakeModuleCallbacks, overtakeModuleId);
     /* Flush restored LEDs to SHM so they render this frame. */
     flushLedQueue();
     return true;
@@ -3397,7 +3425,11 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
             init: (globalThis.init !== savedInit) ? globalThis.init : null,
             tick: (globalThis.tick !== savedTick) ? globalThis.tick : null,
             onMidiMessageInternal: (globalThis.onMidiMessageInternal !== savedMidi) ? globalThis.onMidiMessageInternal : null,
-            onUnload: (typeof globalThis.onUnload === "function") ? globalThis.onUnload : null
+            onUnload: (typeof globalThis.onUnload === "function") ? globalThis.onUnload : null,
+            /* onResume(): optional. Called once each time the module is
+             * resumed from suspend (init() is NOT re-run). See
+             * invokeModuleOnResume for the module-facing contract. */
+            onResume: (typeof globalThis.onResume === "function") ? globalThis.onResume : null
         };
 
         /* Restore shadow UI's globals */
@@ -3405,6 +3437,7 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
         globalThis.tick = savedTick;
         globalThis.onMidiMessageInternal = savedMidi;
         if (typeof globalThis.onUnload === "function") delete globalThis.onUnload;
+        if (typeof globalThis.onResume === "function") delete globalThis.onResume;
 
         debugLog("loadOvertakeModule: callbacks captured - init:" + !!overtakeModuleCallbacks.init +
                  " tick:" + !!overtakeModuleCallbacks.tick +


### PR DESCRIPTION
## What

Adds an optional `onResume()` callback to the overtake-module lifecycle, fired once each time a suspended module is brought back to the foreground.

## Why

When a `suspend_keeps_js` overtake module is suspended (the user opens another module or MoveOriginal over it) and later resumed via `resumeOvertakeModule`, Schwung restores the module's callbacks, LED queue and param shims — but deliberately does **not** re-run `init()`, since the module is already initialised.

The module therefore gets no signal that it was backgrounded and is now active again. That's a problem for anything holding state that doesn't survive suspension. The most common case is LEDs: the hardware LEDs are cleared on overtake exit/entry, but a module that paints them through an on-change delta cache (to stay under the per-frame LED budget) still believes the panel shows what it last drew. Its next frames produce cache hits and write nothing, so the surface stays dark until the user happens to change something that alters a target color.

The only workarounds available to a module today are heuristics: a tick-gap timer (unreliable — `suspend_keeps_js` modules keep ticking while backgrounded, so there's no gap) or "invalidate caches on the next button press" (leaves a visibly broken display until that press). A first-class resume signal is the clean fix.

## What this adds

`onResume()` — an optional module callback, mirroring the existing `onUnload()`:

- captured at module load alongside the other callbacks (and stripped from `globalThis` after capture);
- dispatched by a new `invokeModuleOnResume()` from `resumeOvertakeModule`, after the full callback / LED-queue / shim restore and **before** the LED flush, so the module sees its own globals in place;
- wrapped in `try/catch` so a buggy module can't break the resume path.

Module authors use it to re-establish whatever doesn't survive being backgrounded — typically forcing a full LED repaint.

## Compatibility

Fully opt-in and backward compatible: a module that doesn't define `onResume` is unaffected (captured value is `null` → `invokeModuleOnResume` is a no-op). No change to `init` / `tick` / `onUnload` / `onMidiMessage*` semantics.

## Testing

- `node --check src/shadow/shadow_ui.js` passes.
- Verified on a Move with a `suspend_keeps_js` overtake sequencer module: before, returning from MoveOriginal left the pad / step / track LEDs dark until a button press; with an `onResume` handler that invalidates the module's LED caches, the grid repaints immediately on return. Modules without an `onResume` behave exactly as before.