### PR TITLE
fix(shim): hold MIDI_IN inject a few frames after overtake exit (complements #128)

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -541,6 +541,39 @@ void shadow_drain_midi_inject(void)
 
     if (!inject_shm) return;
 
+    /* Hold the inject drain for a few frames after an overtake module exits
+     * (Back-to-suspend or full exit) before draining anything into Move's
+     * MIDI_IN. On the overtake->native transition the shim queues cleanup
+     * packets (shift/back/jog/vol releases) and the DSP audio callback may
+     * queue note packets (e.g. ROUTE_MOVE drum hits) in the same 1-2 frame
+     * window; either landing in MIDI_IN while Move's firmware is mid-transition
+     * aborts (SIGABRT) deep in Move's own stack.
+     *
+     * This is a *timing* race, distinct from the *ring-integrity* race fixed by
+     * the MPSC inject ring (PR #106). #106 guarantees each ring slot is written
+     * atomically (no torn cable=0/CIN=0 slot reaches Move) — but a
+     * perfectly-formed inject that simply *arrives during the transition* still
+     * crashes Move. So this hold is required in addition to #106, not instead of
+     * it. Empirically 2-3 frames are clean and 1 frame is insufficient (crash
+     * recurs). Packets are not lost — they accumulate in inject_shm and drain
+     * once the hold expires. Keyed on the overtake-exit event (not buffer
+     * occupancy), so it also covers the case where MIDI_IN is idle at exit —
+     * which the cable-0 occupancy defer below does not catch. */
+    {
+        static int prev_overtake_for_hold = 0;
+        static int exit_hold_frames = 0;
+        const int OVERTAKE_EXIT_HOLD_FRAMES = 3;  /* 2 also verified clean; 1 not */
+        shadow_control_t *sc = host_shadow_control ? *host_shadow_control : NULL;
+        int cur_overtake = sc ? (int)sc->overtake_mode : 0;
+        if (prev_overtake_for_hold != 0 && cur_overtake == 0)
+            exit_hold_frames = OVERTAKE_EXIT_HOLD_FRAMES;
+        prev_overtake_for_hold = cur_overtake;
+        if (exit_hold_frames > 0) {
+            exit_hold_frames--;
+            return;
+        }
+    }
+
     /* Defer inject when MIDI_IN has ANY hardware events this tick.
      * All cables share Move's firmware MIDI read path — injecting concurrently
      * with hardware events on ANY cable races Move's internal processing and


### PR DESCRIPTION
Ready to merge — re-cut off current `main` (v0.11.0), which already carries the MPSC-safe inject ring (#128, the merged/rebased form of the old #106). This is the orthogonal *timing* half of the overtake-exit crash; #128 was necessary but not sufficient, and this completes it.

## What it fixes (capability)

Schwung overtake tools can act as a *transport brain* for Move — driving Move's own sequencer (start/stop + tempo via Clock Follow) **while** streaming notes back into Move's native instruments (ROUTE_MOVE). dAVEBOx is the canonical case. Suspending/exiting such a tool — a routine action — can hard-crash the device (MoveOriginal SIGABRT, deep in its own stack). That makes the capability unsafe in practice.

## Root cause — a *timing* race, distinct from the ring-integrity race

On the overtake→native transition the shim queues cleanup packets (shift/back/jog/vol releases) into the MIDI_IN inject ring, and the DSP audio callback may queue note packets (ROUTE_MOVE hits) in the same 1–2 frame window. If either drains into MIDI_IN **while Move's firmware is mid-transition**, Move aborts — *even when the inject is perfectly well-formed*.

This is why the ring fix alone doesn't close it: #128 makes each ring slot atomic (no torn `cable=0/CIN=0` slot), but a clean, atomic inject arriving during the teardown still crashes Move. The two fixes are orthogonal and both needed.

## Fix

A short hold (3 frames, ~9 ms) on the inject drain, armed on the overtake-exit transition, mirroring the existing `DEFER_FRAMES` cable-0 mechanism. Packets are not lost — they accumulate in the ring and drain once Move has settled. Keyed on the exit *event*, not buffer occupancy, so it also covers the (common) case where MIDI_IN is idle at exit.

## Relationship to other inject work

- **#128** (MPSC-safe inject ring, merged — in the public release) — complementary: ring integrity vs. inject timing. Both required; the crash reproduces with the ring fix alone.
- **#140** (drain injected MIDI up to MIDI_IN capacity) — orthogonal throughput change; doesn't touch *when* injects are allowed, only *how many* per frame.
- The earlier transport-*arming* guard approach was dropped: the teardown race fires during *steady playback* too, where an arming-only window is closed. This event-keyed exit hold covers both.

## Testing

206 rapid suspend/resume cycles on a real Move (Clock Follow + transport running + co-run drum input) — the exact torture test that crashed reliably before — **zero crashes, zero dropped notes**. The hold sits at the top of `shadow_drain_midi_inject`, independent of the ring internals, so it composes cleanly with the shipped ring.

🤖 Drafted with Claude Code
