### PR TITLE
Add Aphex — MS-10/MS-20 hybrid mono synth (sound_generator)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1001,6 +1001,17 @@
       "default_branch": "master",
       "asset_name": "fork-module.tar.gz",
       "min_host_version": "0.8.8"
+    },
+    {
+      "id": "aphex",
+      "name": "Aphex",
+      "description": "Korg MS-10/MS-20 hybrid mono synth: KORG-35/OTA filter cascade, source-side patchbay, ESP line-in processor, analog drift, 41 presets",
+      "author": "Filliformes",
+      "component_type": "sound_generator",
+      "github_repo": "filliformes/aphex-move",
+      "default_branch": "master",
+      "asset_name": "aphex-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Aphex** to the module catalog.

A Korg MS-10 / MS-20 hybrid monophonic synthesizer for Move:
- Dual VCO into a switchable **KORG-35 / OTA** HPF+LPF cascade (self-oscillating)
- MS-20-style **source-side patchbay** and **External Signal Processor** (YIN pitch tracker, env follower, gate, routable line-in)
- Multi-source **analog drift**, MS-10 collapse mode, **41 factory presets**

- Repo: https://github.com/filliformes/aphex-move
- Release: https://github.com/filliformes/aphex-move/releases/tag/v0.1.0
- `release.json` is present on the default branch (`master`) with the v0.1.0 download URL.

`api_version: 2`, `component_type: sound_generator` (root + capabilities), `help.json` and `src/module.json` shipped. MIT-licensed, original/clean-room DSP.