### PR TITLE
Validate plugin JSONs + correct param-buffer limit (rebased #120)

### DIFF
--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -462,8 +462,8 @@ int v2_load_synth(chain_instance_t *inst, const char *module_name) {
         }
         free(temp_buf);
 
-        if (cp_len >= 32768 - 1 || ui_len >= SHADOW_PARAM_VALUE_LEN - 1) {
-            snprintf(msg, sizeof(msg), "Synth %s UI or param JSON too large (chain_params: %d, ui_hierarchy: %d). Max cp:32767 ui:%d.", 
+        if (cp_len >= SHADOW_PARAM_VALUE_LEN - 1 || ui_len >= SHADOW_PARAM_VALUE_LEN - 1) {
+            snprintf(msg, sizeof(msg), "Synth %s UI or param JSON too large (chain_params: %d, ui_hierarchy: %d). Max %d.", 
                      module_name, cp_len, ui_len, SHADOW_PARAM_VALUE_LEN - 1);
             v2_chain_log(inst, msg);
             snprintf(inst->synth_load_error, sizeof(inst->synth_load_error), "UI buffer overflow");

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -116,6 +116,10 @@ void v2_synth_panic(chain_instance_t *inst) {
 static int v2_synth_get_error(chain_instance_t *inst, char *buf, int buf_len) {
     if (!inst) return 0;
 
+    if (inst->synth_load_error[0] != '\0') {
+        return snprintf(buf, buf_len, "%s", inst->synth_load_error);
+    }
+
     if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_error) {
         return inst->synth_plugin_v2->get_error(inst->synth_instance, buf, buf_len);
     }
@@ -125,6 +129,7 @@ static int v2_synth_get_error(chain_instance_t *inst, char *buf, int buf_len) {
 /* V2 unload synth */
 void v2_unload_synth(chain_instance_t *inst) {
     if (!inst) return;
+    inst->synth_load_error[0] = '\0';
     chain_mod_clear_target_entries(inst, "synth", 0);
 
     if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->destroy_instance) {
@@ -409,6 +414,7 @@ int v2_load_synth(chain_instance_t *inst, const char *module_name) {
     char dsp_path[MAX_PATH_LEN];
     snprintf(dsp_path, sizeof(dsp_path), "%s/dsp.so", synth_path);
 
+    inst->synth_load_error[0] = '\0';
     snprintf(msg, sizeof(msg), "Loading synth: %s", dsp_path);
     v2_chain_log(inst, msg);
 
@@ -443,6 +449,37 @@ int v2_load_synth(chain_instance_t *inst, const char *module_name) {
         v2_chain_log(inst, msg);
         dlclose(handle);
         return -1;
+    }
+
+    /* Check UI and parameters JSON buffer size limits */
+    char *temp_buf = (char*)malloc(262144);
+    if (temp_buf) {
+        int cp_len = 0;
+        int ui_len = 0;
+        if (api->get_param) {
+            cp_len = api->get_param(synth_inst, "chain_params", temp_buf, 262144);
+            ui_len = api->get_param(synth_inst, "ui_hierarchy", temp_buf, 262144);
+        }
+        free(temp_buf);
+
+        if (cp_len >= 32768 - 1 || ui_len >= SHADOW_PARAM_VALUE_LEN - 1) {
+            snprintf(msg, sizeof(msg), "Synth %s UI or param JSON too large (chain_params: %d, ui_hierarchy: %d). Max cp:32767 ui:%d.", 
+                     module_name, cp_len, ui_len, SHADOW_PARAM_VALUE_LEN - 1);
+            v2_chain_log(inst, msg);
+            snprintf(inst->synth_load_error, sizeof(inst->synth_load_error), "UI buffer overflow");
+            
+            api->destroy_instance(synth_inst);
+            
+            /* Proceed as success with NULL synth_instance so UI loads and displays error */
+            inst->synth_handle = handle;
+            inst->synth_plugin_v2 = api;
+            inst->synth_instance = NULL;
+            strncpy(inst->current_synth_module, module_name, MAX_NAME_LEN - 1);
+            
+            parse_chain_params(synth_path, inst->synth_params, &inst->synth_param_count);
+            inst->mod_param_refresh_ms_synth = 0;
+            return 0;
+        }
     }
 
     inst->synth_handle = handle;

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -35,6 +35,7 @@
 #include "host/midi_fx_api_v1.h"
 #include "host/lfo_common.h"
 #include "../../../host/unified_log.h"
+#include "../../../host/shadow_constants.h"
 
 /* Limits */
 #define MAX_PATCHES 32      /* Max patches to list in browser */
@@ -354,6 +355,9 @@ typedef struct chain_instance {
      * module.json; shim must never park the slot as fx_idle so stateful FX
      * (loopers, modulated delays) keep advancing internal time during silence. */
     int fx_requires_continuous[MAX_AUDIO_FX];
+    
+    /* Synth load error message */
+    char synth_load_error[256];
 } chain_instance_t;
 
 #define CHAIN_INTERNAL __attribute__((visibility("hidden")))

--- a/src/modules/chain/dsp/chain_mod.c
+++ b/src/modules/chain/dsp/chain_mod.c
@@ -474,7 +474,7 @@ void chain_mod_clear_source(void *ctx, const char *source_id) {
 int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target) {
     if (!inst || !target) return -1;
 
-    char buf[32768];
+    char buf[SHADOW_PARAM_VALUE_LEN];
     int result = -1;
     chain_param_info_t parsed[MAX_CHAIN_PARAMS];
     int parsed_count = -1;

--- a/src/modules/chain/ui.js
+++ b/src/modules/chain/ui.js
@@ -2221,23 +2221,30 @@ function drawUI() {
 
     /* Synth module info with bank name */
     const synthDisplay = getComponentName("synth", synthModule) || "SF2";
-    const bankName = host_module_get_param("bank_name");
-    if (bankName) {
-        print(2, 20, `${synthDisplay}  ${bankName}`, 1);
+    const synthError = host_module_get_param("synth_error") || host_module_get_param("load_error");
+    if (synthError) {
+        print(2, 20, `${synthDisplay}: Error`, 1);
+        print(2, 32, synthError.substring(0, 21), 1);
+        print(2, 44, "Check debug.log", 1);
     } else {
-        print(2, 20, synthDisplay, 1);
-    }
+        const bankName = host_module_get_param("bank_name");
+        if (bankName) {
+            print(2, 20, `${synthDisplay}  ${bankName}`, 1);
+        } else {
+            print(2, 20, synthDisplay, 1);
+        }
 
-    /* Preset from synth with number */
-    const pn = host_module_get_param("preset_name");
-    const pib = host_module_get_param("patch_in_bank");
-    if (pn) {
-        presetName = pn.substring(0, 16);
-    }
-    if (pib) {
-        print(2, 32, `#${pib} ${presetName}`, 1);
-    } else {
-        print(2, 32, presetName, 1);
+        /* Preset from synth with number */
+        const pn = host_module_get_param("preset_name");
+        const pib = host_module_get_param("patch_in_bank");
+        if (pn) {
+            presetName = pn.substring(0, 16);
+        }
+        if (pib) {
+            print(2, 32, `#${pib} ${presetName}`, 1);
+        } else {
+            print(2, 32, presetName, 1);
+        }
     }
 
     /* Octave and polyphony */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -7290,6 +7290,11 @@ function enterComponentEdit(slotIndex, componentKey) {
     selectedSlot = slotIndex;
     editingComponentKey = componentKey;
 
+    /* Check for synth load errors first to show a warning overlay */
+    if (componentKey === "synth" && checkAndShowSynthError(slotIndex)) {
+        return;
+    }
+
     /* Try hierarchy editor first (for plugins with ui_hierarchy) */
     const hierarchy = getComponentHierarchy(slotIndex, componentKey);
     debugLog(`enterComponentEdit: hierarchy=${hierarchy ? 'found' : 'null'}`);
@@ -12614,6 +12619,21 @@ function drawComponentEdit() {
     drawHeader(headerText);
 
     const centerY = 32;
+
+    /* Check for load error */
+    const synthError = getSlotParam(selectedSlot, "synth_error");
+    if (editingComponentKey === "synth" && synthError && synthError.length > 0) {
+        const titleText = "ERROR LOADING";
+        const titleX = Math.floor((SCREEN_WIDTH - titleText.length * 5) / 2);
+        print(titleX, centerY - 10, titleText, 1);
+
+        const errorText = truncateText(synthError, 24);
+        const errorX = Math.floor((SCREEN_WIDTH - errorText.length * 5) / 2);
+        print(errorX, centerY + 2, errorText, 1);
+
+        drawFooter({left: "Back: done"});
+        return;
+    }
 
     /* Re-fetch preset count if zero (module may still be loading) */
     if (editComponentPresetCount === 0) {


### PR DESCRIPTION
Clean rebase of **#120** (by @andree182, implements #100) onto current `main`. The original branch forked before `main`'s history rewrite and shows as conflicting despite no real conflict. Its two substantive commits cherry-picked onto current `main` (authorship preserved), zero conflicts.

## What it does
- **Show buffer-overflow errors for synth plugins** — surfaces oversized/invalid plugin JSON to the user in the chain + shadow UI instead of silently truncating.
- **Clarify the 32 KiB param limit** — `chain_mod_refresh_target_param_cache()` used a hardcoded 32 KiB where it should be `SHADOW_PARAM_VALUE_LEN` (as its own comment states).

Net: +84/−16 across `chain_host.c`, `chain_internal.h`, `chain_mod.c`, `chain/ui.js`, `shadow_ui.js`.

Note: the AMY-synth catalog add mentioned in #120's description is not included here — its patch-id already matches `main`, so only the validation/limit work is new.

Supersedes #120 — close that in favor of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)