### PR TITLE
Co-run / overtake LED ownership: per-surface lights + RGB-sysex aware

### DIFF
--- a/docs/CORUN.md
+++ b/docs/CORUN.md
@@ -182,15 +182,36 @@ tools won't hit.
 
 ### LED ownership
 
-For symmetry with input routing, Move's LED writes are gated by `keep_mask`
-during `CORUN_TARGET_MOVE_NATIVE`: Move's outbound CC / note-on / note-off
-LED messages for any surface group the tool **keeps** (per `keep_mask`) are
-stripped before reaching hardware, so the tool's own LED rendering on those
-surfaces stays uncontested. Surfaces the tool **cedes** pass through —
-Move's LEDs reach the buttons / pads / knob rings directly. Sysex LED writes
-aren't classified by group and pass through unchanged; the framework leaves
-sysex (and the palette entries it carries for knob-ring + master colors,
-idx 71-79) alone.
+For symmetry with input routing, Move's LED writes are gated per surface group
+during `CORUN_TARGET_MOVE_NATIVE`: Move's outbound CC / note-on / note-off LED
+messages for any group the tool **owns for LEDs** are stripped before reaching
+hardware, so the tool's own rendering on those surfaces stays uncontested.
+Surfaces the tool does not own pass through — Move's LEDs reach the buttons /
+pads / knob rings directly.
+
+**Lights vs input split.** LED ownership follows `corun.led_keep_mask` when set,
+falling back to `keep_mask` when it is `0`. This lets a tool **paint** a surface
+while still **ceding its presses** — e.g. dAVEBOx draws the track-button clip
+indicator (owns TRACK LEDs) but lets Move/Schwung handle the press (cedes TRACK
+input). Input routing always uses `keep_mask`; only LEDs consult
+`led_keep_mask`. (Because `0` means "follow keep_mask", a tool cannot currently
+own input while ceding *all* LEDs — no consumer needs that yet.)
+
+**Steps** (notes 16–31) are now a first-class surface (`CORUN_GRP_STEPS`), so
+their input and LEDs route like any other group. This is backward-safe for the
+default split and any STEPS-keeping tool, but a tool that passes an explicit
+`keep_mask` **omitting** STEPS now cedes step input + LEDs (previously steps were
+unclassified and always kept).
+
+**RGB sysex.** Move lights its RGB pads / clips / grid via Ableton LED sysex
+(`F0 00 21 1D 01 01 3B <sub> <idx> <rgb> F7`), where `<idx>` equals the control's
+CC/note — so the *same* group map classifies it. The framework strips the whole
+command for groups the tool owns for LEDs (color-independent: keyed on index),
+and leaves sysex for ceded groups (e.g. knob-ring + master colors, idx 71–79)
+untouched. Full-overtake tools that keep Move's sequencer running can opt into
+stripping **all** cable-0 sysex via `shadow_set_overtake_suppress_sysex(1)` to
+take true full LED control; it defaults off and the framework clears it on
+overtake exit.
 
 ## Single source of truth
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -168,7 +168,13 @@ typedef struct shadow_control_t {
         uint16_t keep_mask;
     } corun;
     volatile uint8_t shadow_display_owner; /* display_owner_t: who currently owns the OLED. Independent of shadow_display_mode (which only says "shadow session active"). */
-    volatile uint8_t reserved[1];
+    /* 1=also strip Move's cable-0 sysex (RGB pad/clip/grid LEDs) during FULL
+     * overtake, so a tool that forces Move's sequencer to keep running (e.g.
+     * dAVEBOx Clock Follow) gets true full LED control instead of fighting
+     * Move's repaints. Opt-in per tool (shadow_set_overtake_suppress_sysex);
+     * default 0 leaves the existing sysex passthrough unchanged. Consumes the
+     * former reserved[1] byte so shadow_control_t size is unchanged. */
+    volatile uint8_t overtake_suppress_sysex;
 } shadow_control_t;
 
 /* Co-run control-surface groups. A co-running overtake tool declares which
@@ -222,6 +228,7 @@ static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
     }
     if (type == 0x90 || type == 0x80) {
         if (d1 <= 9) return CORUN_GRP_TOUCH;
+        if (d1 >= 16 && d1 <= 31) return CORUN_GRP_STEPS; /* step-button row */
         if (d1 >= 68 && d1 <= 99) return CORUN_GRP_PADS;
     }
     return 0;

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -51,7 +51,7 @@
  * MIDI_OUT must be bounded by this to avoid corrupting the display. */
 #define HW_MIDI_OUT_SIZE    80
 #define DISPLAY_BUFFER_SIZE 1024  /* 128x64 @ 1bpp = 1024 bytes */
-#define CONTROL_BUFFER_SIZE 72  /* bumped for sampler_source_request + sampler_silent (PR #61); leaves headroom in reserved[] */
+#define CONTROL_BUFFER_SIZE 76  /* +corun.led_keep_mask; 74 bytes content padded to 76 (struct has 4-byte-aligned uint32_t/float members) */
 #define SHADOW_UI_BUFFER_SIZE     512
 #define SHADOW_PARAM_BUFFER_SIZE  65664  /* Large buffer for complex ui_hierarchy */
 #define SHADOW_MIDI_OUT_BUFFER_SIZE 512  /* MIDI out buffer from shadow UI (128 packets) */
@@ -165,7 +165,10 @@ typedef struct shadow_control_t {
     volatile struct {
         int8_t target;       /* corun_target_t */
         int8_t id;
-        uint16_t keep_mask;
+        uint16_t keep_mask;      /* CORUN_GRP_* the tool owns for INPUT (cedes the rest to the peer) */
+        uint16_t led_keep_mask;  /* CORUN_GRP_* the tool owns for LEDs; 0 = follow keep_mask. Lets a tool
+                                  * paint a surface while still ceding its presses (e.g. dAVEBOx draws the
+                                  * track-button clip indicator but lets Move/Schwung handle the press). */
     } corun;
     volatile uint8_t shadow_display_owner; /* display_owner_t: who currently owns the OLED. Independent of shadow_display_mode (which only says "shadow session active"). */
     /* 1=also strip Move's cable-0 sysex (RGB pad/clip/grid LEDs) during FULL
@@ -238,6 +241,15 @@ static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
  * which means "use the default split". */
 static inline uint16_t corun_keep_mask_eff(uint16_t keep_mask) {
     return keep_mask ? keep_mask : CORUN_KEEP_DEFAULT;
+}
+
+/* Effective LED keep-mask: which groups the tool owns for LED stripping. A tool
+ * that wants to paint a surface but cede its input sets led_keep_mask
+ * separately; when unset (0) LED ownership follows the input keep_mask, so the
+ * common case (own both) needs no extra call. */
+static inline uint16_t corun_led_keep_mask_eff(const volatile shadow_control_t *ctrl) {
+    uint16_t led = ctrl ? ctrl->corun.led_keep_mask : 0;
+    return led ? led : corun_keep_mask_eff(ctrl ? ctrl->corun.keep_mask : 0);
 }
 
 /* Co-run target. Stored in shadow_control->corun.target as int8_t. */

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -175,8 +175,10 @@ typedef struct shadow_control_t {
      * overtake, so a tool that forces Move's sequencer to keep running (e.g.
      * dAVEBOx Clock Follow) gets true full LED control instead of fighting
      * Move's repaints. Opt-in per tool (shadow_set_overtake_suppress_sysex);
-     * default 0 leaves the existing sysex passthrough unchanged. Consumes the
-     * former reserved[1] byte so shadow_control_t size is unchanged. */
+     * default 0 leaves the existing sysex passthrough unchanged. This byte
+     * reuses the former reserved[1] slot, but the struct still grew 72->76
+     * because of corun.led_keep_mask above; CONTROL_BUFFER_SIZE was bumped to
+     * match (shim creates the SHM and shadow_ui maps it via the same macro). */
     volatile uint8_t overtake_suppress_sysex;
 } shadow_control_t;
 
@@ -213,8 +215,11 @@ typedef struct shadow_control_t {
 
 /* Map a raw cable-0 MIDI event to its control-surface group, or 0 if it isn't a
  * routable surface control (those always stay with the tool). type is the
- * status nibble (0xB0 CC, 0x90/0x80 note); d1 the data byte. Steps/transport
- * are intentionally unclassified for now (always kept) — they have no settled
+ * status nibble (0xB0 CC, 0x90/0x80 note); d1 the data byte. Steps (notes
+ * 16-31) are now a first-class surface (CORUN_GRP_STEPS): backward-safe for the
+ * default split and any STEPS-keeping tool, but an explicit keep_mask that
+ * OMITS STEPS now cedes step input + LEDs (previously steps were unclassified,
+ * always kept). Transport stays unclassified (always kept) — they have no settled
  * CC map and no co-run consumer cedes them. */
 static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
     if (type == 0xB0) {

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -402,8 +402,10 @@ void shadow_clear_move_leds_if_overtake(void) {
      * (capabilities.button_passthrough) keep their firmware LEDs. */
     const uint8_t *passthrough = host.passthrough_ccs;
 
+    int suppress_sysex = (ctrl && ctrl->overtake_suppress_sysex);
     for (int i = 0; i < HW_MIDI_OUT_SIZE; i += 4) {
         uint8_t cable = (midi_out[i] >> 4) & 0x0F;
+        uint8_t cin  = midi_out[i] & 0x0F;
         uint8_t type = midi_out[i+1] & 0xF0;
         if (cable != 0) continue;
         if (type == 0x90) {
@@ -415,6 +417,20 @@ void shadow_clear_move_leds_if_overtake(void) {
         } else if (type == 0xB0) {
             uint8_t d1 = midi_out[i+2];
             if (passthrough && d1 < 128 && passthrough[d1]) continue;
+            midi_out[i] = 0;
+            midi_out[i+1] = 0;
+            midi_out[i+2] = 0;
+            midi_out[i+3] = 0;
+        } else if (suppress_sysex && cin >= 0x04 && cin <= 0x07) {
+            /* Move's RGB pad/clip/grid LEDs ride cable-0 sysex (the Ableton
+             * F0 00 21 1D ... LED command). The note/CC strips above don't
+             * touch sysex, so by default Move's RGB repaints pass through —
+             * fine when its sequencer is stopped, but they fight the tool's
+             * LEDs once a tool (dAVEBOx Clock Follow) keeps Move running.
+             * Opt-in: strip every cable-0 sysex packet (start/continue/end,
+             * CIN 0x04-0x07) so the tool owns RGB too. Safe because such a
+             * tool paints its own pads via note-palette / CC, injected into
+             * the mailbox AFTER this strip. */
             midi_out[i] = 0;
             midi_out[i+1] = 0;
             midi_out[i+2] = 0;

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -382,7 +382,10 @@ void shadow_clear_move_leds_if_overtake(void) {
      * master colors (palette idx 71-79) and the framework leaves those alone.
      * Runs BEFORE the skip_led_clear early-return so it takes priority. */
     if (corun_target(ctrl) == CORUN_TARGET_MOVE_NATIVE) {
-        uint16_t keep = corun_keep_mask_eff(ctrl->corun.keep_mask);
+        /* LED ownership uses led_keep_mask (falls back to keep_mask): a tool can
+         * own a surface's LEDs while still ceding its input — input routing in
+         * corun_event_owner still uses keep_mask. */
+        uint16_t keep = corun_led_keep_mask_eff(ctrl);
         for (int i = 0; i < HW_MIDI_OUT_SIZE; i += 4) {
             uint8_t cable = (midi_out[i] >> 4) & 0x0F;
             if (cable != 0) continue;
@@ -391,6 +394,31 @@ void shadow_clear_move_leds_if_overtake(void) {
             uint16_t grp = corun_group_for_event(type, d1);
             if (grp && (keep & grp)) {
                 midi_out[i] = 0; midi_out[i+1] = 0; midi_out[i+2] = 0; midi_out[i+3] = 0;
+            }
+        }
+        /* RGB-sysex LEDs: Move lights pads / track buttons / knob rings via the
+         * Ableton LED sysex (F0 00 21 1D 01 01 3B <subcmd> <idx> <6 rgb bytes> F7,
+         * one LED per command, 6 USB-MIDI packets). The idx equals the control's
+         * CC (buttons/knobs) or note (pads), so the SAME group map classifies it.
+         * Strip the whole command for groups the tool owns for LEDs — so a tool
+         * that owns e.g. the track-button LEDs (CC 40-43) beats Move's playback
+         * repaints, while groups it cedes (knob rings) still show Move's colors.
+         * The note/CC loop above doesn't touch sysex, hence this second pass.
+         * The marker packet is "04 3B <subcmd> <idx>" (3rd of the 6); the command
+         * spans [i-8 .. i+12], starting at the "04 F0 ..." packet. */
+        for (int i = 8; i + 12 < HW_MIDI_OUT_SIZE; i += 4) {
+            if ((midi_out[i] & 0x0F) != 0x04) continue;        /* sysex start/continue */
+            if (((midi_out[i] >> 4) & 0x0F) != 0) continue;    /* cable 0 */
+            if (midi_out[i+1] != 0x3B) continue;               /* RGB LED command marker */
+            uint8_t idx = midi_out[i+3];
+            uint16_t grp = corun_group_for_event(0xB0, idx);   /* idx as a CC (buttons/knobs) */
+            if (!grp) grp = corun_group_for_event(0x90, idx);  /* idx as a note (pads/steps) */
+            if (!(grp && (keep & grp))) continue;
+            int start = i - 8;
+            /* Confirm this is a real 6-packet command before zeroing the span. */
+            if ((midi_out[start] & 0x0F) != 0x04 || midi_out[start+1] != 0xF0) continue;
+            for (int z = start; z <= i + 12 && z < HW_MIDI_OUT_SIZE; z += 4) {
+                midi_out[z] = 0; midi_out[z+1] = 0; midi_out[z+2] = 0; midi_out[z+3] = 0;
             }
         }
         return;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2925,6 +2925,7 @@ static void init_shadow_shm(void)
         shadow_control->corun.target = CORUN_TARGET_NONE;  /* co-run inactive at boot */
         shadow_control->corun.id = -1;
         shadow_control->corun.keep_mask = 0;  /* 0 = default split when a target is set without a manifest */
+        shadow_control->corun.led_keep_mask = 0; /* 0 = LED ownership follows keep_mask */
         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI; /* splash boots into shadow UI */
         /* Initialize TTS defaults */
         shadow_control->tts_enabled = 0;    /* Screen Reader off by default */
@@ -6802,6 +6803,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                         shadow_control->corun.target = CORUN_TARGET_NONE;
                         shadow_control->corun.id = -1;
                         shadow_control->corun.keep_mask = 0;
+                        shadow_control->corun.led_keep_mask = 0;
                         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
                         shadow_log("Back: exiting co-run");
                         continue;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2921,6 +2921,7 @@ static void init_shadow_shm(void)
         shadow_control->suspend_overtake = 0;
         shadow_control->selected_slot    = 0;
         shadow_control->skip_led_clear   = 0;
+        shadow_control->overtake_suppress_sysex = 0;
         shadow_control->corun.target = CORUN_TARGET_NONE;  /* co-run inactive at boot */
         shadow_control->corun.id = -1;
         shadow_control->corun.keep_mask = 0;  /* 0 = default split when a target is set without a manifest */

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -238,6 +238,9 @@ static JSValue js_shadow_corun_begin(JSContext *ctx, JSValueConst this_val, int 
     if (JS_ToInt32(ctx, &id, argv[1])) return JS_UNDEFINED;
     if (argc >= 3 && JS_ToInt32(ctx, &keep, argv[2])) return JS_UNDEFINED;
     if (keep < 0 || keep > 0xFFFF) return JS_UNDEFINED;
+    /* Reset LED-keep to "follow keep_mask"; a tool opts into the lights/input
+     * split by calling shadow_corun_set_led_keep_mask() after begin. */
+    shadow_control->corun.led_keep_mask = 0;
     if (target == CORUN_TARGET_CHAIN_EDIT) {
         if (id < 0 || id >= SHADOW_UI_SLOTS) return JS_UNDEFINED;
         shadow_control->corun.keep_mask = (uint16_t)keep;
@@ -270,8 +273,24 @@ static JSValue js_shadow_corun_end(JSContext *ctx, JSValueConst this_val, int ar
     shadow_control->corun.target = CORUN_TARGET_NONE;
     shadow_control->corun.id = -1;
     shadow_control->corun.keep_mask = 0;
+    shadow_control->corun.led_keep_mask = 0;
     /* Returning to the tool's shadow session — shadow_ui resumes rendering. */
     shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
+    return JS_UNDEFINED;
+}
+
+/* shadow_corun_set_led_keep_mask(mask) -> void
+ * Co-run lights/input split: declare which CORUN_GRP_* groups the tool owns for
+ * LED stripping, independent of the input keep_mask. Call after shadow_corun_begin.
+ * 0 = follow keep_mask (the default). Lets a tool paint a surface (e.g. the
+ * track-button clip indicator) while still ceding its presses to the peer. */
+static JSValue js_shadow_corun_set_led_keep_mask(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 1) return JS_UNDEFINED;
+    int32_t mask = 0;
+    JS_ToInt32(ctx, &mask, argv[0]);
+    if (mask < 0 || mask > 0xFFFF) return JS_UNDEFINED;
+    shadow_control->corun.led_keep_mask = (uint16_t)mask;
     return JS_UNDEFINED;
 }
 
@@ -2102,6 +2121,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_overtake_send_external_async_active", JS_NewCFunction(ctx, js_shadow_overtake_send_external_async_active, "shadow_overtake_send_external_async_active", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_begin", JS_NewCFunction(ctx, js_shadow_corun_begin, "shadow_corun_begin", 3));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_end", JS_NewCFunction(ctx, js_shadow_corun_end, "shadow_corun_end", 0));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_led_keep_mask", JS_NewCFunction(ctx, js_shadow_corun_set_led_keep_mask, "shadow_corun_set_led_keep_mask", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_state", JS_NewCFunction(ctx, js_shadow_corun_state, "shadow_corun_state", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_overlay", JS_NewCFunction(ctx, js_shadow_corun_overlay, "shadow_corun_overlay", 2));
     /* Co-run target enum (matches corun_target_t in shadow_constants.h). */

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -395,6 +395,13 @@ static JSValue js_shadow_set_overtake_mode(JSContext *ctx, JSValueConst this_val
         if (shadow_ui_midi_shm) {
             memset(shadow_ui_midi_shm, 0, MIDI_BUFFER_SIZE);
         }
+    } else {
+        /* Clear the full-overtake sysex-suppression opt-in here, the one point
+         * every exit path (exit/hide/complete/suspend) funnels through, so the
+         * next overtake tool can't inherit a stale suppress flag. Mirrors the
+         * shim's init-time reset. (led_keep_mask is already reset on the
+         * co-run begin/end + Back-exit paths.) */
+        shadow_control->overtake_suppress_sysex = 0;
     }
     /* NOTE: Shift-off and volume-touch-off injection on overtake exit is
      * handled by the shim's ioctl handler (transition detection), not here.

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -429,6 +429,19 @@ static JSValue js_shadow_set_skip_led_clear(JSContext *ctx, JSValueConst this_va
     return JS_UNDEFINED;
 }
 
+/* shadow_set_overtake_suppress_sysex(flag) -> void
+ * Opt a full-overtake tool into stripping Move's cable-0 sysex (RGB pad/clip/
+ * grid LEDs) so Move's running-sequencer repaints don't fight the tool's LEDs.
+ * Set on tool init; cleared automatically on overtake exit (and below). */
+static JSValue js_shadow_set_overtake_suppress_sysex(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 1) return JS_UNDEFINED;
+    int32_t flag = 0;
+    JS_ToInt32(ctx, &flag, argv[0]);
+    shadow_control->overtake_suppress_sysex = flag ? 1 : 0;
+    return JS_UNDEFINED;
+}
+
 /* host_mute_move_audio(flag) -> void
  * Mute/unmute Move's audio output. Used for silent clip switching. */
 static JSValue js_host_mute_move_audio(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
@@ -2119,6 +2132,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_move_ui_mode", JS_NewCFunction(ctx, js_shadow_get_move_ui_mode, "shadow_get_move_ui_mode", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_overtake_mode", JS_NewCFunction(ctx, js_shadow_set_overtake_mode, "shadow_set_overtake_mode", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_skip_led_clear", JS_NewCFunction(ctx, js_shadow_set_skip_led_clear, "shadow_set_skip_led_clear", 1));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_set_overtake_suppress_sysex", JS_NewCFunction(ctx, js_shadow_set_overtake_suppress_sysex, "shadow_set_overtake_suppress_sysex", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_suspend_overtake", JS_NewCFunction(ctx, js_shadow_set_suspend_overtake, "shadow_set_suspend_overtake", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_suspend_overtake", JS_NewCFunction(ctx, js_shadow_get_suspend_overtake, "shadow_get_suspend_overtake", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_consume_resume_last_tool", JS_NewCFunction(ctx, js_shadow_consume_resume_last_tool, "shadow_consume_resume_last_tool", 0));

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2961,6 +2961,10 @@ function suspendOvertakeMode() {
         if (typeof shadow_set_skip_led_clear === "function") {
             shadow_set_skip_led_clear(0);
         }
+        /* Clear the opt-in sysex suppression so it never leaks to the next tool. */
+        if (typeof shadow_set_overtake_suppress_sysex === "function") {
+            shadow_set_overtake_suppress_sysex(0);
+        }
 
         /* Dismiss shadow UI entirely so Move's native UI returns. */
         setView(VIEWS.SLOTS);


### PR DESCRIPTION
## Problem

When an overtake tool keeps Move's firmware **sequencer running underneath it** (e.g. a tool that slaves Move's transport to drive a shared clock), Move repaints its own LEDs every frame and they fight the tool's. The current co-run / overtake LED-ownership model has gaps that let Move's repaints win:

1. **Step buttons aren't a recognized surface.** `corun_group_for_event` — the one classifier that drives both input ownership (`corun_event_owner`) *and* LED stripping — maps pad/touch notes but leaves step notes (16–31) unclassified, so a tool that KEEPS the STEPS group still loses its step LEDs (and, symmetrically, a tool that CEDES steps wrongly keeps their input).
2. **Full overtake passes Move's RGB sysex through.** The overtake strip clears note/CC LED writes but intentionally lets cable-0 sysex through (knob-ring / master colors). Move lights its RGB pads/clips/grid via the Ableton LED sysex, so those repaints reach hardware and fight a tool that paints the same pads.
3. **`keep_mask` couples input and LEDs 1:1, and the co-run strip never handled RGB sysex.** A tool can't paint a surface while ceding its presses — and even kept surfaces lit via RGB sysex weren't stripped.

## What this does

All general framework improvements; ownership stays expressed through `keep_mask` / `CORUN_GRP_*`.

- **Classify steps at the root** — notes 16–31 → `CORUN_GRP_STEPS` in `corun_group_for_event`, so steps behave like every other surface for input and LEDs. Backward-safe (the default keep-mask already includes STEPS).
- **Opt-in full-overtake sysex suppression** — `shadow_set_overtake_suppress_sysex(1)` makes the full-overtake strip also zero Move's cable-0 sysex, so a tool can own RGB too. Default off (existing behavior unchanged); framework clears it on overtake exit.
- **Lights/input split** — new `corun.led_keep_mask` (+ `shadow_corun_set_led_keep_mask`) lets a tool own a surface's **LEDs** while still ceding its **input**. Falls back to `keep_mask` when unset, so "own both" needs no extra call. Input routing still uses `keep_mask`.
- **RGB-sysex stripping in co-run, by group** — parse Move's Ableton LED sysex (`F0 00 21 1D 01 01 3B <sub> <idx> <rgb> F7`); the **idx equals the control's CC/note**, so the *existing* group map classifies it. Strip the whole command for groups the tool owns for LEDs — **color-independent** (keyed on index) and **per-surface** (groups the tool cedes, e.g. knob rings, still show Move's colors).

## Motivating consumer

dAVEBOx's new **Clock Follow** mode keeps Move's sequencer running to phase-lock to its clock. It opts into sysex suppression (full overtake) and sets `led_keep_mask = keep_mask | TRACK` so it owns the side clip-button LEDs (CC 40–43) while track-button presses still cede to Move (track switching). Companion module change: legsmechanical/schwung-davebox.

## Testing

Verified on hardware (Move + dAVEBOx, Clock Follow driving playback): track/session full-overtake LEDs, co-run step LEDs, and co-run track-button LEDs all hold the tool's colors with no Move repaint bleed-through, across different active tracks (index-based, so color-independent); track-button presses still switch the Move track / Schwung slot, and Move's synth-editor knob-ring LEDs (a ceded group) are untouched.

## Notes

- `CONTROL_BUFFER_SIZE` 72 → 76 (the +2 for `led_keep_mask` pads to the struct's 4-byte alignment); both the shim (creates the SHM) and shadow_ui (maps it) use the macro, so they stay in sync.
- No behavior change for existing tools: steps were already in the default keep-mask; sysex suppression and `led_keep_mask` are opt-in.
