### PR TITLE
feat(remote-ui): custom-UI pop-out/toggle/spinner + param re-fetch coalescing

### DIFF
--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -303,6 +303,17 @@ func (ru *RemoteUI) handleSubscribe(ctx context.Context, c *ruClient, msg wsMess
 	// Send slot info (which components are loaded).
 	ru.sendSlotInfo(ctx, c, slot)
 
+	// If the synth has a custom web UI, tell the browser FIRST — before the
+	// (potentially multi-second) sendSlotSettings retry block — so the iframe
+	// can start loading while we fetch the rest. The iframe seeds its values
+	// from the parent's cache once it subscribes, so it doesn't need settings
+	// or params to have arrived yet.
+	if synthID, err := ru.shm.GetParam(slot, "synth_module"); err == nil && synthID != "" {
+		if url := ru.findModuleWebUI(synthID); url != "" {
+			ru.sendCustomUI(ctx, c, slot, "synth", url)
+		}
+	}
+
 	// Send slot-level settings + mapped knobs FIRST so the top of the UI
 	// populates immediately — otherwise they'd be blocked behind potentially
 	// many seconds of sendInitialParamValues for param-heavy modules.
@@ -314,12 +325,6 @@ func (ru *RemoteUI) handleSubscribe(ctx context.Context, c *ruClient, msg wsMess
 		modID, err := ru.shm.GetParam(slot, moduleKey)
 		if err != nil || modID == "" {
 			continue
-		}
-		// Check for custom web UI (synth component only).
-		if comp == "synth" {
-			if url := ru.findModuleWebUI(modID); url != "" {
-				ru.sendCustomUI(ctx, c, slot, comp, url)
-			}
 		}
 		ru.sendHierarchy(ctx, c, slot, comp)
 		ru.sendChainParams(ctx, c, slot, comp)

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -208,9 +208,8 @@ func (ru *RemoteUI) refreshLoop(ctx context.Context) {
 				if err != nil || modID == "" {
 					continue
 				}
-				for _, c := range ru.subscribedClients(slot) {
-					ru.sendInitialParamValues(ctx, c, slot, comp)
-				}
+				// Read shm once and fan out to all subscribers of this slot.
+				ru.broadcastInitialParamValues(ctx, slot, comp, ru.subscribedClients(slot))
 			}
 		}
 	}
@@ -438,18 +437,19 @@ func (ru *RemoteUI) sendInitialParamValues(ctx context.Context, c *ruClient, slo
 	ru.logger.Info("initial params: done", "slot", slot, "comp", comp, "fetched", fetched)
 }
 
-// sendAllParamsAtOnce asks the plugin for the "state" key (a JSON object of
-// every param value used for save/restore). If the plugin supports it, sends
-// everything in one param_update. Returns true on success. Modules with many
-// params (e.g. Surge ~280) go from ~10s to one shm round-trip.
-func (ru *RemoteUI) sendAllParamsAtOnce(ctx context.Context, c *ruClient, slot uint8, comp string) bool {
+// fetchAllParams reads the plugin's "state" key (a JSON object of every param
+// value used for save/restore) and flattens it into a param_update payload.
+// Returns (nil, false) if the module doesn't support "state". This is the
+// expensive shm read, factored out so a single read can fan out to multiple
+// subscribers (see broadcastInitialParamValues).
+func (ru *RemoteUI) fetchAllParams(slot uint8, comp string) (map[string]string, bool) {
 	raw, err := ru.shm.GetParam(slot, comp+":state")
 	if err != nil || raw == "" || raw[0] != '{' {
-		return false
+		return nil, false
 	}
 	var values map[string]any
 	if json.Unmarshal([]byte(raw), &values) != nil {
-		return false
+		return nil, false
 	}
 	params := make(map[string]string, len(values))
 	for k, v := range values {
@@ -469,6 +469,17 @@ func (ru *RemoteUI) sendAllParamsAtOnce(ctx context.Context, c *ruClient, slot u
 		}
 	}
 	if len(params) == 0 {
+		return nil, false
+	}
+	return params, true
+}
+
+// sendAllParamsAtOnce sends a component's full param set to one client in a
+// single param_update. Returns true on success. Modules with many params
+// (e.g. Surge ~280) go from ~10s of fetches to one shm round-trip.
+func (ru *RemoteUI) sendAllParamsAtOnce(ctx context.Context, c *ruClient, slot uint8, comp string) bool {
+	params, ok := ru.fetchAllParams(slot, comp)
+	if !ok {
 		return false
 	}
 	ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: params})
@@ -476,12 +487,41 @@ func (ru *RemoteUI) sendAllParamsAtOnce(ctx context.Context, c *ruClient, slot u
 	return true
 }
 
-// sendHierarchyParams extracts preset-browser params (count_param, list_param,
-// name_param) from the ui_hierarchy and fetches their values.
-func (ru *RemoteUI) sendHierarchyParams(ctx context.Context, c *ruClient, slot uint8, comp string) {
+// broadcastInitialParamValues sends a component's full param set to every
+// subscriber of a slot, reading shared memory ONCE and fanning the result out —
+// instead of re-reading per client. Avoids redundant heavy shm reads (e.g. the
+// jv880 365-param "state" blob) when multiple clients view the same slot, such
+// as a popped-out window alongside the main tab. Falls back to the per-client
+// streaming path for modules that don't support the "state" fast path.
+func (ru *RemoteUI) broadcastInitialParamValues(ctx context.Context, slot uint8, comp string, clients []*ruClient) {
+	if len(clients) == 0 {
+		return
+	}
+	hierParams := ru.fetchHierarchyParams(slot, comp)
+	allParams, ok := ru.fetchAllParams(slot, comp)
+	if !ok {
+		// No "state" fast path — fall back to per-client streaming (unchanged).
+		for _, c := range clients {
+			ru.sendInitialParamValues(ctx, c, slot, comp)
+		}
+		return
+	}
+	for _, c := range clients {
+		if len(hierParams) > 0 {
+			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: hierParams})
+		}
+		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: allParams})
+	}
+	ru.logger.Info("initial params: sent via 'state' (coalesced)", "slot", slot, "comp", comp, "count", len(allParams), "clients", len(clients))
+}
+
+// fetchHierarchyParams reads the preset-browser params (count_param, list_param,
+// name_param) referenced by the ui_hierarchy and returns their values. Factored
+// out of sendHierarchyParams so the read can fan out to multiple subscribers.
+func (ru *RemoteUI) fetchHierarchyParams(slot uint8, comp string) map[string]string {
 	raw, err := ru.shm.GetParam(slot, comp+":ui_hierarchy")
 	if err != nil || raw == "" {
-		return
+		return nil
 	}
 
 	// Parse just enough to extract level params
@@ -493,7 +533,7 @@ func (ru *RemoteUI) sendHierarchyParams(ctx context.Context, c *ruClient, slot u
 		} `json:"levels"`
 	}
 	if json.Unmarshal([]byte(raw), &hier) != nil {
-		return
+		return nil
 	}
 
 	params := make(map[string]string)
@@ -510,6 +550,13 @@ func (ru *RemoteUI) sendHierarchyParams(ctx context.Context, c *ruClient, slot u
 			}
 		}
 	}
+	return params
+}
+
+// sendHierarchyParams extracts preset-browser params (count_param, list_param,
+// name_param) from the ui_hierarchy and sends their values to one client.
+func (ru *RemoteUI) sendHierarchyParams(ctx context.Context, c *ruClient, slot uint8, comp string) {
+	params := ru.fetchHierarchyParams(slot, comp)
 	if len(params) > 0 {
 		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: params})
 	}
@@ -897,18 +944,21 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					continue
 				}
 				lastResend[slot] = now
+				delete(pendingResend, slot)
+				// Coalesce the re-fetch: snapshot subscribers + comps, then read
+				// shm once per comp and fan out to all of them (cdbc123d), while
+				// keeping upstream's goroutine offload so the 5ms drain loop never
+				// blocks on a param-heavy module's sendInitialParamValues.
+				subs := ru.subscribedClients(slot)
 				compList := make([]string, 0, len(comps))
 				for comp := range comps {
 					compList = append(compList, comp)
 				}
-				delete(pendingResend, slot)
-				go func(slot uint8, comps []string) {
+				go func(slot uint8, comps []string, subs []*ruClient) {
 					for _, comp := range comps {
-						for _, c := range ru.subscribedClients(slot) {
-							ru.sendInitialParamValues(ctx, c, slot, comp)
-						}
+						ru.broadcastInitialParamValues(ctx, slot, comp, subs)
 					}
-				}(slot, compList)
+				}(slot, compList, subs)
 			}
 		}
 

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -303,15 +303,18 @@ func (ru *RemoteUI) handleSubscribe(ctx context.Context, c *ruClient, msg wsMess
 	// Send slot info (which components are loaded).
 	ru.sendSlotInfo(ctx, c, slot)
 
-	// If the synth has a custom web UI, tell the browser FIRST — before the
-	// (potentially multi-second) sendSlotSettings retry block — so the iframe
-	// can start loading while we fetch the rest. The iframe seeds its values
-	// from the parent's cache once it subscribes, so it doesn't need settings
-	// or params to have arrived yet.
+	// Give the synth priority: send its custom_ui (if any) AND its hierarchy +
+	// chain_params BEFORE the (potentially multi-second) sendSlotSettings retry
+	// block. A data-driven custom UI (e.g. jv880 builds its controls from
+	// chain_params) then has its metadata on the first request and renders
+	// immediately instead of polling for it; embedded-layout UIs just start
+	// loading sooner. The iframe seeds values from the parent cache on subscribe.
 	if synthID, err := ru.shm.GetParam(slot, "synth_module"); err == nil && synthID != "" {
 		if url := ru.findModuleWebUI(synthID); url != "" {
 			ru.sendCustomUI(ctx, c, slot, "synth", url)
 		}
+		ru.sendHierarchy(ctx, c, slot, "synth")
+		ru.sendChainParams(ctx, c, slot, "synth")
 	}
 
 	// Send slot-level settings + mapped knobs FIRST so the top of the UI
@@ -319,15 +322,18 @@ func (ru *RemoteUI) handleSubscribe(ctx context.Context, c *ruClient, msg wsMess
 	// many seconds of sendInitialParamValues for param-heavy modules.
 	ru.sendSlotSettings(ctx, c, slot)
 
-	// Send hierarchy and chain_params for all loaded components.
+	// Send hierarchy and chain_params for the remaining components, plus initial
+	// param values for every component (synth metadata already sent above).
 	for _, comp := range componentPrefixes {
 		moduleKey := comp + "_module"
 		modID, err := ru.shm.GetParam(slot, moduleKey)
 		if err != nil || modID == "" {
 			continue
 		}
-		ru.sendHierarchy(ctx, c, slot, comp)
-		ru.sendChainParams(ctx, c, slot, comp)
+		if comp != "synth" {
+			ru.sendHierarchy(ctx, c, slot, comp)
+			ru.sendChainParams(ctx, c, slot, comp)
+		}
 		// Fetch initial param values (one-time on subscribe).
 		ru.sendInitialParamValues(ctx, c, slot, comp)
 	}
@@ -774,6 +780,7 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 	const presetResendThrottle = 120 * time.Millisecond
 	lastResend := make(map[uint8]time.Time)
 	pendingResend := make(map[uint8]map[string]bool) // slot -> comp -> needs full re-send
+	lastPreset := make(map[uint8]map[string]string)  // slot -> comp -> last preset value seen
 	// Master FX lives at slot 0 but is delivered to a separate subscription
 	// (masterFxSub), so it gets its own pending set + throttle keyed by comp
 	// ("master_fx:fxN") rather than sharing the chain-slot maps above.
@@ -829,10 +836,22 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 				}
 				m[c.Key] = c.Value
 				if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
-					if pendingResend[c.Slot] == nil {
-						pendingResend[c.Slot] = make(map[string]bool)
+					// Only re-push full state when the preset VALUE actually
+					// changed. Some modules (e.g. jv880) re-assert preset on the
+					// notify ring without a real change; without this guard each
+					// such notification triggers a full N-param re-fetch, which
+					// floods the channel and makes sync feel inconsistent.
+					comp := c.Key[:i]
+					if lastPreset[c.Slot] == nil {
+						lastPreset[c.Slot] = make(map[string]string)
 					}
-					pendingResend[c.Slot][c.Key[:i]] = true
+					if prev, seen := lastPreset[c.Slot][comp]; !seen || prev != c.Value {
+						lastPreset[c.Slot][comp] = c.Value
+						if pendingResend[c.Slot] == nil {
+							pendingResend[c.Slot] = make(map[string]bool)
+						}
+						pendingResend[c.Slot][comp] = true
+					}
 				}
 			}
 

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -596,9 +596,8 @@ func (ru *RemoteUI) handleSetParam(ctx context.Context, c *ruClient, msg wsMessa
 		if paramKey == "preset" || paramKey == "preset_index" || strings.HasSuffix(paramKey, "_index") {
 			go func() {
 				time.Sleep(50 * time.Millisecond) // Let the plugin process the change
-				for _, sub := range ru.subscribedClients(slot) {
-					ru.sendInitialParamValues(ctx, sub, slot, comp)
-				}
+				// Read shm once and fan out to all subscribers of this slot.
+				ru.broadcastInitialParamValues(ctx, slot, comp, ru.subscribedClients(slot))
 			}()
 		}
 	}

--- a/schwung-manager/static/remote-ui.css
+++ b/schwung-manager/static/remote-ui.css
@@ -501,6 +501,56 @@
 }
 
 /* ---- Custom Module Web UI (iframe) ---- */
+/* ---- Custom / Default UI toggle ---- */
+.ui-mode-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-md);
+}
+
+.ui-mode-label {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.ui-mode-group {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.ui-mode-btn {
+    padding: var(--space-xs) var(--space-md);
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    cursor: pointer;
+    font-family: var(--font-stack);
+    font-size: 0.9rem;
+    min-height: var(--min-touch);
+    transition: color 0.15s, background 0.15s;
+}
+
+.ui-mode-btn:hover {
+    color: var(--text);
+    background: var(--bg-card-hover);
+}
+
+.ui-mode-btn:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: calc(var(--focus-offset) * -1);
+}
+
+.ui-mode-btn.active {
+    color: var(--accent);
+    background: var(--bg-card);
+    font-weight: 600;
+}
+
 .custom-ui-container {
     width: 100%;
     margin-bottom: var(--space-md);

--- a/schwung-manager/static/remote-ui.css
+++ b/schwung-manager/static/remote-ui.css
@@ -560,6 +560,36 @@
     background: var(--bg-card);
 }
 
+.custom-ui-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-xs) var(--space-sm);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-card-hover);
+}
+
+.custom-ui-popout-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: var(--space-xs) var(--space-sm);
+    cursor: pointer;
+    font-family: var(--font-stack);
+    font-size: 0.85rem;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.custom-ui-popout-btn:hover {
+    background: var(--border);
+    border-color: var(--text-muted);
+}
+
+.custom-ui-popout-btn:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: var(--focus-offset);
+}
+
 .custom-ui-iframe {
     display: block;
     width: 100%;

--- a/schwung-manager/static/remote-ui.css
+++ b/schwung-manager/static/remote-ui.css
@@ -566,12 +566,27 @@
 }
 
 .custom-ui-container {
+    position: relative;
     width: 100%;
     margin-bottom: var(--space-md);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     overflow: hidden;
     background: var(--bg-card);
+}
+
+/* Loading overlay shown over the iframe until the module UI is ready. */
+.custom-ui-loading {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-sm);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    background: var(--bg-card);
+    z-index: 1;
 }
 
 /* Compact pop-out button — sits inline in the slot header. */

--- a/schwung-manager/static/remote-ui.css
+++ b/schwung-manager/static/remote-ui.css
@@ -152,13 +152,28 @@
 
 /* ---- Slot Header ---- */
 .slot-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-sm) var(--space-md);
     margin-bottom: var(--space-lg);
 }
 
 .slot-header h2 {
     font-size: 1.25rem;
     font-weight: 600;
-    margin-bottom: var(--space-xs);
+    margin: 0;
+}
+
+/* Inline controls (Interface toggle + pop-out) beside the slot label. */
+.slot-header-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.slot-header-controls:empty {
+    display: none;
 }
 
 /* ---- Breadcrumb ---- */
@@ -501,17 +516,16 @@
 }
 
 /* ---- Custom Module Web UI (iframe) ---- */
-/* ---- Custom / Default UI toggle ---- */
+/* ---- Custom / Default Interface toggle (compact, in slot header) ---- */
 .ui-mode-toggle {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: var(--space-sm);
-    margin-bottom: var(--space-md);
+    gap: var(--space-xs);
 }
 
 .ui-mode-label {
     color: var(--text-muted);
-    font-size: 0.85rem;
+    font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
@@ -524,14 +538,14 @@
 }
 
 .ui-mode-btn {
-    padding: var(--space-xs) var(--space-md);
+    padding: 2px var(--space-sm);
     background: transparent;
     color: var(--text-muted);
     border: none;
     cursor: pointer;
     font-family: var(--font-stack);
-    font-size: 0.9rem;
-    min-height: var(--min-touch);
+    font-size: 0.78rem;
+    line-height: 1.6;
     transition: color 0.15s, background 0.15s;
 }
 
@@ -560,23 +574,17 @@
     background: var(--bg-card);
 }
 
-.custom-ui-toolbar {
-    display: flex;
-    justify-content: flex-end;
-    padding: var(--space-xs) var(--space-sm);
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-card-hover);
-}
-
+/* Compact pop-out button — sits inline in the slot header. */
 .custom-ui-popout-btn {
     background: transparent;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     color: var(--text);
-    padding: var(--space-xs) var(--space-sm);
+    padding: 2px var(--space-sm);
     cursor: pointer;
     font-family: var(--font-stack);
-    font-size: 0.85rem;
+    font-size: 0.78rem;
+    line-height: 1.6;
     transition: background 0.15s, border-color 0.15s;
 }
 

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -36,7 +36,10 @@
             // Track which component sections are collapsed (true = collapsed).
             collapsed: { synth: false, fx1: true, fx2: true, midi_fx1: true },
             // Custom web UI URL for synth component (null = use auto-generated UI).
-            customUI: null
+            customUI: null,
+            // When true, ignore customUI and show the auto-generated parameter
+            // UI even though a module web_ui.html is available. Session-only.
+            useDefaultUI: false
         };
     }
 
@@ -1455,8 +1458,15 @@
             return;
         }
 
-        // Check for custom web UI on synth component.
-        if (s.customUI && s.customUI.url && hasAnyModule) {
+        // When the synth ships a custom web UI, show a toggle (in both modes)
+        // so the user can switch between it and the auto-generated param UI.
+        var hasCustomUI = !!(s.customUI && s.customUI.url && hasAnyModule);
+        if (hasCustomUI) {
+            slotContentEl.appendChild(renderUiModeToggle(s));
+        }
+
+        // Render the custom web UI unless the user opted out for this slot.
+        if (hasCustomUI && !s.useDefaultUI) {
             renderCustomUI(s);
             return;
         }
@@ -1885,6 +1895,39 @@
     // ------------------------------------------------------------------
     // Custom Module Web UI (iframe)
     // ------------------------------------------------------------------
+
+    // Segmented Custom/Default switch shown when the synth has a web_ui.html.
+    // Lets the user fall back to the auto-generated parameter UI for this slot
+    // (session-only — resets on refresh, like the collapse state).
+    function renderUiModeToggle(s) {
+        var bar = document.createElement("div");
+        bar.className = "ui-mode-toggle";
+
+        var label = document.createElement("span");
+        label.className = "ui-mode-label";
+        label.textContent = "UI";
+        bar.appendChild(label);
+
+        var group = document.createElement("div");
+        group.className = "ui-mode-group";
+
+        [["Custom", false], ["Default", true]].forEach(function (opt) {
+            var btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "ui-mode-btn" + (s.useDefaultUI === opt[1] ? " active" : "");
+            btn.textContent = opt[0];
+            btn.setAttribute("aria-pressed", s.useDefaultUI === opt[1] ? "true" : "false");
+            btn.onclick = function () {
+                if (s.useDefaultUI === opt[1]) return;
+                s.useDefaultUI = opt[1];
+                renderSlot();
+            };
+            group.appendChild(btn);
+        });
+
+        bar.appendChild(group);
+        return bar;
+    }
 
     function renderCustomUI(s) {
         var url = s.customUI.url;

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -1931,10 +1931,30 @@
 
     function renderCustomUI(s) {
         var url = s.customUI.url;
+        var slot = activeSlot;
 
         // Create iframe container.
         var container = document.createElement("div");
         container.className = "custom-ui-container";
+
+        // Toolbar with a "pop out" button — opens the module UI as its own
+        // top-level window, free of the iframe's sandbox/sizing. The standalone
+        // page talks to /ws/remote-ui directly (see schwung-remote-api.js), so
+        // it keeps working even if this manager tab is closed.
+        var toolbar = document.createElement("div");
+        toolbar.className = "custom-ui-toolbar";
+        var popBtn = document.createElement("button");
+        popBtn.type = "button";
+        popBtn.className = "custom-ui-popout-btn";
+        popBtn.textContent = "Pop out ↗";
+        popBtn.title = "Open this UI in its own window";
+        popBtn.onclick = function () {
+            var sep = url.indexOf("?") === -1 ? "?" : "&";
+            var popUrl = url + sep + "schwungStandalone=1&slot=" + slot;
+            window.open(popUrl, "schwungPopout_" + slot);
+        };
+        toolbar.appendChild(popBtn);
+        container.appendChild(toolbar);
 
         var iframe = document.createElement("iframe");
         iframe.className = "custom-ui-iframe";

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -86,6 +86,7 @@
     // DOM references.
     var statusEl = document.getElementById("remote-ui-status");
     var slotTitleEl = document.getElementById("slot-title");
+    var slotHeaderControlsEl = document.getElementById("slot-header-controls");
     var slotContentEl = document.getElementById("slot-content");
     var debugEl = document.getElementById("slot-debug");
     var tabButtons = document.querySelectorAll(".remote-ui-tab");
@@ -1428,6 +1429,7 @@
     function renderSlot() {
         slotContentEl.innerHTML = "";
         debugEl.innerHTML = "";
+        if (slotHeaderControlsEl) slotHeaderControlsEl.innerHTML = "";
 
         // Clear custom UI iframe state on re-render.
         customUIIframe = null;
@@ -1458,11 +1460,12 @@
             return;
         }
 
-        // When the synth ships a custom web UI, show a toggle (in both modes)
-        // so the user can switch between it and the auto-generated param UI.
+        // When the synth ships a custom web UI, put the Interface toggle and
+        // the pop-out button inline next to the slot label (compact, both modes).
         var hasCustomUI = !!(s.customUI && s.customUI.url && hasAnyModule);
-        if (hasCustomUI) {
-            slotContentEl.appendChild(renderUiModeToggle(s));
+        if (hasCustomUI && slotHeaderControlsEl) {
+            slotHeaderControlsEl.appendChild(renderUiModeToggle(s));
+            slotHeaderControlsEl.appendChild(makePopOutButton(s.customUI.url, activeSlot));
         }
 
         // Render the custom web UI unless the user opted out for this slot.
@@ -1905,7 +1908,7 @@
 
         var label = document.createElement("span");
         label.className = "ui-mode-label";
-        label.textContent = "UI";
+        label.textContent = "Interface";
         bar.appendChild(label);
 
         var group = document.createElement("div");
@@ -1929,20 +1932,11 @@
         return bar;
     }
 
-    function renderCustomUI(s) {
-        var url = s.customUI.url;
-        var slot = activeSlot;
-
-        // Create iframe container.
-        var container = document.createElement("div");
-        container.className = "custom-ui-container";
-
-        // Toolbar with a "pop out" button — opens the module UI as its own
-        // top-level window, free of the iframe's sandbox/sizing. The standalone
-        // page talks to /ws/remote-ui directly (see schwung-remote-api.js), so
-        // it keeps working even if this manager tab is closed.
-        var toolbar = document.createElement("div");
-        toolbar.className = "custom-ui-toolbar";
+    // "Pop out" button — opens the module UI as its own top-level window, free
+    // of the iframe's sandbox/sizing. The standalone page talks to
+    // /ws/remote-ui directly (see schwung-remote-api.js), so it keeps working
+    // even if this manager tab is closed.
+    function makePopOutButton(url, slot) {
         var popBtn = document.createElement("button");
         popBtn.type = "button";
         popBtn.className = "custom-ui-popout-btn";
@@ -1953,8 +1947,15 @@
             var popUrl = url + sep + "schwungStandalone=1&slot=" + slot;
             window.open(popUrl, "schwungPopout_" + slot);
         };
-        toolbar.appendChild(popBtn);
-        container.appendChild(toolbar);
+        return popBtn;
+    }
+
+    function renderCustomUI(s) {
+        var url = s.customUI.url;
+
+        // Create iframe container.
+        var container = document.createElement("div");
+        container.className = "custom-ui-container";
 
         var iframe = document.createElement("iframe");
         iframe.className = "custom-ui-iframe";

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -1940,6 +1940,12 @@
                 break;
             case "subscribe":
                 customUISubscribed = true;
+                // Bulk-seed: push every param value the parent has already
+                // cached (from the host's initial fetch) in one message, so the
+                // iframe paints real values immediately instead of pulling them
+                // back one-by-one via getParam. Late-arriving values still flow
+                // through the normal param_update path below.
+                seedCustomUI();
                 break;
             case "getHierarchy":
                 handleIframeGetHierarchy(msg);
@@ -2004,6 +2010,28 @@
         if (customUIIframe && customUIIframe.contentWindow) {
             customUIIframe.contentWindow.postMessage(msg, "*");
         }
+    }
+
+    // Push all params the parent has already cached for the active slot to the
+    // custom UI iframe in a single paramUpdate. Called when the iframe first
+    // subscribes so it can seed its controls without a round-trip per param.
+    function seedCustomUI() {
+        if (!customUIIframe) return;
+        if (typeof activeSlot !== "number") return;
+        var comps = slots[activeSlot].components;
+        var params = {};
+        var any = false;
+        for (var k = 0; k < COMPONENT_KEYS.length; k++) {
+            var cp = comps[COMPONENT_KEYS[k]];
+            if (!cp || !cp.params) continue;
+            for (var key in cp.params) {
+                if (Object.prototype.hasOwnProperty.call(cp.params, key)) {
+                    params[key] = cp.params[key];
+                    any = true;
+                }
+            }
+        }
+        if (any) postToIframe({ type: "paramUpdate", params: params });
     }
 
     function renderMasterFx() {

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -77,6 +77,8 @@
     // Custom module web UI state.
     var customUIIframe = null; // Reference to active custom UI iframe element
     var customUISubscribed = false; // Whether the iframe has subscribed to param updates
+    var customUILoadingEl = null; // Loading overlay shown until the module UI is ready
+    var customUILoadingTimer = null; // Fallback timer to clear the overlay
 
     // Knob drag state.
     var dragging = null; // { component, key, startY, startValue, min, max, step, type, slot }
@@ -1434,6 +1436,8 @@
         // Clear custom UI iframe state on re-render.
         customUIIframe = null;
         customUISubscribed = false;
+        customUILoadingEl = null;
+        if (customUILoadingTimer) { clearTimeout(customUILoadingTimer); customUILoadingTimer = null; }
 
         if (activeSlot === "master") {
             renderMasterFx();
@@ -1962,8 +1966,19 @@
         iframe.src = url;
         iframe.sandbox = "allow-scripts allow-same-origin";
         iframe.setAttribute("title", "Custom Module UI");
-
         container.appendChild(iframe);
+
+        // Loading overlay shown over the iframe until the module UI is ready.
+        // Cleared when the iframe subscribes (module JS ran), or on iframe
+        // onload, or after a timeout — whichever comes first.
+        var overlay = document.createElement("div");
+        overlay.className = "custom-ui-loading";
+        overlay.innerHTML = '<span class="loading-spinner"></span> Loading module…';
+        container.appendChild(overlay);
+        customUILoadingEl = overlay;
+        iframe.addEventListener("load", hideCustomUILoading);
+        customUILoadingTimer = setTimeout(hideCustomUILoading, 10000);
+
         slotContentEl.appendChild(container);
 
         // Also render FX sections below the iframe if any are loaded.
@@ -2004,6 +2019,8 @@
                 break;
             case "subscribe":
                 customUISubscribed = true;
+                // Module JS has run — clear the loading overlay.
+                hideCustomUILoading();
                 // Bulk-seed: push every param value the parent has already
                 // cached (from the host's initial fetch) in one message, so the
                 // iframe paints real values immediately instead of pulling them
@@ -2074,6 +2091,15 @@
         if (customUIIframe && customUIIframe.contentWindow) {
             customUIIframe.contentWindow.postMessage(msg, "*");
         }
+    }
+
+    // Remove the custom-UI loading overlay (idempotent).
+    function hideCustomUILoading() {
+        if (customUILoadingTimer) { clearTimeout(customUILoadingTimer); customUILoadingTimer = null; }
+        if (customUILoadingEl && customUILoadingEl.parentNode) {
+            customUILoadingEl.parentNode.removeChild(customUILoadingEl);
+        }
+        customUILoadingEl = null;
     }
 
     // Push all params the parent has already cached for the active slot to the

--- a/schwung-manager/static/schwung-remote-api.js
+++ b/schwung-manager/static/schwung-remote-api.js
@@ -1,9 +1,17 @@
 /* ================================================================
    schwung-remote-api.js
    Include this in your module's web_ui.html to communicate with
-   the Schwung Remote UI host page via postMessage.
+   the Schwung Remote UI host page.
 
-   Usage:
+   Two transports, selected automatically:
+     - Iframe mode (default): embedded in the manager's Remote UI page,
+       talks to the parent frame via postMessage.
+     - Standalone mode: when the page is popped out into its own window
+       (opened with ?schwungStandalone=1&slot=N, i.e. a top-level window
+       with no manager parent), it opens its own /ws/remote-ui WebSocket
+       and talks to the device directly — independent of the manager tab.
+
+   The public API is identical in both modes:
      <script src="/static/schwung-remote-api.js"></script>
      <script>
        schwungRemote.onParamChange(function(params) {
@@ -19,82 +27,223 @@
 (function () {
     "use strict";
 
-    var reqCounter = 0;
+    // Standalone (popped-out) when this page is top-level rather than embedded
+    // in the manager's iframe. The explicit query flag is the reliable signal
+    // (and carries the slot); window.top === window.self is the fallback.
+    var query = new URLSearchParams(window.location.search);
+    var standalone = query.get("schwungStandalone") === "1" || window.top === window.self;
 
-    function makeId() {
-        return "req_" + (++reqCounter) + "_" + Date.now();
-    }
+    if (!standalone) {
+        // ----------------------------------------------------------------
+        // Iframe mode — bridge to the manager parent page via postMessage.
+        // ----------------------------------------------------------------
+        var reqCounter = 0;
 
-    function requestFromParent(msg) {
-        return new Promise(function (resolve) {
-            var id = makeId();
-            msg.id = id;
+        function makeId() {
+            return "req_" + (++reqCounter) + "_" + Date.now();
+        }
 
-            function handler(e) {
-                if (e.data && e.data.id === id) {
-                    window.removeEventListener("message", handler);
-                    resolve(e.data);
+        function requestFromParent(msg) {
+            return new Promise(function (resolve) {
+                var id = makeId();
+                msg.id = id;
+
+                function handler(e) {
+                    if (e.data && e.data.id === id) {
+                        window.removeEventListener("message", handler);
+                        resolve(e.data);
+                    }
                 }
-            }
 
-            window.addEventListener("message", handler);
-            window.parent.postMessage(msg, "*");
-        });
+                window.addEventListener("message", handler);
+                window.parent.postMessage(msg, "*");
+            });
+        }
+
+        window.schwungRemote = {
+            /**
+             * Get the current value of a parameter.
+             * @param {string} key - Parameter key, e.g. "synth:cutoff"
+             * @returns {Promise<string>} The parameter value
+             */
+            getParam: function (key) {
+                return requestFromParent({ type: "getParam", key: key }).then(function (resp) {
+                    return resp.value;
+                });
+            },
+
+            /**
+             * Set a parameter value.
+             * @param {string} key - Parameter key, e.g. "synth:cutoff"
+             * @param {string|number} value - New value
+             */
+            setParam: function (key, value) {
+                window.parent.postMessage({ type: "setParam", key: key, value: String(value) }, "*");
+            },
+
+            /**
+             * Register a callback for parameter value changes.
+             * @param {function} callback - Called with an object of {key: value} pairs
+             */
+            onParamChange: function (callback) {
+                window.addEventListener("message", function (e) {
+                    if (e.data && e.data.type === "paramUpdate") {
+                        callback(e.data.params);
+                    }
+                });
+                // Tell the parent to start forwarding param updates.
+                window.parent.postMessage({ type: "subscribe" }, "*");
+            },
+
+            /**
+             * Get the synth module's UI hierarchy.
+             * @returns {Promise<object>} The hierarchy data
+             */
+            getHierarchy: function () {
+                return requestFromParent({ type: "getHierarchy" }).then(function (resp) {
+                    return resp.data;
+                });
+            },
+
+            /**
+             * Get the synth module's chain_params metadata.
+             * @returns {Promise<Array>} The chain_params array
+             */
+            getChainParams: function () {
+                return requestFromParent({ type: "getChainParams" }).then(function (resp) {
+                    return resp.data;
+                });
+            }
+        };
+        return;
     }
+
+    // --------------------------------------------------------------------
+    // Standalone mode — own WebSocket connection to /ws/remote-ui.
+    // --------------------------------------------------------------------
+    var slot = parseInt(query.get("slot"), 10);
+    if (isNaN(slot)) slot = 0;
+
+    var wsUrl = (window.location.protocol === "https:" ? "wss://" : "ws://") +
+        window.location.host + "/ws/remote-ui";
+
+    var cache = {};               // key -> last known value (mirrors parent cache)
+    var listeners = [];           // onParamChange callbacks
+    var hierarchyData = null, hierarchyWaiters = [];
+    var chainParamsData = null, chainParamsWaiters = [];
+    var ws = null;
+    var reconnectDelay = 1000;    // exponential backoff, capped
+    var RECONNECT_MAX = 10000;
+
+    function copyCache() {
+        var out = {};
+        for (var k in cache) {
+            if (Object.prototype.hasOwnProperty.call(cache, k)) out[k] = cache[k];
+        }
+        return out;
+    }
+
+    function emit(params) {
+        for (var i = 0; i < listeners.length; i++) {
+            try { listeners[i](params); } catch (e) { /* keep other listeners alive */ }
+        }
+    }
+
+    function resolveWaiters(arr, val) {
+        while (arr.length) arr.shift()(val);
+    }
+
+    function handleMessage(msg) {
+        switch (msg.type) {
+            case "param_update":
+                if (msg.params) {
+                    for (var k in msg.params) {
+                        if (Object.prototype.hasOwnProperty.call(msg.params, k)) {
+                            cache[k] = msg.params[k];
+                        }
+                    }
+                    emit(msg.params);
+                }
+                break;
+            case "hierarchy":
+                // Only the synth component drives the custom UI.
+                if (msg.component === "synth") {
+                    hierarchyData = msg.data;
+                    resolveWaiters(hierarchyWaiters, hierarchyData);
+                }
+                break;
+            case "chain_params":
+                if (msg.component === "synth") {
+                    chainParamsData = msg.data;
+                    resolveWaiters(chainParamsWaiters, chainParamsData);
+                }
+                break;
+            // slot_info / custom_ui / error are not needed by the module UI.
+        }
+    }
+
+    function connect() {
+        ws = new WebSocket(wsUrl);
+
+        ws.onopen = function () {
+            reconnectDelay = 1000;
+            ws.send(JSON.stringify({ type: "subscribe", slot: slot }));
+        };
+
+        ws.onmessage = function (e) {
+            var msg;
+            try { msg = JSON.parse(e.data); } catch (err) { return; }
+            if (msg && msg.type) handleMessage(msg);
+        };
+
+        ws.onclose = function () {
+            ws = null;
+            setTimeout(connect, reconnectDelay);
+            reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX);
+        };
+
+        ws.onerror = function () {
+            try { if (ws) ws.close(); } catch (e) { /* ignore */ }
+        };
+    }
+
+    connect();
 
     window.schwungRemote = {
-        /**
-         * Get the current value of a parameter.
-         * @param {string} key - Parameter key, e.g. "synth:cutoff"
-         * @returns {Promise<string>} The parameter value
-         */
         getParam: function (key) {
-            return requestFromParent({ type: "getParam", key: key }).then(function (resp) {
-                return resp.value;
-            });
+            // Resolve from the local cache. Values stream in via param_update
+            // shortly after subscribe, so early reads may be undefined — the
+            // same best-effort contract as the iframe path's seed/onParamChange.
+            return Promise.resolve(cache[key]);
         },
 
-        /**
-         * Set a parameter value.
-         * @param {string} key - Parameter key, e.g. "synth:cutoff"
-         * @param {string|number} value - New value
-         */
         setParam: function (key, value) {
-            window.parent.postMessage({ type: "setParam", key: key, value: String(value) }, "*");
+            if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({
+                    type: "set_param",
+                    slot: slot,
+                    key: key,
+                    value: String(value)
+                }));
+            }
         },
 
-        /**
-         * Register a callback for parameter value changes.
-         * @param {function} callback - Called with an object of {key: value} pairs
-         */
         onParamChange: function (callback) {
-            window.addEventListener("message", function (e) {
-                if (e.data && e.data.type === "paramUpdate") {
-                    callback(e.data.params);
-                }
-            });
-            // Tell the parent to start forwarding param updates.
-            window.parent.postMessage({ type: "subscribe" }, "*");
+            listeners.push(callback);
+            // Replay whatever we already have so a late subscriber is seeded.
+            if (Object.keys(cache).length) {
+                try { callback(copyCache()); } catch (e) { /* ignore */ }
+            }
         },
 
-        /**
-         * Get the synth module's UI hierarchy.
-         * @returns {Promise<object>} The hierarchy data
-         */
         getHierarchy: function () {
-            return requestFromParent({ type: "getHierarchy" }).then(function (resp) {
-                return resp.data;
-            });
+            if (hierarchyData !== null) return Promise.resolve(hierarchyData);
+            return new Promise(function (resolve) { hierarchyWaiters.push(resolve); });
         },
 
-        /**
-         * Get the synth module's chain_params metadata.
-         * @returns {Promise<Array>} The chain_params array
-         */
         getChainParams: function () {
-            return requestFromParent({ type: "getChainParams" }).then(function (resp) {
-                return resp.data;
-            });
+            if (chainParamsData !== null) return Promise.resolve(chainParamsData);
+            return new Promise(function (resolve) { chainParamsWaiters.push(resolve); });
         }
     };
 })();

--- a/schwung-manager/templates/remote_ui.html
+++ b/schwung-manager/templates/remote_ui.html
@@ -20,6 +20,7 @@
 <div id="remote-ui-slot" class="remote-ui-slot" role="tabpanel">
     <div id="slot-header" class="slot-header">
         <h2 id="slot-title">Slot 1</h2>
+        <div id="slot-header-controls" class="slot-header-controls"></div>
     </div>
 
     <div id="slot-content">


### PR DESCRIPTION
Remote-UI improvements that build on the same-origin framing landed in #118. All changes are manager-side (`schwung-manager`): the Go server + the browser-served web UI assets. No host/shim/module changes.

### Custom module UI handling
- **Pop custom module UI into its own window** via a direct WebSocket, so a module's `web_ui.html` can run full-size detached from the slot strip.
- **Per-slot custom ↔ default UI toggle** — switch between a module's custom interface and the generic param view per slot.
- **Inline Interface toggle + pop-out** moved into the slot header.
- **Loading spinner** over the custom UI until the module is ready (avoids a blank iframe).
- **Send `custom_ui` before slot settings + bulk-seed the iframe** so a data-driven UI has its metadata on first request and renders immediately.

### Param re-fetch perf (coalescing)
The notify loop previously re-fetched a component's full param set per subscriber and on every preset re-assert. Under quick preset scrolling on a param-heavy module this floods the shared channel and stalls sync. This bundle:
- **Stops the redundant full-param re-fetch storm** (value-diff guard: only re-push when a preset value actually changed) and hoists synth hierarchy/`chain_params` metadata ahead of `sendSlotSettings`.
- **Coalesces the per-slot re-fetch across subscribers** — read shm once per component, fan out to all subscribers of that slot, inside the existing notify-loop goroutine so the drain loop never blocks.
- **Coalesces the set-preset re-fetch path** too.

Depends on #118 (merged). Device-tested on the fork's daily-driver build.

## Screenshot

Remote UI with OB-Xd loaded in Slot 1 — the new per-slot **Interface: Custom / Default** toggle and **Pop out** control in the slot header (this PR), with the module's custom `web_ui.html` rendered below.

<img width="1149" height="408" alt="Screenshot 2026-06-20 at 7 47 03 PM" src="https://github.com/user-attachments/assets/96294250-1056-481c-b6ce-7145d6b86765" />
