### PR TITLE
fix(build): host target depends on all src/host/*.h (avoid stale-host param corruption)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -202,11 +202,14 @@ else
 fi
 
 # Build host with module manager and settings
+# Depend on ALL host headers (src/host/*.h), not a hand-picked subset. The host
+# includes shadow_constants.h (the shared-memory layout); omitting it meant a
+# layout change rebuilt the shim/modules but NOT the host, leaving mismatched
+# binaries. Globbing every header makes that class of bug impossible.
 if needs_rebuild build/schwung \
     src/schwung_host.c src/host/module_manager.c src/host/settings.c src/host/unified_log.c \
     src/host/analytics.c src/host/js_host_common.c \
-    src/host/module_manager.h src/host/settings.h src/host/plugin_api_v1.h src/host/unified_log.h \
-    src/host/js_host_common.h; then
+    src/host/*.h; then
     echo "Building host..."
     "${CROSS_PREFIX}gcc" -g -O3 \
         src/schwung_host.c \


### PR DESCRIPTION
### The bug
The host build's dependency list hand-picks a subset of headers:

```
src/host/module_manager.h src/host/settings.h src/host/plugin_api_v1.h \
src/host/unified_log.h src/host/js_host_common.h
```

But `src/schwung_host.c` `#include`s **`src/host/shadow_constants.h`** — the shared-memory layout struct — which is **not** on that list. So editing the SHM layout rebuilds the shim and modules (their dep lists do track it) but **not the host**. The result is mismatched binaries that disagree about struct offsets, which shows up at runtime as **silent param corruption** — no build error, nothing to point at it.

### The fix
Depend on **all** host headers (`src/host/*.h`) instead of a hand-maintained subset, so any header change forces a host rebuild and this whole "stale host vs. fresh shim" class becomes impossible.

### Trade-off
The glob will occasionally rebuild the host when an unrelated host header changes — a few seconds of C compile. That's a cheap price for eliminating a silent-corruption footgun. The hand-picked list was reasonable minimalism, but it silently rots whenever a source starts including a header that isn't on it (which is exactly what happened here).

### Longer-term option
The fully robust fix is compiler auto-dependency generation (`gcc -MMD -MP`), which would remove the manual header lists everywhere and never drift again — but that's a larger build rework. This one-line glob is the right-sized fix for this specific footgun.
