### PR TITLE
fix(midi-inject): MPSC-safe ring for /schwung-midi-inject (rebased #106)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,7 +236,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_midi.c src/host/unified_log.c src/host/shim_worker.c \
     src/host/shadow_shm_util.c \
     $SHIM_TTS_SRC \
-    src/host/shadow_constants.h src/host/shadow_midi.h src/host/shadow_sampler.h \
+    src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
     src/host/shim_worker.h \
     src/host/shadow_set_pages.h src/host/shadow_dbus.h src/host/shadow_chain_mgmt.h \
     src/host/shadow_chain_types.h src/host/shadow_link_audio.h src/host/shadow_process.h \

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -372,15 +372,49 @@ typedef struct shadow_midi_dsp_t {
 } shadow_midi_dsp_t;
 
 /*
- * MIDI Inject buffer structure.
- * Used by Shadow UI (or external tools) to inject USB-MIDI packets into
- * Move's MIDI_IN buffer, making Move process them as real hardware events.
+ * MIDI Inject ring — multi-producer, single-consumer SHM channel.
+ * Lets multiple processes inject USB-MIDI packets into Move's MIDI_IN
+ * buffer so Move firmware processes them as real hardware events.
  * Packets are 4-byte USB-MIDI format (CIN/cable, status, data1, data2).
+ *
+ * Producers (multiple, may run concurrently across processes):
+ *   - JS host: shadow_ui.c:js_move_midi_inject_to_move (schwung_host)
+ *   - Shim:    schwung_shim.c overtake-entry "shift off"
+ *   - Shim:    schwung_shim.c overtake-exit 4× CC release
+ *   - Shim:    shadow_midi.c:shadow_chain_midi_inject (cable-2 forwarder)
+ *
+ * Consumer (single, in shim's SPI thread, ~344 Hz):
+ *   - shadow_midi.c:shadow_drain_midi_inject
+ *
+ * Cursor protocol (MPSC ring, lock-free):
+ *   alloc_idx  — allocation cursor. Producers atomically reserve a 4-byte
+ *                slot here via CAS. Drain DOES NOT read this — it only
+ *                reflects how much space has been claimed, not what's
+ *                been written.
+ *   commit_idx — commit cursor. A producer advances this *after* its slot
+ *                is fully written, in FIFO order (briefly waiting via the
+ *                helper's bounded spin if a prior producer hasn't
+ *                committed yet). Drain reads up to commit_idx — anything
+ *                past that may be reserved-but-unwritten.
+ *
+ * Invariant: bytes [0, commit_idx) are fully written and safe to read.
+ *
+ * All producers MUST go through the shadow_midi_inject_push() helper in
+ * src/host/shadow_midi_inject_writer.h — do not write to the cursors or
+ * buffer directly. The helper encodes the CAS-reserve / ordered-commit
+ * dance once; ad-hoc writers race the drain (CIN=0/cable=0 ends up as
+ * "misc function" and Move firmware aborts — see shadow_midi.c:553).
+ *
+ * Note: alloc_idx kept its old name `write_idx` would confuse direct-write
+ * callers we just removed; commit_idx fits in one of the two reserved
+ * bytes from the prior layout, so on-disk SHM size and offsets are
+ * unchanged — old binaries that mmap this segment continue to work.
  */
 typedef struct shadow_midi_inject_t {
-    volatile uint8_t write_idx;      /* Writer increments after writing */
-    volatile uint8_t ready;          /* Toggle to signal new data */
-    volatile uint8_t reserved[2];
+    volatile uint8_t alloc_idx;      /* Allocation cursor (CAS-reserved by producers) */
+    volatile uint8_t ready;          /* Toggle, bumped after each successful commit */
+    volatile uint8_t commit_idx;     /* Commit cursor (drain reads up to here) */
+    volatile uint8_t reserved;       /* one byte left for future use */
     uint8_t buffer[SHADOW_MIDI_INJECT_BUFFER_SIZE];  /* USB-MIDI packets (4 bytes each) */
 } shadow_midi_inject_t;
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -56,7 +56,8 @@
 #define SHADOW_PARAM_BUFFER_SIZE  65664  /* Large buffer for complex ui_hierarchy */
 #define SHADOW_MIDI_OUT_BUFFER_SIZE 512  /* MIDI out buffer from shadow UI (128 packets) */
 #define SHADOW_MIDI_DSP_BUFFER_SIZE 512  /* MIDI to DSP buffer from shadow UI (128 packets) */
-#define SHADOW_MIDI_INJECT_BUFFER_SIZE 256    /* MIDI inject buffer (64 packets) */
+/* MIDI inject ring capacity is SHADOW_MIDI_INJECT_SLOTS (defined with the
+ * struct below) — the old flat byte-buffer size is gone. */
 #define SHADOW_SCREENREADER_BUFFER_SIZE 8448  /* Screen reader message buffer */
 #define SHADOW_OVERLAY_BUFFER_SIZE 256        /* Overlay state buffer */
 
@@ -386,36 +387,56 @@ typedef struct shadow_midi_dsp_t {
  * Consumer (single, in shim's SPI thread, ~344 Hz):
  *   - shadow_midi.c:shadow_drain_midi_inject
  *
- * Cursor protocol (MPSC ring, lock-free):
- *   alloc_idx  — allocation cursor. Producers atomically reserve a 4-byte
- *                slot here via CAS. Drain DOES NOT read this — it only
- *                reflects how much space has been claimed, not what's
- *                been written.
- *   commit_idx — commit cursor. A producer advances this *after* its slot
- *                is fully written, in FIFO order (briefly waiting via the
- *                helper's bounded spin if a prior producer hasn't
- *                committed yet). Drain reads up to commit_idx — anything
- *                past that may be reserved-but-unwritten.
+ * Design — bounded MPSC queue (Dmitry Vyukov's per-slot-sequence scheme):
+ * an array of fixed slots, each carrying a `seq` number and one 4-byte
+ * packet. Indices are monotonic and masked into the slot array; nothing
+ * is ever reset or memset.
  *
- * Invariant: bytes [0, commit_idx) are fully written and safe to read.
+ *   enqueue_pos — producers claim a slot by fetch/CAS-advancing this
+ *                 monotonic counter; the slot is slots[pos & MASK].
+ *   read_pos    — the single consumer's cursor; it advances only past
+ *                 packets it has actually consumed.
+ *   slot.seq    — publication state. Initialized to its index i. A
+ *                 producer that claimed `pos` publishes by storing
+ *                 seq = pos+1 (RELEASE); the consumer detects "ready"
+ *                 when seq == read_pos+1 (ACQUIRE) and frees the slot for
+ *                 a future lap by storing seq = pos + SLOTS (RELEASE).
  *
- * All producers MUST go through the shadow_midi_inject_push() helper in
- * src/host/shadow_midi_inject_writer.h — do not write to the cursors or
- * buffer directly. The helper encodes the CAS-reserve / ordered-commit
- * dance once; ad-hoc writers race the drain (CIN=0/cable=0 ends up as
- * "misc function" and Move firmware aborts — see shadow_midi.c:553).
+ * Why this and not a byte ring with alloc/commit cursors + a reset:
+ *   - The consumer never resets cursors or memsets the buffer, so it
+ *     cannot race a cross-process producer mid-write (the old reset path
+ *     could satisfy a producer's commit-wait with reset-to-0 and let it
+ *     write into wiped space → cable=0/CIN=0 packet → Move SIGABRT).
+ *   - Producers never wait for each other to commit (no FIFO-commit spin),
+ *     so a producer preempted between claim and publish cannot stall the
+ *     SPI-thread producer on the realtime path. A preempted producer only
+ *     delays the consumer past its one slot, and self-heals on resume.
+ *   - All cursor/seq access is atomic — no volatile-store-vs-atomic-CAS
+ *     data race.
  *
- * Note: alloc_idx kept its old name `write_idx` would confuse direct-write
- * callers we just removed; commit_idx fits in one of the two reserved
- * bytes from the prior layout, so on-disk SHM size and offsets are
- * unchanged — old binaries that mmap this segment continue to work.
+ * All producers MUST go through shadow_midi_inject_push() and the consumer
+ * through shadow_midi_inject_peek()/_pop() in shadow_midi_inject_writer.h —
+ * do not touch slots or cursors directly. Ad-hoc writers race the consumer
+ * (a torn / zero packet reaches MIDI_IN, where cable=0/CIN=0 reads as "misc
+ * function" and Move firmware aborts — see shadow_midi.c).
+ *
+ * The SHM must be initialized once by its creator (the shim) via
+ * shadow_midi_inject_init() before any producer maps it — zero-fill alone
+ * is NOT a valid initial state (it needs seq[i] = i). Layout/size changed
+ * vs the prior byte-ring, so shim + schwung_host must be built together.
  */
+#define SHADOW_MIDI_INJECT_SLOTS 64   /* power of two; ring capacity in packets */
+#define SHADOW_MIDI_INJECT_MASK  (SHADOW_MIDI_INJECT_SLOTS - 1)
+
+typedef struct shadow_midi_inject_slot_t {
+    uint32_t seq;        /* publication sequence (accessed via __atomic_*) */
+    uint8_t  pkt[4];     /* one 4-byte USB-MIDI packet (cable/CIN, status, d1, d2) */
+} shadow_midi_inject_slot_t;   /* 8 bytes, naturally aligned */
+
 typedef struct shadow_midi_inject_t {
-    volatile uint8_t alloc_idx;      /* Allocation cursor (CAS-reserved by producers) */
-    volatile uint8_t ready;          /* Toggle, bumped after each successful commit */
-    volatile uint8_t commit_idx;     /* Commit cursor (drain reads up to here) */
-    volatile uint8_t reserved;       /* one byte left for future use */
-    uint8_t buffer[SHADOW_MIDI_INJECT_BUFFER_SIZE];  /* USB-MIDI packets (4 bytes each) */
+    uint32_t enqueue_pos;   /* producer claim cursor (monotonic, __atomic_*) */
+    uint32_t read_pos;      /* single-consumer cursor (monotonic, __atomic_*) */
+    shadow_midi_inject_slot_t slots[SHADOW_MIDI_INJECT_SLOTS];
 } shadow_midi_inject_t;
 
 /*

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "shadow_midi.h"
+#include "shadow_midi_inject_writer.h"
 #include "shadow_chain_mgmt.h"
 #include "shadow_led_queue.h"
 #include "shadow_overlay.h"  /* MIDI channel indicator globals */
@@ -573,8 +574,21 @@ void shadow_drain_midi_inject(void)
 
     last_ready = inject_shm->ready;
 
-    /* Snapshot buffer first, then reset write_idx */
-    int snapshot_len = inject_shm->write_idx;
+    /* Snapshot up to commit_idx (NOT alloc_idx) — anything between
+     * commit_idx and alloc_idx is reserved-but-unwritten by an
+     * in-flight producer. Reading from there would pull garbage; the
+     * producer will commit on its own thread and we'll catch the data
+     * on the next drain pass.
+     *
+     * Acquire load pairs with each producer's release store on
+     * commit_idx so we're guaranteed to see their buffer writes.
+     *
+     * Caveat: if alloc_idx > commit_idx (reservations in flight) at
+     * the time we reset both cursors below, those producers' data
+     * will be wiped by the memset and they'll hit spin-timeout (-2)
+     * in shadow_midi_inject_push(). That's a documented, very rare
+     * loss window — tracked in flagist0/schwung#2. */
+    int snapshot_len = __atomic_load_n(&inject_shm->commit_idx, __ATOMIC_ACQUIRE);
     uint8_t local_buf[SHADOW_MIDI_INJECT_BUFFER_SIZE];
     int copy_len = snapshot_len < (int)SHADOW_MIDI_INJECT_BUFFER_SIZE
                  ? snapshot_len : (int)SHADOW_MIDI_INJECT_BUFFER_SIZE;
@@ -582,7 +596,11 @@ void shadow_drain_midi_inject(void)
         memcpy(local_buf, inject_shm->buffer, copy_len);
     }
     __sync_synchronize();
-    inject_shm->write_idx = 0;
+    /* Reset both cursors to 0 — the alloc_idx reset frees space for new
+     * reservations; the commit_idx reset re-arms the FIFO order so the
+     * next batch of producers can commit from slot 0 in order. */
+    inject_shm->alloc_idx  = 0;
+    inject_shm->commit_idx = 0;
     memset(inject_shm->buffer, 0, SHADOW_MIDI_INJECT_BUFFER_SIZE);
 
     if (copy_len <= 0) return;
@@ -622,19 +640,26 @@ void shadow_drain_midi_inject(void)
     }
 
     /* Carry over any undrained packets so they fire in subsequent frames.
-     * Without this, bursts that exceed the 8-per-frame cap (or pile up
+     * Without this, bursts that exceed the 16-per-frame cap (or pile up
      * during DEFER_FRAMES while cable-0 is active) lose events when the
-     * snapshot resets write_idx above — which strands note-offs and leaves
+     * snapshot resets cursors above — which strands note-offs and leaves
      * voices hanging on Move's track. Safe to rewrite inject_shm->buffer
-     * here because shadow_chain_midi_inject runs on the same SPI thread. */
+     * here because shadow_chain_midi_inject runs on the same SPI thread.
+     *
+     * Cursor invariant: carryover data is already committed by its
+     * original producer, so we set both alloc_idx and commit_idx to
+     * `remaining` — drain on the next frame reads commit_idx and sees
+     * the carried packets as ready-to-go. */
     int remaining = copy_len - consumed_bytes;
     if (remaining > 0) {
-        /* write_idx is uint8_t (0..255) and the inject guard checks wr+4 <= 256,
-         * so write_idx must never exceed 252 (63 packets). Cap carryover at
-         * 252 so a new inject from chain_host can still land. */
+        /* alloc_idx/commit_idx are uint8_t (0..255) and the producer
+         * guard checks wr+4 < 256, so they must never exceed 252
+         * (63 packets). Cap carryover at 252 so a new inject from
+         * chain_host can still land. */
         if (remaining > 252) remaining = 252;
         memcpy(inject_shm->buffer, &local_buf[consumed_bytes], remaining);
-        inject_shm->write_idx = (uint8_t)remaining;
+        __atomic_store_n(&inject_shm->alloc_idx,  (uint8_t)remaining, __ATOMIC_RELAXED);
+        __atomic_store_n(&inject_shm->commit_idx, (uint8_t)remaining, __ATOMIC_RELEASE);
         inject_shm->ready++;  /* re-arm so next frame drains without waiting
                                * for a new inject to bump ready */
     }
@@ -670,24 +695,18 @@ int shadow_chain_midi_inject(const uint8_t *msg, int len)
     shadow_midi_inject_t *shm = *host_shadow_midi_inject_shm;
     if (!shm) return 0;
 
-    int wr = shm->write_idx;
-    if (wr + 4 > (int)SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-        if (host_log) {
-            char dbg[96];
-            uint8_t type = msg[1] & 0xF0;
-            snprintf(dbg, sizeof(dbg),
-                     "MIDI inject FULL: wr=%d dropped status=0x%02x n=%d v=%d",
-                     wr, msg[1], msg[2], msg[3]);
-            host_log(dbg);
-        }
-        return 0;
-    }
+    int rc = shadow_midi_inject_push(shm, msg);
+    if (rc == 0) return 4;
 
-    memcpy(&shm->buffer[wr], msg, 4);
-    shm->write_idx = (uint8_t)(wr + 4);
-    __sync_synchronize();
-    shm->ready++;
-    return 4;
+    if (host_log) {
+        char dbg[96];
+        const char *why = (rc == -1) ? "FULL" : "STRANDED";
+        snprintf(dbg, sizeof(dbg),
+                 "MIDI inject %s: dropped status=0x%02x n=%d v=%d",
+                 why, msg[1], msg[2], msg[3]);
+        host_log(dbg);
+    }
+    return 0;
 }
 
 /* Drain MIDI-to-DSP buffer from shadow UI and dispatch to chain slots. */

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -531,7 +531,6 @@ void shadow_inject_ui_midi_out(void)
 void shadow_drain_midi_inject(void)
 {
     shadow_midi_inject_t *inject_shm = *host_shadow_midi_inject_shm;
-    static uint8_t last_ready = 0;
     /* MIDI_IN events are 8 bytes each (4 USB-MIDI + 4 timestamp). Scanning
      * at 4-byte stride would land mid-event and corrupt Move's parse (Move
      * terminates the scan at the first zero slot, so any gap loses all
@@ -570,107 +569,49 @@ void shadow_drain_midi_inject(void)
         return;
     }
 
-    if (inject_shm->ready == last_ready) return;
-
-    last_ready = inject_shm->ready;
-
-    /* Snapshot up to commit_idx (NOT alloc_idx) — anything between
-     * commit_idx and alloc_idx is reserved-but-unwritten by an
-     * in-flight producer. Reading from there would pull garbage; the
-     * producer will commit on its own thread and we'll catch the data
-     * on the next drain pass.
-     *
-     * Acquire load pairs with each producer's release store on
-     * commit_idx so we're guaranteed to see their buffer writes.
-     *
-     * Caveat: if alloc_idx > commit_idx (reservations in flight) at
-     * the time we reset both cursors below, those producers' data
-     * will be wiped by the memset and they'll hit spin-timeout (-2)
-     * in shadow_midi_inject_push(). That's a documented, very rare
-     * loss window — tracked in flagist0/schwung#2. */
-    int snapshot_len = __atomic_load_n(&inject_shm->commit_idx, __ATOMIC_ACQUIRE);
-    uint8_t local_buf[SHADOW_MIDI_INJECT_BUFFER_SIZE];
-    int copy_len = snapshot_len < (int)SHADOW_MIDI_INJECT_BUFFER_SIZE
-                 ? snapshot_len : (int)SHADOW_MIDI_INJECT_BUFFER_SIZE;
-    if (copy_len > 0) {
-        memcpy(local_buf, inject_shm->buffer, copy_len);
-    }
-    __sync_synchronize();
-    /* Reset both cursors to 0 — the alloc_idx reset frees space for new
-     * reservations; the commit_idx reset re-arms the FIFO order so the
-     * next batch of producers can commit from slot 0 in order. */
-    inject_shm->alloc_idx  = 0;
-    inject_shm->commit_idx = 0;
-    memset(inject_shm->buffer, 0, SHADOW_MIDI_INJECT_BUFFER_SIZE);
-
-    if (copy_len <= 0) return;
-
-    /* Inject into shadow_mailbox at MIDI_IN_OFFSET */
+    /* Peek the next published packet, place it in an empty MIDI_IN slot,
+     * and only then pop it. Packets we can't place this pass (MIDI_IN full,
+     * or hardware events appeared mid-drain) stay in the ring untouched and
+     * are retried next frame — no snapshot, no reset, no carryover writeback.
+     * The consumer touches only its own read_pos and the per-slot seq it
+     * frees; it never resets producer state or memsets the buffer. */
     uint8_t *midi_in = host_shadow_mailbox + MIDI_IN_OFFSET;
-
     int hw_offset = 0;
     int injected = 0;
-    int consumed_bytes = 0;
-    for (int i = 0; i < copy_len && injected < 16; i += 4) {
-        /* Find empty 8-byte slot (byte 0 == 0 means no cable/CIN, unused) */
+    uint8_t pkt[4];
+    while (injected < 16 && shadow_midi_inject_peek(inject_shm, pkt)) {
+        /* Find an empty 8-byte slot (byte 0 == 0 means no cable/CIN, unused) */
         int saw_existing = 0;
         while (hw_offset < MIDI_IN_MAX_BYTES) {
             if (midi_in[hw_offset] == 0) break;
             saw_existing = 1;
             hw_offset += MIDI_IN_EVT_STRIDE;
         }
-        if (hw_offset >= MIDI_IN_MAX_BYTES) break;  /* Buffer full */
-        /* If we skipped over pre-existing events to find an empty slot, bail
-         * and carry remaining packets to the next frame.  The defer guard has
-         * a narrow race window: events can appear in MIDI_IN between the guard
-         * check and the write.  Injecting alongside hardware events (at a
-         * non-zero offset) races Move's firmware MIDI read path and causes
-         * SIGABRT — empirically the crash always fires at a non-zero offset. */
+        if (hw_offset >= MIDI_IN_MAX_BYTES) break;  /* MIDI_IN full — retry next frame */
+        /* If we'd have to write past pre-existing events, bail and leave the
+         * packet in the ring for next frame. The defer guard has a narrow
+         * race window: events can appear in MIDI_IN between the guard check
+         * and the write. Injecting alongside hardware events (at a non-zero
+         * offset) races Move's firmware MIDI read path and causes SIGABRT —
+         * empirically the crash always fires at a non-zero offset. */
         if (saw_existing) break;
 
-        /* Write 4-byte USB-MIDI packet + zero the 4-byte timestamp.
-         * Cable nibble in local_buf[i] is preserved — callers choose cable:
+        /* Write the 4-byte USB-MIDI packet + zero its 4-byte timestamp.
+         * Cable nibble in pkt[0] is preserved — callers choose cable:
          * 0 for internal hardware (pads/buttons, Move-prefix protocol),
          * 2 for external USB (general MIDI, routed to tracks by channel). */
-        memcpy(&midi_in[hw_offset], &local_buf[i], 4);
+        memcpy(&midi_in[hw_offset], pkt, 4);
         memset(&midi_in[hw_offset + 4], 0, 4);
         hw_offset += MIDI_IN_EVT_STRIDE;
+        shadow_midi_inject_pop(inject_shm);   /* consume only after a successful inject */
         injected++;
-        consumed_bytes = i + 4;
-    }
-
-    /* Carry over any undrained packets so they fire in subsequent frames.
-     * Without this, bursts that exceed the 16-per-frame cap (or pile up
-     * during DEFER_FRAMES while cable-0 is active) lose events when the
-     * snapshot resets cursors above — which strands note-offs and leaves
-     * voices hanging on Move's track. Safe to rewrite inject_shm->buffer
-     * here because shadow_chain_midi_inject runs on the same SPI thread.
-     *
-     * Cursor invariant: carryover data is already committed by its
-     * original producer, so we set both alloc_idx and commit_idx to
-     * `remaining` — drain on the next frame reads commit_idx and sees
-     * the carried packets as ready-to-go. */
-    int remaining = copy_len - consumed_bytes;
-    if (remaining > 0) {
-        /* alloc_idx/commit_idx are uint8_t (0..255) and the producer
-         * guard checks wr+4 < 256, so they must never exceed 252
-         * (63 packets). Cap carryover at 252 so a new inject from
-         * chain_host can still land. */
-        if (remaining > 252) remaining = 252;
-        memcpy(inject_shm->buffer, &local_buf[consumed_bytes], remaining);
-        __atomic_store_n(&inject_shm->alloc_idx,  (uint8_t)remaining, __ATOMIC_RELAXED);
-        __atomic_store_n(&inject_shm->commit_idx, (uint8_t)remaining, __ATOMIC_RELEASE);
-        inject_shm->ready++;  /* re-arm so next frame drains without waiting
-                               * for a new inject to bump ready */
     }
 
     if (host_log && injected > 0) {
         char dbg[128];
         snprintf(dbg, sizeof(dbg),
-                 "MIDI inject: drained %d/%d pkts at offset %d%s",
-                 injected, copy_len / 4,
-                 hw_offset - injected * MIDI_IN_EVT_STRIDE,
-                 remaining > 0 ? " [carryover]" : "");
+                 "MIDI inject: drained %d pkts at offset %d",
+                 injected, hw_offset - injected * MIDI_IN_EVT_STRIDE);
         host_log(dbg);
     }
 }
@@ -695,15 +636,14 @@ int shadow_chain_midi_inject(const uint8_t *msg, int len)
     shadow_midi_inject_t *shm = *host_shadow_midi_inject_shm;
     if (!shm) return 0;
 
-    int rc = shadow_midi_inject_push(shm, msg);
-    if (rc == 0) return 4;
+    if (shadow_midi_inject_push(shm, msg) == 0) return 4;
 
+    /* Only failure is -1 (ring full / drain starved). */
     if (host_log) {
         char dbg[96];
-        const char *why = (rc == -1) ? "FULL" : "STRANDED";
         snprintf(dbg, sizeof(dbg),
-                 "MIDI inject %s: dropped status=0x%02x n=%d v=%d",
-                 why, msg[1], msg[2], msg[3]);
+                 "MIDI inject FULL: dropped status=0x%02x n=%d v=%d",
+                 msg[1], msg[2], msg[3]);
         host_log(dbg);
     }
     return 0;

--- a/src/host/shadow_midi_inject_writer.h
+++ b/src/host/shadow_midi_inject_writer.h
@@ -1,0 +1,114 @@
+/*
+ * shadow_midi_inject_writer.h — single source of truth for writing into
+ * the /schwung-midi-inject SHM ring.
+ *
+ * The inject ring is multi-producer / single-consumer. Producers can
+ * be in different processes (shim, schwung_host) and may call
+ * concurrently. Without coordination they race on the cursor or
+ * leave reserved-but-unwritten slots that the drain reads as garbage —
+ * the latter manifests as Move firmware SIGABRT (see shadow_midi.c:553).
+ *
+ * This helper encodes the lock-free MPSC pattern once:
+ *   1. CAS-reserve a 4-byte slot at `alloc_idx`
+ *   2. memcpy our 4 bytes into the reserved slot
+ *   3. Spin (bounded) until prior producers have advanced `commit_idx`
+ *      to our slot start (FIFO commit order)
+ *   4. Atomically advance `commit_idx` past our slot, then bump `ready`
+ *
+ * The drain reads `commit_idx` (not `alloc_idx`), so steps 1–3 are
+ * invisible to it; only step 4 publishes our packet.
+ *
+ * Memory ordering:
+ *   - alloc_idx CAS: RELAXED — we only need atomic agreement on which
+ *     slot belongs to whom, no data dependency.
+ *   - commit_idx load (in spin): ACQUIRE — pairs with prior producer's
+ *     RELEASE store to commit_idx, ensuring their buffer write is
+ *     visible to us if we ever needed to read it (we don't, but the
+ *     pairing keeps semantics tight).
+ *   - commit_idx store: RELEASE — pairs with the drain's ACQUIRE load,
+ *     publishing our buffer write to the drain.
+ *   - ready fetch_add: RELEASE — pairs with drain's read of `ready`
+ *     to detect "something new arrived".
+ *
+ * Header-only on purpose: the helper is small, hot enough that we want
+ * inlining at every callsite, and self-contained (depends only on
+ * shadow_constants.h and stdatomic-style GCC builtins).
+ */
+
+#ifndef SHADOW_MIDI_INJECT_WRITER_H
+#define SHADOW_MIDI_INJECT_WRITER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "shadow_constants.h"
+
+/* Bound on the FIFO-commit spin. In realistic conditions this never
+ * triggers — concurrent-writer rate across all four producers is well
+ * under 100/sec, drain runs every ~3ms, so the chance of finding a
+ * prior producer mid-write is ~10^-4 per push. When it does fire, a
+ * tight loop of atomic loads is nanoseconds per iteration; 100k caps
+ * worst-case at ~1ms of CPU, after which we give up and return -2
+ * rather than hang the caller. */
+#define SHADOW_MIDI_INJECT_SPIN_LIMIT 100000
+
+/* shadow_midi_inject_push — push one 4-byte USB-MIDI packet into the ring.
+ *
+ * Safe to call concurrently from any thread/process that has the SHM
+ * mapped read-write. Wait-free in the no-contention case; bounded spin
+ * (~1 ms cap) in the rare case a prior producer is mid-write.
+ *
+ * Returns:
+ *    0 — committed; drain will see this packet on its next pass.
+ *   -1 — buffer full (drain hasn't run / can't keep up). Caller may retry
+ *        after a frame.
+ *   -2 — gave up waiting for a prior stranded producer's commit. Our
+ *        4 bytes are physically in the buffer but were never published
+ *        via commit_idx; they will be wiped on the next drain reset.
+ *        Callers that care should log a one-shot warning and skip the
+ *        packet (or retry).
+ */
+static inline int
+shadow_midi_inject_push(shadow_midi_inject_t *shm, const uint8_t pkt[4])
+{
+    /* 1. CAS-reserve a slot. Loop body retries only if another producer
+     *    advanced alloc_idx between our load and our compare-exchange —
+     *    not a busy-wait, just a value refresh. */
+    uint8_t my_slot;
+    do {
+        my_slot = __atomic_load_n(&shm->alloc_idx, __ATOMIC_RELAXED);
+        if ((unsigned)my_slot + 4u >= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
+            return -1;  /* buffer full */
+        }
+    } while (!__atomic_compare_exchange_n(
+        &shm->alloc_idx, &my_slot, (uint8_t)(my_slot + 4),
+        false /* strong */,
+        __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+
+    /* 2. We now own [my_slot, my_slot + 4). No other producer will
+     *    touch these bytes; safe to memcpy without further locks. */
+    memcpy(&shm->buffer[my_slot], pkt, 4);
+
+    /* 3. Wait for prior producers to commit so commits land in FIFO
+     *    order. The acquire load pairs with each prior producer's
+     *    release store on commit_idx. Bounded by SPIN_LIMIT — see
+     *    macro comment for rationale. */
+    int spin_iters = 0;
+    while (__atomic_load_n(&shm->commit_idx, __ATOMIC_ACQUIRE) != my_slot) {
+        if (++spin_iters > SHADOW_MIDI_INJECT_SPIN_LIMIT) {
+            return -2;  /* prior producer stranded */
+        }
+    }
+
+    /* 4. Publish. The release store on commit_idx makes our memcpy
+     *    visible to the drain's acquire load. The ready bump signals
+     *    "something new arrived" so drain doesn't need to poll
+     *    commit_idx every frame when nothing is happening. */
+    __atomic_store_n(&shm->commit_idx, (uint8_t)(my_slot + 4),
+                     __ATOMIC_RELEASE);
+    __atomic_fetch_add(&shm->ready, 1, __ATOMIC_RELEASE);
+    return 0;
+}
+
+#endif /* SHADOW_MIDI_INJECT_WRITER_H */

--- a/src/host/shadow_midi_inject_writer.h
+++ b/src/host/shadow_midi_inject_writer.h
@@ -1,38 +1,35 @@
 /*
- * shadow_midi_inject_writer.h — single source of truth for writing into
- * the /schwung-midi-inject SHM ring.
+ * shadow_midi_inject_writer.h — single source of truth for the
+ * /schwung-midi-inject SHM ring (producers + the single consumer).
  *
- * The inject ring is multi-producer / single-consumer. Producers can
- * be in different processes (shim, schwung_host) and may call
- * concurrently. Without coordination they race on the cursor or
- * leave reserved-but-unwritten slots that the drain reads as garbage —
- * the latter manifests as Move firmware SIGABRT (see shadow_midi.c:553).
+ * The ring is multi-producer / single-consumer. Producers can live in
+ * different processes (shim, schwung_host) and call concurrently; the
+ * one consumer is the shim's SPI-thread drain. Without coordination they
+ * race on slot contents and the drain reads garbage — a cable=0/CIN=0
+ * packet reaching Move's MIDI_IN reads as "misc function" and Move
+ * firmware aborts (SIGABRT).
  *
- * This helper encodes the lock-free MPSC pattern once:
- *   1. CAS-reserve a 4-byte slot at `alloc_idx`
- *   2. memcpy our 4 bytes into the reserved slot
- *   3. Spin (bounded) until prior producers have advanced `commit_idx`
- *      to our slot start (FIFO commit order)
- *   4. Atomically advance `commit_idx` past our slot, then bump `ready`
+ * This is Dmitry Vyukov's bounded MPSC queue: an array of slots, each
+ * with a sequence number `seq` and a 4-byte packet. Properties that
+ * matter here (see the long note in shadow_constants.h):
+ *   - the consumer never resets cursors or memsets the buffer, so it
+ *     cannot race a cross-process producer mid-write;
+ *   - producers never wait on each other's commit (no FIFO-commit spin),
+ *     so a producer preempted between claim and publish cannot stall the
+ *     SPI-thread producer on the realtime path;
+ *   - every cursor/seq access is atomic — no volatile-vs-atomic race.
  *
- * The drain reads `commit_idx` (not `alloc_idx`), so steps 1–3 are
- * invisible to it; only step 4 publishes our packet.
+ * Memory ordering (the standard Vyukov pairing):
+ *   - enqueue_pos / read_pos advance RELAXED (they only arbitrate slot
+ *     ownership; the data handoff rides on seq).
+ *   - producer publishes with a RELEASE store on slot.seq; consumer's
+ *     ACQUIRE load of slot.seq pairs with it, making the packet write
+ *     visible before the consumer reads it.
+ *   - consumer frees a slot with a RELEASE store on slot.seq; the next
+ *     lap's producer ACQUIRE-loads it before reusing the slot.
  *
- * Memory ordering:
- *   - alloc_idx CAS: RELAXED — we only need atomic agreement on which
- *     slot belongs to whom, no data dependency.
- *   - commit_idx load (in spin): ACQUIRE — pairs with prior producer's
- *     RELEASE store to commit_idx, ensuring their buffer write is
- *     visible to us if we ever needed to read it (we don't, but the
- *     pairing keeps semantics tight).
- *   - commit_idx store: RELEASE — pairs with the drain's ACQUIRE load,
- *     publishing our buffer write to the drain.
- *   - ready fetch_add: RELEASE — pairs with drain's read of `ready`
- *     to detect "something new arrived".
- *
- * Header-only on purpose: the helper is small, hot enough that we want
- * inlining at every callsite, and self-contained (depends only on
- * shadow_constants.h and stdatomic-style GCC builtins).
+ * Header-only: small, hot, self-contained (depends only on
+ * shadow_constants.h and GCC __atomic builtins).
  */
 
 #ifndef SHADOW_MIDI_INJECT_WRITER_H
@@ -44,71 +41,100 @@
 
 #include "shadow_constants.h"
 
-/* Bound on the FIFO-commit spin. In realistic conditions this never
- * triggers — concurrent-writer rate across all four producers is well
- * under 100/sec, drain runs every ~3ms, so the chance of finding a
- * prior producer mid-write is ~10^-4 per push. When it does fire, a
- * tight loop of atomic loads is nanoseconds per iteration; 100k caps
- * worst-case at ~1ms of CPU, after which we give up and return -2
- * rather than hang the caller. */
-#define SHADOW_MIDI_INJECT_SPIN_LIMIT 100000
+/* shadow_midi_inject_init — one-time initialization by the SHM creator
+ * (the shim), BEFORE any producer maps the segment. Zero-fill is not a
+ * valid initial state: each slot's seq must equal its index. Safe to call
+ * on a freshly created (or re-created) segment when no producer is live. */
+static inline void
+shadow_midi_inject_init(shadow_midi_inject_t *shm)
+{
+    __atomic_store_n(&shm->enqueue_pos, 0u, __ATOMIC_RELAXED);
+    __atomic_store_n(&shm->read_pos, 0u, __ATOMIC_RELAXED);
+    for (uint32_t i = 0; i < SHADOW_MIDI_INJECT_SLOTS; i++) {
+        shm->slots[i].pkt[0] = shm->slots[i].pkt[1] =
+            shm->slots[i].pkt[2] = shm->slots[i].pkt[3] = 0;
+        __atomic_store_n(&shm->slots[i].seq, i, __ATOMIC_RELAXED);
+    }
+}
 
-/* shadow_midi_inject_push — push one 4-byte USB-MIDI packet into the ring.
+/* shadow_midi_inject_push — enqueue one 4-byte USB-MIDI packet.
  *
  * Safe to call concurrently from any thread/process that has the SHM
- * mapped read-write. Wait-free in the no-contention case; bounded spin
- * (~1 ms cap) in the rare case a prior producer is mid-write.
+ * mapped read-write. Wait-free except for a bounded CAS-retry under
+ * producer contention (retries at most once per concurrent producer —
+ * never waits on another producer to publish).
  *
  * Returns:
- *    0 — committed; drain will see this packet on its next pass.
- *   -1 — buffer full (drain hasn't run / can't keep up). Caller may retry
- *        after a frame.
- *   -2 — gave up waiting for a prior stranded producer's commit. Our
- *        4 bytes are physically in the buffer but were never published
- *        via commit_idx; they will be wiped on the next drain reset.
- *        Callers that care should log a one-shot warning and skip the
- *        packet (or retry).
+ *    0 — enqueued; the drain will deliver it on a subsequent pass.
+ *   -1 — ring full (consumer hasn't freed this slot's previous lap yet).
+ *        Caller may retry after a frame.
  */
 static inline int
 shadow_midi_inject_push(shadow_midi_inject_t *shm, const uint8_t pkt[4])
 {
-    /* 1. CAS-reserve a slot. Loop body retries only if another producer
-     *    advanced alloc_idx between our load and our compare-exchange —
-     *    not a busy-wait, just a value refresh. */
-    uint8_t my_slot;
-    do {
-        my_slot = __atomic_load_n(&shm->alloc_idx, __ATOMIC_RELAXED);
-        if ((unsigned)my_slot + 4u >= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-            return -1;  /* buffer full */
-        }
-    } while (!__atomic_compare_exchange_n(
-        &shm->alloc_idx, &my_slot, (uint8_t)(my_slot + 4),
-        false /* strong */,
-        __ATOMIC_RELAXED, __ATOMIC_RELAXED));
-
-    /* 2. We now own [my_slot, my_slot + 4). No other producer will
-     *    touch these bytes; safe to memcpy without further locks. */
-    memcpy(&shm->buffer[my_slot], pkt, 4);
-
-    /* 3. Wait for prior producers to commit so commits land in FIFO
-     *    order. The acquire load pairs with each prior producer's
-     *    release store on commit_idx. Bounded by SPIN_LIMIT — see
-     *    macro comment for rationale. */
-    int spin_iters = 0;
-    while (__atomic_load_n(&shm->commit_idx, __ATOMIC_ACQUIRE) != my_slot) {
-        if (++spin_iters > SHADOW_MIDI_INJECT_SPIN_LIMIT) {
-            return -2;  /* prior producer stranded */
+    shadow_midi_inject_slot_t *slot;
+    uint32_t pos = __atomic_load_n(&shm->enqueue_pos, __ATOMIC_RELAXED);
+    for (;;) {
+        slot = &shm->slots[pos & SHADOW_MIDI_INJECT_MASK];
+        uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+        int32_t diff = (int32_t)(seq - pos);
+        if (diff == 0) {
+            /* Slot is free for this lap. Try to claim `pos`. Weak CAS:
+             * on failure `pos` is refreshed to the current enqueue_pos. */
+            if (__atomic_compare_exchange_n(&shm->enqueue_pos, &pos, pos + 1,
+                                            true /* weak */,
+                                            __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+                break;  /* we own `slot` at `pos` */
+            }
+            /* CAS failed → pos reloaded; recompute slot and retry. */
+        } else if (diff < 0) {
+            /* Slot still holds an unconsumed packet from a prior lap. The
+             * ring is full at this position → drop, let the caller retry. */
+            return -1;
+        } else {
+            /* diff > 0: another producer already claimed this pos. Refresh
+             * and retry against the current head. */
+            pos = __atomic_load_n(&shm->enqueue_pos, __ATOMIC_RELAXED);
         }
     }
 
-    /* 4. Publish. The release store on commit_idx makes our memcpy
-     *    visible to the drain's acquire load. The ready bump signals
-     *    "something new arrived" so drain doesn't need to poll
-     *    commit_idx every frame when nothing is happening. */
-    __atomic_store_n(&shm->commit_idx, (uint8_t)(my_slot + 4),
-                     __ATOMIC_RELEASE);
-    __atomic_fetch_add(&shm->ready, 1, __ATOMIC_RELEASE);
+    memcpy(slot->pkt, pkt, 4);
+    /* Publish: RELEASE makes the packet write visible to the consumer's
+     * ACQUIRE load of seq. */
+    __atomic_store_n(&slot->seq, pos + 1, __ATOMIC_RELEASE);
     return 0;
+}
+
+/* shadow_midi_inject_peek — copy the next ready packet into out[4] WITHOUT
+ * consuming it. Single-consumer only (the drain). Returns 1 if a packet was
+ * copied, 0 if none is ready yet (empty, or the head slot's producer is
+ * still mid-write). The packet stays stable until _pop(), so the consumer
+ * may decline to consume it this pass (it will reappear next pass). */
+static inline int
+shadow_midi_inject_peek(shadow_midi_inject_t *shm, uint8_t out[4])
+{
+    uint32_t pos = __atomic_load_n(&shm->read_pos, __ATOMIC_RELAXED);
+    shadow_midi_inject_slot_t *slot = &shm->slots[pos & SHADOW_MIDI_INJECT_MASK];
+    uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+    if ((int32_t)(seq - (pos + 1)) != 0) {
+        return 0;  /* not published yet → nothing ready at the head */
+    }
+    memcpy(out, slot->pkt, 4);
+    return 1;
+}
+
+/* shadow_midi_inject_pop — consume the packet previously observed by _peek,
+ * freeing its slot for a future lap. Single-consumer only. Call exactly once
+ * per successful _peek that you decide to consume. */
+static inline void
+shadow_midi_inject_pop(shadow_midi_inject_t *shm)
+{
+    uint32_t pos = __atomic_load_n(&shm->read_pos, __ATOMIC_RELAXED);
+    shadow_midi_inject_slot_t *slot = &shm->slots[pos & SHADOW_MIDI_INJECT_MASK];
+    /* Free the slot for the producer that will claim pos + SLOTS. RELEASE
+     * pairs with that producer's ACQUIRE load of seq. */
+    __atomic_store_n(&slot->seq, pos + SHADOW_MIDI_INJECT_SLOTS, __ATOMIC_RELEASE);
+    __atomic_store_n(&shm->read_pos, pos + 1, __ATOMIC_RELAXED);
 }
 
 #endif /* SHADOW_MIDI_INJECT_WRITER_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -39,6 +39,7 @@
 #include "host/plugin_api_v1.h"
 #include "host/audio_fx_api_v2.h"
 #include "host/shadow_constants.h"
+#include "host/shadow_midi_inject_writer.h"
 #include "host/shadow_chain_types.h"
 #include "host/unified_log.h"
 #include "host/tts_engine.h"
@@ -5571,42 +5572,18 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
     {
         static int prev_overtake_mode = 0;
         if (prev_overtake_mode != 0 && overtake_mode == 0 && shadow_midi_inject_shm) {
-            int wr = shadow_midi_inject_shm->write_idx;
-            /* Shift off: CC 49 value 0 */
-            if (wr + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-                shadow_midi_inject_shm->buffer[wr]     = 0x0B; /* CIN=CC, cable=0 */
-                shadow_midi_inject_shm->buffer[wr + 1] = 0xB0; /* CC status, ch 0 */
-                shadow_midi_inject_shm->buffer[wr + 2] = CC_SHIFT;
-                shadow_midi_inject_shm->buffer[wr + 3] = 0;    /* value 0 = off */
-                wr += 4;
-            }
-            /* Volume touch off: Note-off note 8 */
-            if (wr + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-                shadow_midi_inject_shm->buffer[wr]     = 0x08; /* CIN=NoteOff, cable=0 */
-                shadow_midi_inject_shm->buffer[wr + 1] = 0x80; /* Note-off status, ch 0 */
-                shadow_midi_inject_shm->buffer[wr + 2] = 8;    /* Volume touch note */
-                shadow_midi_inject_shm->buffer[wr + 3] = 0;    /* velocity 0 */
-                wr += 4;
-            }
-            /* Back off: CC 51 value 0 */
-            if (wr + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-                shadow_midi_inject_shm->buffer[wr]     = 0x0B; /* CIN=CC, cable=0 */
-                shadow_midi_inject_shm->buffer[wr + 1] = 0xB0; /* CC status, ch 0 */
-                shadow_midi_inject_shm->buffer[wr + 2] = CC_BACK;
-                shadow_midi_inject_shm->buffer[wr + 3] = 0;    /* value 0 = off */
-                wr += 4;
-            }
-            /* Jog click off: CC 3 value 0 */
-            if (wr + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-                shadow_midi_inject_shm->buffer[wr]     = 0x0B; /* CIN=CC, cable=0 */
-                shadow_midi_inject_shm->buffer[wr + 1] = 0xB0; /* CC status, ch 0 */
-                shadow_midi_inject_shm->buffer[wr + 2] = CC_JOG_CLICK;
-                shadow_midi_inject_shm->buffer[wr + 3] = 0;    /* value 0 = off */
-                wr += 4;
-            }
-            shadow_midi_inject_shm->write_idx = wr;
-            __sync_synchronize();
-            shadow_midi_inject_shm->ready++;
+            /* Synthesize releases for any controls that may have been
+             * down at overtake start so Move firmware doesn't think
+             * buttons are still held. Each push is independent under
+             * the MPSC helper — no cursor coordination required here. */
+            const uint8_t shift_off[4]    = {0x0B, 0xB0, CC_SHIFT,     0};
+            const uint8_t vol_touch_off[4]= {0x08, 0x80, 8,            0};
+            const uint8_t back_off[4]     = {0x0B, 0xB0, CC_BACK,      0};
+            const uint8_t jog_click_off[4]= {0x0B, 0xB0, CC_JOG_CLICK, 0};
+            shadow_midi_inject_push(shadow_midi_inject_shm, shift_off);
+            shadow_midi_inject_push(shadow_midi_inject_shm, vol_touch_off);
+            shadow_midi_inject_push(shadow_midi_inject_shm, back_off);
+            shadow_midi_inject_push(shadow_midi_inject_shm, jog_click_off);
             shadow_log("Overtake exit: injected shift-off, volume-touch-off, back-off, jog-click-off");
         }
         /* Forced reset of cable-2 channel remap on overtake exit. The active
@@ -5626,16 +5603,8 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
          * never reaches Move otherwise. */
         if (prev_overtake_mode == 0 && overtake_mode != 0 && shadow_midi_inject_shm &&
             shadow_shift_held) {
-            int wr = shadow_midi_inject_shm->write_idx;
-            if (wr + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-                shadow_midi_inject_shm->buffer[wr]     = 0x0B;
-                shadow_midi_inject_shm->buffer[wr + 1] = 0xB0;
-                shadow_midi_inject_shm->buffer[wr + 2] = CC_SHIFT;
-                shadow_midi_inject_shm->buffer[wr + 3] = 0;
-                wr += 4;
-                shadow_midi_inject_shm->write_idx = wr;
-                __sync_synchronize();
-                shadow_midi_inject_shm->ready++;
+            const uint8_t shift_off[4] = {0x0B, 0xB0, CC_SHIFT, 0};
+            if (shadow_midi_inject_push(shadow_midi_inject_shm, shift_off) == 0) {
                 shadow_log("Overtake entry with shift held: injected shift-off");
             }
         }

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2976,6 +2976,12 @@ static void init_shadow_shm(void)
     /* Create/open MIDI inject shared memory (for injecting events into Move's MIDI_IN) */
     shadow_midi_inject_shm = (shadow_midi_inject_t *)shadow_shm_map(SHM_SHADOW_MIDI_INJECT,
                                                                     sizeof(shadow_midi_inject_t), 1, 1);
+    /* The Vyukov ring needs seq[i] = i — zero-fill is not a valid initial
+     * state. The shim creates this segment before any producer (schwung_host)
+     * maps it, so initializing here once at startup is race-free. */
+    if (shadow_midi_inject_shm) {
+        shadow_midi_inject_init(shadow_midi_inject_shm);
+    }
 
     /* Create/open cable-2 channel remap shared memory (active overtake module writes,
      * shim reads on every SPI frame to rewrite cable-2 MIDI_IN channel byte). */
@@ -5580,11 +5586,23 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
             const uint8_t vol_touch_off[4]= {0x08, 0x80, 8,            0};
             const uint8_t back_off[4]     = {0x0B, 0xB0, CC_BACK,      0};
             const uint8_t jog_click_off[4]= {0x0B, 0xB0, CC_JOG_CLICK, 0};
-            shadow_midi_inject_push(shadow_midi_inject_shm, shift_off);
-            shadow_midi_inject_push(shadow_midi_inject_shm, vol_touch_off);
-            shadow_midi_inject_push(shadow_midi_inject_shm, back_off);
-            shadow_midi_inject_push(shadow_midi_inject_shm, jog_click_off);
-            shadow_log("Overtake exit: injected shift-off, volume-touch-off, back-off, jog-click-off");
+            /* These are the highest-consequence injects: a dropped release
+             * leaves Move believing a control is still held. push() only
+             * fails (-1) if the ring is full (drain starved) — never expected
+             * for four one-shot packets, but check each and name any casualty
+             * rather than dropping it silently. */
+            int rc_shift = shadow_midi_inject_push(shadow_midi_inject_shm, shift_off);
+            int rc_vol   = shadow_midi_inject_push(shadow_midi_inject_shm, vol_touch_off);
+            int rc_back  = shadow_midi_inject_push(shadow_midi_inject_shm, back_off);
+            int rc_jog   = shadow_midi_inject_push(shadow_midi_inject_shm, jog_click_off);
+            if (rc_shift == 0 && rc_vol == 0 && rc_back == 0 && rc_jog == 0) {
+                shadow_log("Overtake exit: injected shift-off, volume-touch-off, back-off, jog-click-off");
+            } else {
+                if (rc_shift) shadow_log("Overtake exit: DROPPED shift-off inject (ring full) — Move may think Shift is held");
+                if (rc_vol)   shadow_log("Overtake exit: DROPPED volume-touch-off inject (ring full)");
+                if (rc_back)  shadow_log("Overtake exit: DROPPED back-off inject (ring full) — Move may think Back is held");
+                if (rc_jog)   shadow_log("Overtake exit: DROPPED jog-click-off inject (ring full) — Move may think Jog Click is held");
+            }
         }
         /* Forced reset of cable-2 channel remap on overtake exit. The active
          * module owns the table during overtake; on exit, clear it so a

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -944,10 +944,11 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
     JS_FreeValue(ctx, len_val);
 
     /* Process 4 bytes at a time (USB-MIDI packet format).
-     * Each packet goes through the MPSC helper, which CAS-reserves a
-     * slot, commits in FIFO order, and bumps `ready` per packet. The
-     * helper handles the cross-process race with the test daemon and
-     * the shim's own writers — see shadow_midi_inject_writer.h. */
+     * Each packet goes through the MPSC helper (shadow_midi_inject_push),
+     * which CAS-reserves a slot and publishes it with a release-store on
+     * the slot's seq. The helper handles the cross-process race with the
+     * other producers (the shim's own writers, the test daemon) — see
+     * shadow_midi_inject_writer.h. */
     for (int i = 0; i < len; i += 4) {
         uint8_t packet[4] = {0, 0, 0, 0};
 

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -964,7 +964,7 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
          * to the track synth). See function docblock. */
 
         if (shadow_midi_inject_push(shadow_midi_inject, packet) != 0) {
-            /* Buffer full or stranded — drop this packet and stop the
+            /* Ring full (drain starved) — drop this packet and stop the
              * batch (subsequent packets would just back up). */
             break;
         }

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -29,6 +29,7 @@
 #include "host/shadow_constants.h"
 #include "host/shadow_shm_util.h"
 #include "host/js_host_common.h"
+#include "host/shadow_midi_inject_writer.h"
 #include "../host/unified_log.h"
 #include "../host/analytics.h"
 
@@ -942,7 +943,11 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
     JS_ToInt32(ctx, &len, len_val);
     JS_FreeValue(ctx, len_val);
 
-    /* Process 4 bytes at a time (USB-MIDI packet format) */
+    /* Process 4 bytes at a time (USB-MIDI packet format).
+     * Each packet goes through the MPSC helper, which CAS-reserves a
+     * slot, commits in FIFO order, and bumps `ready` per packet. The
+     * helper handles the cross-process race with the test daemon and
+     * the shim's own writers — see shadow_midi_inject_writer.h. */
     for (int i = 0; i < len; i += 4) {
         uint8_t packet[4] = {0, 0, 0, 0};
 
@@ -958,17 +963,12 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
          * route (cable 0 = pad simulation, cable 2 = external MIDI in
          * to the track synth). See function docblock. */
 
-        /* Find space in buffer and write */
-        int write_offset = shadow_midi_inject->write_idx;
-        if (write_offset + 4 <= SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-            memcpy(&shadow_midi_inject->buffer[write_offset], packet, 4);
-            shadow_midi_inject->write_idx = write_offset + 4;
+        if (shadow_midi_inject_push(shadow_midi_inject, packet) != 0) {
+            /* Buffer full or stranded — drop this packet and stop the
+             * batch (subsequent packets would just back up). */
+            break;
         }
     }
-
-    /* Signal shim that data is ready */
-    __sync_synchronize();
-    shadow_midi_inject->ready++;
 
     return JS_TRUE;
 }

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -1,0 +1,36 @@
+# Host-side unit tests for code that's worth testing standalone, on the
+# dev machine, without the Move device or its toolchain.
+#
+# Currently:
+#   - test_midi_inject_writer — exercises the lock-free MPSC helper for
+#     the /schwung-midi-inject ring with multi-threaded producers.
+#
+# Usage: `make -C tests/host test`
+
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -Wextra -Wno-unused-parameter -std=c11
+INCLUDES = -I../../src/host
+LDFLAGS = -lpthread
+
+BUILD_DIR = ../../build/tests/host
+
+TARGETS = $(BUILD_DIR)/test_midi_inject_writer
+
+.PHONY: all test clean
+
+all: $(TARGETS)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/%: %.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+
+test: $(TARGETS)
+	@for t in $(TARGETS); do \
+		echo "==> $$t"; \
+		$$t || exit 1; \
+	done
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/tests/host/README.md
+++ b/tests/host/README.md
@@ -1,0 +1,40 @@
+# Host-side unit tests
+
+These tests run on the dev machine (Mac/Linux), not on the Move device.
+They cover small, well-isolated pieces of code where end-to-end testing
+on hardware is overkill — typically pure data-structure helpers that are
+worth pounding with multi-threaded stress before they ship into the shim
+or a host process.
+
+## Running
+
+```sh
+make -C tests/host test
+```
+
+Builds artifacts in `build/tests/host/` and runs each as a separate
+binary. A passing run prints `ALL PASS`; any assertion failure aborts.
+
+## What's here
+
+- **`test_midi_inject_writer`** — exercises `shadow_midi_inject_push()`
+  (in `src/host/shadow_midi_inject_writer.h`), the lock-free MPSC helper
+  that all producers must use to write into `/schwung-midi-inject`.
+  Stack-allocates a `shadow_midi_inject_t`, runs single-thread happy
+  path, full-buffer rejection, and 8-thread concurrent stress (50
+  iterations) to validate that no two writers ever clobber the same
+  slot.
+
+## When to add a test here
+
+Add a host-side unit test when:
+
+- The code under test is **pure** (no SHM, no `/dev/ablspi0.0`, no
+  QuickJS) — or can be exercised through a tiny shim that fakes those.
+- You want **deterministic** coverage of edge cases (boundary values,
+  concurrency interleavings) that are awkward to reproduce on hardware.
+- The cost of a hardware round-trip per change is too high relative to
+  the change rate.
+
+For anything that requires a live shim, Move firmware, or LED feedback,
+test on hardware against a deployed build.

--- a/tests/host/test_midi_inject_writer.c
+++ b/tests/host/test_midi_inject_writer.c
@@ -1,10 +1,14 @@
 /*
- * Host-side unit tests for shadow_midi_inject_writer.h.
+ * Host-side unit tests for shadow_midi_inject_writer.h (bounded MPSC ring).
  *
- * Runs on the dev machine (Mac/Linux), not on Move. Validates the MPSC
- * helper standalone — no SHM, no shim, no QuickJS — by stack-allocating
- * a shadow_midi_inject_t and pounding it with single-threaded and
- * multi-threaded producers.
+ * Runs on the dev machine (Mac/Linux), not on Move. Validates the ring
+ * standalone — no SHM, no shim, no QuickJS — by stack-allocating a
+ * shadow_midi_inject_t and exercising producers AND a concurrent consumer.
+ *
+ * The concurrent-consumer tests are the point: the bug class this ring
+ * fixes (Move SIGABRT from a torn / cable=0/CIN=0 packet) only manifests
+ * when producers push WHILE the consumer drains and frees slots. A
+ * producer-vs-producer-only test cannot reproduce it.
  *
  * Build + run:
  *   cc tests/host/test_midi_inject_writer.c -Isrc/host -lpthread \
@@ -16,209 +20,230 @@
 
 #include <assert.h>
 #include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "shadow_midi_inject_writer.h"
 
+/* ------------------------------------------------------------------ *
+ * Packet encoding: byte 0 is a fixed non-zero CIN (0x09 = note-on).
+ * The remaining 3 bytes carry a 24-bit unique id so the consumer can
+ * verify exactly-once delivery. byte 0 == 0 is the SIGABRT smoking gun
+ * (cable=0/CIN=0 → Move reads "misc function" → abort), so every
+ * consumed packet MUST have byte 0 == 0x09.
+ * ------------------------------------------------------------------ */
+static inline void encode_pkt(uint8_t pkt[4], uint32_t id) {
+    pkt[0] = 0x09;
+    pkt[1] = (uint8_t)(id >> 16);
+    pkt[2] = (uint8_t)(id >> 8);
+    pkt[3] = (uint8_t)(id);
+}
+static inline uint32_t decode_id(const uint8_t pkt[4]) {
+    return ((uint32_t)pkt[1] << 16) | ((uint32_t)pkt[2] << 8) | pkt[3];
+}
+
+/* ------------------------------------------------------------------ */
+/* Single-threaded correctness                                         */
 /* ------------------------------------------------------------------ */
 
-static void test_single_push(void) {
-    shadow_midi_inject_t shm = {0};
-    uint8_t pkt[4] = {0x09, 0x90, 60, 100};
+static void test_single_push_peek_pop(void) {
+    shadow_midi_inject_t shm;
+    shadow_midi_inject_init(&shm);
 
-    int rc = shadow_midi_inject_push(&shm, pkt);
-    assert(rc == 0);
+    uint8_t pkt[4], out[4];
+    encode_pkt(pkt, 0xABCDE);
 
-    assert(shm.alloc_idx == 4);
-    assert(shm.commit_idx == 4);
-    assert(shm.ready == 1);
-    assert(memcmp(shm.buffer, pkt, 4) == 0);
+    assert(shadow_midi_inject_peek(&shm, out) == 0);  /* empty */
+    assert(shadow_midi_inject_push(&shm, pkt) == 0);
+    assert(shadow_midi_inject_peek(&shm, out) == 1);
+    assert(memcmp(out, pkt, 4) == 0);
+    /* peek does not consume — peeking again yields the same packet */
+    assert(shadow_midi_inject_peek(&shm, out) == 1);
+    assert(memcmp(out, pkt, 4) == 0);
+    shadow_midi_inject_pop(&shm);
+    assert(shadow_midi_inject_peek(&shm, out) == 0);  /* empty again */
 
-    printf("  test_single_push                     PASS\n");
+    printf("  test_single_push_peek_pop            PASS\n");
 }
 
-static void test_sequential_pushes_advance_cursors(void) {
-    shadow_midi_inject_t shm = {0};
+static void test_sequential_fifo(void) {
+    shadow_midi_inject_t shm;
+    shadow_midi_inject_init(&shm);
 
-    for (int i = 0; i < 10; i++) {
-        uint8_t pkt[4] = {0x09, 0x90, (uint8_t)(60 + i), 100};
+    for (uint32_t i = 0; i < 10; i++) {
+        uint8_t pkt[4]; encode_pkt(pkt, 1000 + i);
         assert(shadow_midi_inject_push(&shm, pkt) == 0);
-        assert(shm.alloc_idx == (i + 1) * 4);
-        assert(shm.commit_idx == (i + 1) * 4);
-        assert(shm.ready == (uint8_t)(i + 1));
-        /* Note byte == 60+i is at offset (i*4 + 2) */
-        assert(shm.buffer[i * 4 + 2] == (uint8_t)(60 + i));
     }
+    for (uint32_t i = 0; i < 10; i++) {
+        uint8_t out[4];
+        assert(shadow_midi_inject_peek(&shm, out) == 1);
+        assert(out[0] == 0x09);
+        assert(decode_id(out) == 1000 + i);  /* FIFO order */
+        shadow_midi_inject_pop(&shm);
+    }
+    assert(shadow_midi_inject_peek(&shm, (uint8_t[4]){0}) == 0);
 
-    printf("  test_sequential_pushes_advance       PASS\n");
+    printf("  test_sequential_fifo                 PASS\n");
 }
 
-static void test_buffer_full_rejection(void) {
-    shadow_midi_inject_t shm = {0};
-    uint8_t pkt[4] = {0x09, 0x90, 60, 100};
+static void test_full_capacity_and_recovery(void) {
+    shadow_midi_inject_t shm;
+    shadow_midi_inject_init(&shm);
 
-    /* Buffer holds 256 bytes / 4 per packet = 64 slots, but the bounds
-     * check uses `>= 256` so the last legal slot start is 252. That
-     * gives 63 successful pushes, then -1. */
-    int n_ok = 0;
-    int rc;
+    /* A bounded MPSC ring holds exactly SLOTS items when empty — not
+     * SLOTS-1. (The prior byte-ring's `>= SIZE` bound lost one slot.) */
+    uint8_t pkt[4]; encode_pkt(pkt, 1);
+    int n_ok = 0, rc;
     while ((rc = shadow_midi_inject_push(&shm, pkt)) == 0) n_ok++;
     assert(rc == -1);
-    assert(n_ok == 63);
-    assert(shm.alloc_idx == 252);
-    assert(shm.commit_idx == 252);
+    assert(n_ok == SHADOW_MIDI_INJECT_SLOTS);  /* full capacity, no off-by-one */
 
-    printf("  test_buffer_full_rejection           PASS\n");
+    /* Drain a few, then pushes succeed again (slots recycle). */
+    uint8_t out[4];
+    for (int i = 0; i < 3; i++) { assert(shadow_midi_inject_peek(&shm, out) == 1); shadow_midi_inject_pop(&shm); }
+    for (int i = 0; i < 3; i++) assert(shadow_midi_inject_push(&shm, pkt) == 0);
+    assert(shadow_midi_inject_push(&shm, pkt) == -1);  /* full again */
+
+    printf("  test_full_capacity_and_recovery      PASS\n");
 }
 
 /* ------------------------------------------------------------------ */
-/* Concurrent producers                                                */
+/* Concurrent producers + concurrent consumer (the real hazard)        */
 /* ------------------------------------------------------------------ */
 
-#define N_THREADS 8
-#define WRITES_PER_THREAD 7  /* 8 * 7 = 56 packets, fits in 63-slot buffer */
+#define N_THREADS         8
+#define WRITES_PER_THREAD 4000           /* 8 * 4000 = 32000 packets total */
+#define TOTAL_PACKETS     (N_THREADS * WRITES_PER_THREAD)
+#define PUSH_RETRY_CAP    200000000      /* sanity bound; never hit if healthy */
 
 typedef struct {
     shadow_midi_inject_t *shm;
-    uint8_t marker;       /* unique per thread, written into pkt[2] */
-    int stranded_count;   /* how many pushes returned -2 */
+    uint32_t base_id;    /* this thread owns ids [base_id, base_id + WRITES_PER_THREAD) */
+    long     retries;    /* how many -1 (full) we spun through */
 } writer_arg_t;
 
 static void *writer_thread(void *arg_) {
     writer_arg_t *arg = arg_;
-    uint8_t pkt[4] = {0x09, 0x90, arg->marker, 100};
-    for (int i = 0; i < WRITES_PER_THREAD; i++) {
-        int rc = shadow_midi_inject_push(arg->shm, pkt);
-        if (rc == 0) continue;
-        if (rc == -2) {
-            arg->stranded_count++;
-            continue;
+    for (uint32_t i = 0; i < WRITES_PER_THREAD; i++) {
+        uint8_t pkt[4]; encode_pkt(pkt, arg->base_id + i);
+        long attempts = 0;
+        while (shadow_midi_inject_push(arg->shm, pkt) != 0) {
+            /* Ring momentarily full — the consumer will free a slot. Retry.
+             * -1 is the ONLY failure code; it must clear, never wedge. */
+            if (++attempts > PUSH_RETRY_CAP) {
+                fprintf(stderr, "writer base=%u stuck at i=%u (ring never drained)\n",
+                        arg->base_id, i);
+                exit(1);
+            }
+            sched_yield();
         }
-        fprintf(stderr, "writer %u: unexpected rc=%d on iter %d\n",
-                arg->marker, rc, i);
-        exit(1);
+        arg->retries += attempts;
     }
     return NULL;
 }
 
-static void test_concurrent_no_collision(void) {
-    shadow_midi_inject_t shm = {0};
-    pthread_t threads[N_THREADS];
-    writer_arg_t args[N_THREADS];
+typedef struct {
+    shadow_midi_inject_t *shm;
+    uint8_t *seen;        /* seen[id]++ — consumer-only, so plain array is fine */
+    long     consumed;
+    int      done;        /* set by main once producers have joined */
+    int      torn;        /* count of torn/garbage packets (must stay 0) */
+} reader_arg_t;
 
-    for (int i = 0; i < N_THREADS; i++) {
-        args[i] = (writer_arg_t){
-            .shm = &shm,
-            .marker = (uint8_t)(0x10 + i),
-            .stranded_count = 0,
-        };
-        int err = pthread_create(&threads[i], NULL, writer_thread, &args[i]);
-        assert(err == 0);
-    }
-    for (int i = 0; i < N_THREADS; i++) {
-        pthread_join(threads[i], NULL);
-    }
-
-    /* Total successful pushes = N_THREADS * WRITES_PER_THREAD - stranded */
-    int total_stranded = 0;
-    for (int i = 0; i < N_THREADS; i++) total_stranded += args[i].stranded_count;
-    int total_committed = N_THREADS * WRITES_PER_THREAD - total_stranded;
-
-    /* Cursors must equal 4 * total_committed (each push advances by 4
-     * on success) plus 4 * total_stranded on alloc_idx (reservations
-     * succeeded but never committed). */
-    int total_reserved = N_THREADS * WRITES_PER_THREAD;
-    assert(shm.alloc_idx == total_reserved * 4);
-    /* commit_idx may stop short if any thread stranded — but only if
-     * the strand happened MID-sequence. With our spin limit and the
-     * realistic test load, stranding should be near-zero. */
-    if (total_stranded == 0) {
-        assert(shm.commit_idx == total_committed * 4);
-        assert(shm.ready == (uint8_t)total_committed);
-    } else {
-        printf("    (note: %d packets stranded — unusual under test load)\n",
-               total_stranded);
-    }
-
-    /* Every committed slot must contain a real marker byte (0x10..0x17),
-     * never zero. This is the smoking-gun assertion for the bug we're
-     * fixing: with the old racy writer, two threads could clobber the
-     * same slot and one packet would be silently lost — observable here
-     * as a slot containing 0x00 in pkt[2] or pkt[0]. */
-    for (int i = 0; i < total_committed; i++) {
-        uint8_t cin    = shm.buffer[i * 4 + 0];
-        uint8_t status = shm.buffer[i * 4 + 1];
-        uint8_t note   = shm.buffer[i * 4 + 2];
-        uint8_t vel    = shm.buffer[i * 4 + 3];
-        assert(cin == 0x09);
-        assert(status == 0x90);
-        assert(note >= 0x10 && note <= (0x10 + N_THREADS - 1));
-        assert(vel == 100);
-    }
-
-    /* And every thread's writes are accounted for in some order. Count
-     * how many slots carry each marker; should equal WRITES_PER_THREAD
-     * minus that thread's stranded_count. */
-    int per_thread_seen[N_THREADS] = {0};
-    for (int i = 0; i < total_committed; i++) {
-        uint8_t marker = shm.buffer[i * 4 + 2];
-        per_thread_seen[marker - 0x10]++;
-    }
-    for (int t = 0; t < N_THREADS; t++) {
-        int expected = WRITES_PER_THREAD - args[t].stranded_count;
-        if (per_thread_seen[t] != expected) {
-            fprintf(stderr,
-                    "thread %d: expected %d packets, saw %d\n",
-                    t, expected, per_thread_seen[t]);
-            assert(0);
+static void *reader_thread(void *arg_) {
+    reader_arg_t *arg = arg_;
+    for (;;) {
+        uint8_t out[4];
+        if (shadow_midi_inject_peek(arg->shm, out)) {
+            /* Smoking gun: a torn / partially-written packet would show
+             * byte 0 == 0 (the cable=0/CIN=0 that aborts Move firmware),
+             * or an id outside the produced range. */
+            if (out[0] != 0x09) { arg->torn++; }
+            uint32_t id = decode_id(out);
+            if (id >= TOTAL_PACKETS) { arg->torn++; }
+            else { arg->seen[id]++; }
+            shadow_midi_inject_pop(arg->shm);
+            arg->consumed++;
+        } else if (__atomic_load_n(&arg->done, __ATOMIC_ACQUIRE) &&
+                   !shadow_midi_inject_peek(arg->shm, out)) {
+            /* Producers finished and the ring is drained → we're done. */
+            break;
+        } else {
+            sched_yield();
         }
     }
-
-    printf("  test_concurrent_no_collision         PASS\n");
+    return NULL;
 }
 
-/* ------------------------------------------------------------------ */
-/* Stress: repeated runs to catch low-probability races                */
-/* ------------------------------------------------------------------ */
+static void run_concurrent_case(int print) {
+    shadow_midi_inject_t shm;
+    shadow_midi_inject_init(&shm);
 
-static void test_stress_concurrent(void) {
-    /* Re-run the concurrent case 50× to flush out timing-sensitive bugs
-     * that only fire on rare interleavings. Total ~50 * 56 = 2800
-     * packets, all should commit cleanly with no clobbering. */
-    for (int run = 0; run < 50; run++) {
-        shadow_midi_inject_t shm = {0};
-        pthread_t threads[N_THREADS];
-        writer_arg_t args[N_THREADS];
-        for (int i = 0; i < N_THREADS; i++) {
-            args[i] = (writer_arg_t){.shm = &shm,
-                                     .marker = (uint8_t)(0x10 + i)};
-            pthread_create(&threads[i], NULL, writer_thread, &args[i]);
-        }
-        for (int i = 0; i < N_THREADS; i++) pthread_join(threads[i], NULL);
+    uint8_t *seen = calloc(TOTAL_PACKETS, 1);
+    assert(seen);
 
-        int total = 0;
-        for (int t = 0; t < N_THREADS; t++)
-            total += WRITES_PER_THREAD - args[t].stranded_count;
+    pthread_t producers[N_THREADS], consumer;
+    writer_arg_t wargs[N_THREADS];
+    reader_arg_t rarg = { .shm = &shm, .seen = seen, .consumed = 0, .done = 0, .torn = 0 };
 
-        for (int i = 0; i < total; i++) {
-            assert(shm.buffer[i * 4 + 0] == 0x09);
-            uint8_t marker = shm.buffer[i * 4 + 2];
-            assert(marker >= 0x10 && marker < 0x10 + N_THREADS);
-        }
+    /* Start the consumer first so it's already draining as producers ramp. */
+    assert(pthread_create(&consumer, NULL, reader_thread, &rarg) == 0);
+    for (int i = 0; i < N_THREADS; i++) {
+        wargs[i] = (writer_arg_t){ .shm = &shm,
+                                   .base_id = (uint32_t)i * WRITES_PER_THREAD,
+                                   .retries = 0 };
+        assert(pthread_create(&producers[i], NULL, writer_thread, &wargs[i]) == 0);
     }
-    printf("  test_stress_concurrent (x50)         PASS\n");
+    for (int i = 0; i < N_THREADS; i++) pthread_join(producers[i], NULL);
+    __atomic_store_n(&rarg.done, 1, __ATOMIC_RELEASE);
+    pthread_join(consumer, NULL);
+
+    /* No torn / garbage packets ever reached the consumer. */
+    assert(rarg.torn == 0);
+    /* Exactly-once delivery: every produced id consumed exactly once. */
+    assert(rarg.consumed == TOTAL_PACKETS);
+    long missing = 0, dup = 0;
+    for (long id = 0; id < TOTAL_PACKETS; id++) {
+        if (seen[id] == 0) missing++;
+        else if (seen[id] > 1) dup++;
+    }
+    if (missing || dup) {
+        fprintf(stderr, "delivery error: missing=%ld duplicated=%ld\n", missing, dup);
+        assert(0);
+    }
+
+    long total_retries = 0;
+    for (int i = 0; i < N_THREADS; i++) total_retries += wargs[i].retries;
+    if (print) {
+        printf("  test_concurrent_producers_consumer   PASS  (%d pkts, %ld full-retries)\n",
+               TOTAL_PACKETS, total_retries);
+    }
+    free(seen);
+}
+
+static void test_concurrent_producers_consumer(void) {
+    run_concurrent_case(1);
+}
+
+/* Repeat the concurrent case to shake out rare interleavings. */
+static void test_stress_concurrent(void) {
+    for (int run = 0; run < 20; run++) {
+        run_concurrent_case(0);
+    }
+    printf("  test_stress_concurrent (x20)         PASS\n");
 }
 
 /* ------------------------------------------------------------------ */
 
 int main(void) {
-    printf("shadow_midi_inject_writer tests:\n");
-    test_single_push();
-    test_sequential_pushes_advance_cursors();
-    test_buffer_full_rejection();
-    test_concurrent_no_collision();
+    printf("shadow_midi_inject_writer tests (Vyukov MPSC):\n");
+    test_single_push_peek_pop();
+    test_sequential_fifo();
+    test_full_capacity_and_recovery();
+    test_concurrent_producers_consumer();
     test_stress_concurrent();
     printf("ALL PASS\n");
     return 0;

--- a/tests/host/test_midi_inject_writer.c
+++ b/tests/host/test_midi_inject_writer.c
@@ -1,0 +1,225 @@
+/*
+ * Host-side unit tests for shadow_midi_inject_writer.h.
+ *
+ * Runs on the dev machine (Mac/Linux), not on Move. Validates the MPSC
+ * helper standalone — no SHM, no shim, no QuickJS — by stack-allocating
+ * a shadow_midi_inject_t and pounding it with single-threaded and
+ * multi-threaded producers.
+ *
+ * Build + run:
+ *   cc tests/host/test_midi_inject_writer.c -Isrc/host -lpthread \
+ *      -O2 -Wall -Wextra -Wno-unused-parameter -o /tmp/test_inject \
+ *   && /tmp/test_inject
+ *
+ * Or via the Makefile in this directory: `make -C tests/host test`.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shadow_midi_inject_writer.h"
+
+/* ------------------------------------------------------------------ */
+
+static void test_single_push(void) {
+    shadow_midi_inject_t shm = {0};
+    uint8_t pkt[4] = {0x09, 0x90, 60, 100};
+
+    int rc = shadow_midi_inject_push(&shm, pkt);
+    assert(rc == 0);
+
+    assert(shm.alloc_idx == 4);
+    assert(shm.commit_idx == 4);
+    assert(shm.ready == 1);
+    assert(memcmp(shm.buffer, pkt, 4) == 0);
+
+    printf("  test_single_push                     PASS\n");
+}
+
+static void test_sequential_pushes_advance_cursors(void) {
+    shadow_midi_inject_t shm = {0};
+
+    for (int i = 0; i < 10; i++) {
+        uint8_t pkt[4] = {0x09, 0x90, (uint8_t)(60 + i), 100};
+        assert(shadow_midi_inject_push(&shm, pkt) == 0);
+        assert(shm.alloc_idx == (i + 1) * 4);
+        assert(shm.commit_idx == (i + 1) * 4);
+        assert(shm.ready == (uint8_t)(i + 1));
+        /* Note byte == 60+i is at offset (i*4 + 2) */
+        assert(shm.buffer[i * 4 + 2] == (uint8_t)(60 + i));
+    }
+
+    printf("  test_sequential_pushes_advance       PASS\n");
+}
+
+static void test_buffer_full_rejection(void) {
+    shadow_midi_inject_t shm = {0};
+    uint8_t pkt[4] = {0x09, 0x90, 60, 100};
+
+    /* Buffer holds 256 bytes / 4 per packet = 64 slots, but the bounds
+     * check uses `>= 256` so the last legal slot start is 252. That
+     * gives 63 successful pushes, then -1. */
+    int n_ok = 0;
+    int rc;
+    while ((rc = shadow_midi_inject_push(&shm, pkt)) == 0) n_ok++;
+    assert(rc == -1);
+    assert(n_ok == 63);
+    assert(shm.alloc_idx == 252);
+    assert(shm.commit_idx == 252);
+
+    printf("  test_buffer_full_rejection           PASS\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* Concurrent producers                                                */
+/* ------------------------------------------------------------------ */
+
+#define N_THREADS 8
+#define WRITES_PER_THREAD 7  /* 8 * 7 = 56 packets, fits in 63-slot buffer */
+
+typedef struct {
+    shadow_midi_inject_t *shm;
+    uint8_t marker;       /* unique per thread, written into pkt[2] */
+    int stranded_count;   /* how many pushes returned -2 */
+} writer_arg_t;
+
+static void *writer_thread(void *arg_) {
+    writer_arg_t *arg = arg_;
+    uint8_t pkt[4] = {0x09, 0x90, arg->marker, 100};
+    for (int i = 0; i < WRITES_PER_THREAD; i++) {
+        int rc = shadow_midi_inject_push(arg->shm, pkt);
+        if (rc == 0) continue;
+        if (rc == -2) {
+            arg->stranded_count++;
+            continue;
+        }
+        fprintf(stderr, "writer %u: unexpected rc=%d on iter %d\n",
+                arg->marker, rc, i);
+        exit(1);
+    }
+    return NULL;
+}
+
+static void test_concurrent_no_collision(void) {
+    shadow_midi_inject_t shm = {0};
+    pthread_t threads[N_THREADS];
+    writer_arg_t args[N_THREADS];
+
+    for (int i = 0; i < N_THREADS; i++) {
+        args[i] = (writer_arg_t){
+            .shm = &shm,
+            .marker = (uint8_t)(0x10 + i),
+            .stranded_count = 0,
+        };
+        int err = pthread_create(&threads[i], NULL, writer_thread, &args[i]);
+        assert(err == 0);
+    }
+    for (int i = 0; i < N_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    /* Total successful pushes = N_THREADS * WRITES_PER_THREAD - stranded */
+    int total_stranded = 0;
+    for (int i = 0; i < N_THREADS; i++) total_stranded += args[i].stranded_count;
+    int total_committed = N_THREADS * WRITES_PER_THREAD - total_stranded;
+
+    /* Cursors must equal 4 * total_committed (each push advances by 4
+     * on success) plus 4 * total_stranded on alloc_idx (reservations
+     * succeeded but never committed). */
+    int total_reserved = N_THREADS * WRITES_PER_THREAD;
+    assert(shm.alloc_idx == total_reserved * 4);
+    /* commit_idx may stop short if any thread stranded — but only if
+     * the strand happened MID-sequence. With our spin limit and the
+     * realistic test load, stranding should be near-zero. */
+    if (total_stranded == 0) {
+        assert(shm.commit_idx == total_committed * 4);
+        assert(shm.ready == (uint8_t)total_committed);
+    } else {
+        printf("    (note: %d packets stranded — unusual under test load)\n",
+               total_stranded);
+    }
+
+    /* Every committed slot must contain a real marker byte (0x10..0x17),
+     * never zero. This is the smoking-gun assertion for the bug we're
+     * fixing: with the old racy writer, two threads could clobber the
+     * same slot and one packet would be silently lost — observable here
+     * as a slot containing 0x00 in pkt[2] or pkt[0]. */
+    for (int i = 0; i < total_committed; i++) {
+        uint8_t cin    = shm.buffer[i * 4 + 0];
+        uint8_t status = shm.buffer[i * 4 + 1];
+        uint8_t note   = shm.buffer[i * 4 + 2];
+        uint8_t vel    = shm.buffer[i * 4 + 3];
+        assert(cin == 0x09);
+        assert(status == 0x90);
+        assert(note >= 0x10 && note <= (0x10 + N_THREADS - 1));
+        assert(vel == 100);
+    }
+
+    /* And every thread's writes are accounted for in some order. Count
+     * how many slots carry each marker; should equal WRITES_PER_THREAD
+     * minus that thread's stranded_count. */
+    int per_thread_seen[N_THREADS] = {0};
+    for (int i = 0; i < total_committed; i++) {
+        uint8_t marker = shm.buffer[i * 4 + 2];
+        per_thread_seen[marker - 0x10]++;
+    }
+    for (int t = 0; t < N_THREADS; t++) {
+        int expected = WRITES_PER_THREAD - args[t].stranded_count;
+        if (per_thread_seen[t] != expected) {
+            fprintf(stderr,
+                    "thread %d: expected %d packets, saw %d\n",
+                    t, expected, per_thread_seen[t]);
+            assert(0);
+        }
+    }
+
+    printf("  test_concurrent_no_collision         PASS\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* Stress: repeated runs to catch low-probability races                */
+/* ------------------------------------------------------------------ */
+
+static void test_stress_concurrent(void) {
+    /* Re-run the concurrent case 50× to flush out timing-sensitive bugs
+     * that only fire on rare interleavings. Total ~50 * 56 = 2800
+     * packets, all should commit cleanly with no clobbering. */
+    for (int run = 0; run < 50; run++) {
+        shadow_midi_inject_t shm = {0};
+        pthread_t threads[N_THREADS];
+        writer_arg_t args[N_THREADS];
+        for (int i = 0; i < N_THREADS; i++) {
+            args[i] = (writer_arg_t){.shm = &shm,
+                                     .marker = (uint8_t)(0x10 + i)};
+            pthread_create(&threads[i], NULL, writer_thread, &args[i]);
+        }
+        for (int i = 0; i < N_THREADS; i++) pthread_join(threads[i], NULL);
+
+        int total = 0;
+        for (int t = 0; t < N_THREADS; t++)
+            total += WRITES_PER_THREAD - args[t].stranded_count;
+
+        for (int i = 0; i < total; i++) {
+            assert(shm.buffer[i * 4 + 0] == 0x09);
+            uint8_t marker = shm.buffer[i * 4 + 2];
+            assert(marker >= 0x10 && marker < 0x10 + N_THREADS);
+        }
+    }
+    printf("  test_stress_concurrent (x50)         PASS\n");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+    printf("shadow_midi_inject_writer tests:\n");
+    test_single_push();
+    test_sequential_pushes_advance_cursors();
+    test_buffer_full_rejection();
+    test_concurrent_no_collision();
+    test_stress_concurrent();
+    printf("ALL PASS\n");
+    return 0;
+}

--- a/tests/shadow/midi_inject_test.c
+++ b/tests/shadow/midi_inject_test.c
@@ -24,6 +24,7 @@
 #include <sys/mman.h>
 
 #include "host/shadow_constants.h"
+#include "host/shadow_midi_inject_writer.h"
 
 static shadow_midi_inject_t *inject_shm = NULL;
 
@@ -47,27 +48,21 @@ static int open_inject_shm(void)
     return 0;
 }
 
-/* Write a single USB-MIDI packet: [CIN|cable, status, d1, d2] */
+/* Write a single USB-MIDI packet: [CIN|cable, status, d1, d2].
+ * Goes through the shared MPSC helper which handles cursor reservation,
+ * commit ordering, and the ready bump. */
 static void write_packet(uint8_t cin, uint8_t status, uint8_t d1, uint8_t d2)
 {
-    int idx = inject_shm->write_idx;
-    if (idx + 4 > SHADOW_MIDI_INJECT_BUFFER_SIZE) {
-        fprintf(stderr, "Buffer full\n");
-        return;
-    }
-    inject_shm->buffer[idx]     = cin;       /* CIN nibble, cable 0 */
-    inject_shm->buffer[idx + 1] = status;
-    inject_shm->buffer[idx + 2] = d1;
-    inject_shm->buffer[idx + 3] = d2;
-    inject_shm->write_idx = idx + 4;
+    const uint8_t pkt[4] = {cin, status, d1, d2};
+    int rc = shadow_midi_inject_push(inject_shm, pkt);
+    if (rc == -1) fprintf(stderr, "Buffer full\n");
+    else if (rc == -2) fprintf(stderr, "Prior producer stranded\n");
 }
 
-/* Signal the shim that data is ready */
-static void flush(void)
-{
-    __sync_synchronize();
-    inject_shm->ready++;
-}
+/* No-op: the helper already bumps `ready` per-packet. Kept so existing
+ * call sites that expect a flush() compile cleanly without behavior
+ * change. */
+static void flush(void) {}
 
 /* Send note-on, wait, send note-off */
 static void cmd_pad(int note, int velocity)


### PR DESCRIPTION
Clean rebase of **#106** (by @flagist0) onto current `main`. The original branch forked before `main`'s history rewrite, so it shows as conflicting on GitHub despite having no real conflict. These are its two substantive commits cherry-picked onto current `main` (authorship preserved), applied with zero conflicts.

## What it fixes
MoveOriginal SIGABRT during overtake entry/exit when another MIDI injection coincides. The `/schwung-midi-inject` ring was de-facto multi-producer (JS host, shim overtake inject, cable-2 forwarder) but coded as single-writer; a producer preempted between cursor-advance and memcpy could let the drain forward a reserved-but-unwritten slot (cable=0/CIN=0 → SIGABRT, per `shadow_midi.c:553`).

## Commits
- `MPSC-safe ring contract` — initial alloc/commit cursor split.
- `redesign ring as a bounded MPSC queue (address review)` — supersedes the above per maintainer review with Dmitry Vyukov's bounded MPSC queue (per-slot sequence numbers): consumer never resets/memsets, every cursor/seq access is `__atomic`, exact SLOTS capacity, host stress test with a concurrent consumer (32k packets/run × 20). ThreadSanitizer-clean.

Supersedes #106 — close that in favor of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)