### PR TITLE
fix(shim): drop garbage MIDI_IN forwards to overtake tools

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2662,6 +2662,13 @@ static uint64_t last_speech_time_ms = 0;  /* Rate limiting for TTS */
 static inline void shadow_ui_midi_publish(uint8_t head, uint8_t status,
                                           uint8_t d1, uint8_t d2) {
     if (head == 0 || !shadow_ui_midi_shm || !shadow_control) return;
+    /* Drop misaligned/garbage VOICE-message slots. head = cable<<4 | CIN; a
+     * channel-voice (CIN 0x08-0x0E) or single-byte system (0x0F) message always
+     * carries a status byte >= 0x80, so a sub-0x80 byte there is a torn/stale
+     * read of the unfiltered hardware MIDI_IN buffer — observed flooding overtake
+     * tools with status=0 events during co-run. SysEx CINs (0x04-0x07)
+     * legitimately carry data bytes < 0x80, so they are NOT subject to this. */
+    if ((head & 0x0F) >= 0x08 && !(status & 0x80)) return;
     for (int slot = 0; slot < MIDI_BUFFER_SIZE; slot += 4) {
         if (__atomic_load_n(&shadow_ui_midi_shm[slot], __ATOMIC_ACQUIRE) == 0) {
             shadow_ui_midi_shm[slot + 1] = status;


### PR DESCRIPTION
The shim scans the *unfiltered hardware* `MIDI_IN` buffer and forwards events to overtake tools via `shadow_ui_midi_publish` (the `overtake_mode==2` "forward all cables" path). That path doesn't validate the status byte, so a **torn/concurrent read** — valid CIN byte, status byte still zero — gets forwarded as a `status=0` event, observed **flooding the overtake tool (davebox) during co-run** (and contributing to an audio dropout on another slot).

The normal voice path already validates `status & 0x80`; the overtake forward didn't.

**Fix:** in `shadow_ui_midi_publish`, drop events whose CIN is a voice/system message (low nibble ≥ 0x08) but whose status byte is < 0x80 — provably garbage. **CIN-aware**, so SysEx CINs (0x04–0x07, which legitimately carry data bytes < 0x80) are never dropped.

Validating events at a shared-memory hardware boundary is correct regardless; any overtake tool fed by this path is exposed to torn reads of `MIDI_IN`. Verified on-device. Draft.