### PR TITLE
catalog: add War Bells (audio_fx)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1012,6 +1012,17 @@
       "default_branch": "master",
       "asset_name": "aphex-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "war_bells",
+      "name": "War Bells",
+      "description": "Granular / glitch / delay / looper multi-FX: 11 effects x 4 variations, 4-mode reverb with shimmer + tone, resonant filter, 60s looper",
+      "author": "seajaysec",
+      "component_type": "audio_fx",
+      "github_repo": "seajaysec/war-bells",
+      "default_branch": "main",
+      "asset_name": "war_bells-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1016,7 +1016,7 @@
     {
       "id": "war_bells",
       "name": "War Bells",
-      "description": "Granular / glitch / delay / looper multi-FX: 11 effects x 4 variations, 4-mode reverb with shimmer + tone, resonant filter, 60s looper",
+      "description": "Granular/glitch/delay/looper multi-FX: 11 effects x 4 variations, shimmer reverb + tone, generative Motion/Evolve, Hold sampler, resonant filter, 60s looper",
       "author": "seajay",
       "component_type": "audio_fx",
       "github_repo": "seajaysec/war-bells",

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1017,7 +1017,7 @@
       "id": "war_bells",
       "name": "War Bells",
       "description": "Granular / glitch / delay / looper multi-FX: 11 effects x 4 variations, 4-mode reverb with shimmer + tone, resonant filter, 60s looper",
-      "author": "seajaysec",
+      "author": "seajay",
       "component_type": "audio_fx",
       "github_repo": "seajaysec/war-bells",
       "default_branch": "main",


### PR DESCRIPTION
Adds **War Bells** to `module-catalog.json` — a hand-written C `audio_fx` module for the Move.

**War Bells** is a granular / glitch / delay / looper multi-FX: 11 effects across 4 families (44 variations), four grain envelopes, a Hold sampler, a 4-mode stereo reverb with **shimmer** and a new **send-tone** (hi/lo-pass) control, a resonant low-pass filter, a tempo-synced Motion LFO, a generative Evolve/Dice engine, input-ducking, and a 60-second phrase looper with a 16-slot preset bank.

- **Repo:** https://github.com/seajaysec/war-bells (AGPL-3.0)
- **Interactive demo + manual:** https://seajaysec.github.io/war-bells/
- It also ships a custom `web_ui.html` (live controller from the Move, demo+manual when hosted).

Catalog requirements:

- [x] `release.json` on `main` with `version` + `download_url`
- [x] Tagged GitHub Release with the `war_bells-module.tar.gz` asset, packed as `war_bells/module.json` + `war_bells.so` + `ui_chain.js` + `web_ui.html` + `help.json`
- [x] `min_host_version: 0.3.0` (matching the other `audio_fx` modules)
- [x] `component_type: audio_fx`, `default_branch: main`

Happy to adjust the description or version floor if you'd prefer different conventions.