### PR TITLE
Co-run input ownership: cede-default model + full cedeable control surface + canvas sub-view

### DIFF
--- a/docs/CORUN.md
+++ b/docs/CORUN.md
@@ -12,12 +12,47 @@ Two co-run targets ship today:
 | `CORUN_TARGET_CHAIN_EDIT` | Schwung shadow_ui's chain-slot editor   |
 | `CORUN_TARGET_MOVE_NATIVE`| Move firmware's native preset / synth editor |
 
-Both targets share the same default split, encoded as `CORUN_KEEP_DEFAULT =
-PADS | STEPS | TRANSPORT | MENU` — the tool keeps those control-surface
-groups and cedes everything else (OLED, jog, track buttons, knobs 71-78,
-master CC 79, Shift, touch notes 0-9) to the peer. Back is framework-reserved
-as the exit gesture by default; see [Exit gesture](#exit-gesture). Tools can
-override by passing an explicit `keep_mask` to `shadow_corun_begin()`.
+## Ownership model
+
+Every physically distinct Move control is classified into a `CORUN_GRP_*` group,
+so a tool can keep or cede **any** input. There are two ways to declare the split:
+
+- **Cede model (recommended).** The tool **keeps the whole surface by default** and
+  lists only the groups it **cedes** to the peer, via
+  `shadow_corun_begin_cede(target, id, cede_mask)`. Keep-by-default means a control
+  the tool doesn't mention stays with the tool — the friendly default, and the one
+  to use for new tools.
+- **Legacy keep-list model.** `shadow_corun_begin(target, id, keep_mask)` — the tool
+  lists what it **keeps**; everything else classified cedes. `keep_mask == 0` uses
+  `CORUN_KEEP_DEFAULT = PADS | STEPS | TRANSPORT | MENU | MUTE`. Preserved
+  byte-for-byte for existing tools; a tool on this path also keeps the extended
+  buttons (transport/edit/nav) it never named, exactly as before they were classified.
+
+Both produce identical routing — the cede mask is just stored internally as its
+keep complement, so one representation drives every routing/LED site. Back is
+framework-reserved as the exit gesture by default; see [Exit gesture](#exit-gesture).
+
+### Control-surface groups
+
+| Group | Control | Group | Control |
+| ----- | ------- | ----- | ------- |
+| `CORUN_GRP_OLED`  | the screen        | `CORUN_GRP_MUTE`    | Mute (CC 88) |
+| `CORUN_GRP_PADS`  | 32 pads           | `CORUN_GRP_PLAY`    | Play (CC 85) |
+| `CORUN_GRP_STEPS` | 16 step buttons   | `CORUN_GRP_REC`     | Rec (CC 86) |
+| `CORUN_GRP_JOG`   | jog turn + click  | `CORUN_GRP_SAMPLE`  | Record/Sample (CC 118) |
+| `CORUN_GRP_TRACK_BUTTONS` | rows CC 40-43 | `CORUN_GRP_LOOP`  | Loop (CC 58) |
+| `CORUN_GRP_KNOBS` | knobs CC 71-78    | `CORUN_GRP_COPY`    | Copy (CC 60) |
+| `CORUN_GRP_MASTER`| master CC 79      | `CORUN_GRP_DELETE`  | Delete (CC 119) |
+| `CORUN_GRP_SHIFT` | Shift (CC 49)     | `CORUN_GRP_UNDO`    | Undo (CC 56) |
+| `CORUN_GRP_BACK`  | Back (CC 51)      | `CORUN_GRP_CAPTURE` | Capture (CC 52) |
+| `CORUN_GRP_MENU`  | Menu (CC 50)      | `CORUN_GRP_NAV_UP/DOWN/LEFT/RIGHT` | arrows CC 55/54/62/63 |
+| `CORUN_GRP_TOUCH` | capacitive touch notes 0-9 | | |
+
+Convenience composites: `CORUN_GRP_TRANSPORT` (= Play|Rec|Sample|Loop),
+`CORUN_GRP_NAV` (the 4 arrows), `CORUN_GRP_EDIT` (Copy|Delete|Undo|Capture).
+The mic/speaker plug-detect CCs (114/115) are sensor state, not routable buttons,
+so they stay unclassified and always with the tool. The power button is not a
+routable MIDI event and is out of scope.
 
 ## Exit gesture
 
@@ -29,19 +64,22 @@ UI; Shift+Vol+Menu opens Master FX. While a co-run is active, Menu is
 forwarded to the tool by default via `CORUN_KEEP_DEFAULT` so the tool can use
 it as its own affordance.)
 
-### Opting out — `CORUN_KEEP_BACK`
+### Opting out of framework Back
 
 Tools that need Back free for in-session peer navigation (sub-view pop in
-the chain editor, native back-navigation inside Move firmware) set
-`CORUN_KEEP_BACK` in `keep_mask`:
+the chain editor, native back-navigation inside Move firmware) signal it — and
+Back then routes per the normal keep/cede rules (cedes to peer unless the tool
+also keeps `CORUN_GRP_BACK`):
 
-```js
-shadow_corun_begin(CORUN_TARGET_CHAIN_EDIT, slot,
-                   CORUN_KEEP_DEFAULT | CORUN_KEEP_BACK);
-```
-
-When this bit is set, the framework leaves Back alone: Back routes per the
-normal `keep_mask` rules (cedes to peer unless `CORUN_GRP_BACK` is also kept).
+- **Cede model:** pass `CORUN_F_OWN_BACK` as the `flags` argument:
+  ```js
+  shadow_corun_begin_cede(CORUN_TARGET_CHAIN_EDIT, slot, cedeMask, CORUN_F_OWN_BACK);
+  ```
+- **Legacy model:** set `CORUN_KEEP_BACK` in `keep_mask`:
+  ```js
+  shadow_corun_begin(CORUN_TARGET_CHAIN_EDIT, slot,
+                     CORUN_KEEP_DEFAULT | CORUN_KEEP_BACK);
+  ```
 For `CORUN_TARGET_CHAIN_EDIT`, shadow_ui's own Back handler still ends the
 session when the chain editor is at its top-level view (`CHAIN_EDIT`) — it
 owns the view stack and can tell, so it provides Charles's "Back exits at
@@ -59,25 +97,33 @@ collide with any `CORUN_GRP_*` bit.
 Exposed on the global object in shadow_ui's JS runtime:
 
 ```js
-shadow_corun_begin(target, id, keep_mask)
+// --- Cede model (recommended) ---
+shadow_corun_begin_cede(target, id, cede_mask, flags)
   // target: CORUN_TARGET_CHAIN_EDIT | CORUN_TARGET_MOVE_NATIVE
   // id:     chain slot 0-3 (CHAIN_EDIT) or tool track 0-7 (MOVE_NATIVE)
-  // keep_mask: bitfield of CORUN_GRP_* the tool KEEPS; 0 = default split
+  // cede_mask: bitfield of CORUN_GRP_* the tool CEDES; keeps everything else
+  // flags (optional): CORUN_F_OWN_BACK to handle Back itself
+shadow_corun_set_cede_mask(cede_mask)        // update the cede-list mid-session
+shadow_corun_set_led_cede_mask(led_cede_mask)// cede these groups' LEDs; paint the rest
 
+// --- Legacy keep-list model ---
+shadow_corun_begin(target, id, keep_mask)    // keep_mask: groups the tool KEEPS; 0 = default
+shadow_corun_set_led_keep_mask(led_keep_mask)// groups the tool owns for LEDs; 0 = follow keep
+
+// --- Shared ---
 shadow_corun_end()
   // Tear down co-run. Called by the framework on Back, or by the tool to
   // exit programmatically (e.g. on track-mode change).
-
 shadow_corun_state()
-  // Returns { target, id, keep_mask } or null when no co-run is active.
-  // Tools poll this each frame to detect framework-driven exit and to
-  // reconcile their own mirror state.
+  // Returns { target, id, keep_mask, flags } or null when no co-run is active.
+  // keep_mask is the effective KEEP set in both models (cede is stored as its
+  // complement). Tools poll this each frame to detect framework-driven exit.
 ```
 
-Enum constants are registered as JS globals: `CORUN_TARGET_NONE`,
-`CORUN_TARGET_CHAIN_EDIT`, `CORUN_TARGET_MOVE_NATIVE`, plus
-`CORUN_GRP_OLED` ... `CORUN_GRP_TOUCH`, `CORUN_KEEP_DEFAULT`, and
-`CORUN_KEEP_BACK` (matching `shadow_constants.h`).
+Enum constants are registered as JS globals: `CORUN_TARGET_*`, every
+`CORUN_GRP_*` group + the `NAV`/`EDIT`/`TRANSPORT` composites, `CORUN_KEEP_DEFAULT`,
+`CORUN_KEEP_BACK`, and `CORUN_F_OWN_BACK` (matching `shadow_constants.h`) — so
+modules reference them directly instead of hand-copying bit values.
 
 ### Capability gate
 
@@ -189,13 +235,15 @@ hardware, so the tool's own rendering on those surfaces stays uncontested.
 Surfaces the tool does not own pass through — Move's LEDs reach the buttons /
 pads / knob rings directly.
 
-**Lights vs input split.** LED ownership follows `corun.led_keep_mask` when set,
-falling back to `keep_mask` when it is `0`. This lets a tool **paint** a surface
-while still **ceding its presses** — e.g. dAVEBOx draws the track-button clip
-indicator (owns TRACK LEDs) but lets Move/Schwung handle the press (cedes TRACK
-input). Input routing always uses `keep_mask`; only LEDs consult
-`led_keep_mask`. (Because `0` means "follow keep_mask", a tool cannot currently
-own input while ceding *all* LEDs — no consumer needs that yet.)
+**Lights vs input split.** LED ownership is its own mask, letting a tool **paint** a
+surface while still **ceding its presses** — e.g. dAVEBOx draws the track-button
+clip indicator (owns TRACK LEDs) but lets Move/Schwung handle the press (cedes
+TRACK input). Cede-model tools set it with `shadow_corun_set_led_cede_mask`
+(cede these LEDs, paint the rest); legacy tools use `shadow_corun_set_led_keep_mask`
+(own these LEDs, `0` = follow input). The cede setter also sets
+`CORUN_F_LED_DISTINCT`, which makes the LED mask authoritative even at `0` — so a
+cede tool *can* cede all LEDs while keeping input (the legacy "0 follows input"
+sentinel no longer blocks that). Input routing never consults the LED mask.
 
 **Steps** (notes 16–31) are now a first-class surface (`CORUN_GRP_STEPS`), so
 their input and LEDs route like any other group. This is backward-safe for the
@@ -221,3 +269,10 @@ event belongs to right now. Both the sh_midi let-through filter (forward to
 Move) and the forward-to-shadow_ui suppress filter (forward to tool) call this
 helper and switch on the result, so the two routes cannot drift apart. Adding
 a new target = extend this function; no mirror checks elsewhere.
+
+It is model-aware via `corun.flags & CORUN_F_CEDE_MODEL`: cede-model sessions
+govern the full surface uniformly, while legacy sessions take a frozen path with
+a carve-out that keeps the extended buttons (transport/edit/nav) with the tool —
+so a pre-cede module behaves byte-identically. The cede mask is stored as its
+keep complement (`corun_cede_to_keep`), so the predicate's core test
+(`keep & grp`) and every LED/JS site share one representation.

--- a/docs/CORUN.md
+++ b/docs/CORUN.md
@@ -118,12 +118,19 @@ shadow_corun_state()
   // Returns { target, id, keep_mask, flags } or null when no co-run is active.
   // keep_mask is the effective KEEP set in both models (cede is stored as its
   // complement). Tools poll this each frame to detect framework-driven exit.
+shadow_corun_event_owner(status, d1)
+  // -> CORUN_OWNER_{TOOL,PEER,NONE,BOTH}. The host's corun_event_owner exposed
+  // for JS dispatch decisions (single source of truth — keep/cede spec + legacy
+  // carve-out honored). e.g. a raw-MIDI overlay (a type:"canvas" editor) consumes
+  // an event only when owner === CORUN_OWNER_PEER, so tool-kept controls fall
+  // through to the still-running tool instead of being swallowed.
 ```
 
 Enum constants are registered as JS globals: `CORUN_TARGET_*`, every
-`CORUN_GRP_*` group + the `NAV`/`EDIT`/`TRANSPORT` composites, `CORUN_KEEP_DEFAULT`,
-`CORUN_KEEP_BACK`, and `CORUN_F_OWN_BACK` (matching `shadow_constants.h`) — so
-modules reference them directly instead of hand-copying bit values.
+`CORUN_GRP_*` group + the `NAV`/`EDIT`/`TRANSPORT` composites, `CORUN_OWNER_*`,
+`CORUN_KEEP_DEFAULT`, `CORUN_KEEP_BACK`, and `CORUN_F_OWN_BACK` (matching
+`shadow_constants.h`) — so modules reference them directly instead of hand-copying
+bit values.
 
 ### Capability gate
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -52,7 +52,7 @@
  * MIDI_OUT must be bounded by this to avoid corrupting the display. */
 #define HW_MIDI_OUT_SIZE    80
 #define DISPLAY_BUFFER_SIZE 1024  /* 128x64 @ 1bpp = 1024 bytes */
-#define CONTROL_BUFFER_SIZE 76  /* +corun.led_keep_mask; 74 bytes content padded to 76 (struct has 4-byte-aligned uint32_t/float members) */
+#define CONTROL_BUFFER_SIZE 84  /* corun masks widened to uint32 + flags byte (cede-default model); static-asserted below */
 #define SHADOW_UI_BUFFER_SIZE     512
 #define SHADOW_PARAM_BUFFER_SIZE  65664  /* Large buffer for complex ui_hierarchy */
 #define SHADOW_MIDI_OUT_BUFFER_SIZE 512  /* MIDI out buffer from shadow UI (128 packets) */
@@ -167,10 +167,19 @@ typedef struct shadow_control_t {
     volatile struct {
         int8_t target;       /* corun_target_t */
         int8_t id;
-        uint16_t keep_mask;      /* CORUN_GRP_* the tool owns for INPUT (cedes the rest to the peer) */
-        uint16_t led_keep_mask;  /* CORUN_GRP_* the tool owns for LEDs; 0 = follow keep_mask. Lets a tool
-                                  * paint a surface while still ceding its presses (e.g. dAVEBOx draws the
-                                  * track-button clip indicator but lets Move/Schwung handle the press). */
+        uint8_t flags;       /* CORUN_F_* — model selector + per-session toggles (see below) */
+        uint8_t _pad;
+        /* INPUT ownership. Stored ALWAYS as a keep-mask internally (CORUN_GRP_*
+         * the tool owns; the rest cede to the peer) so every routing site uses
+         * one representation. New cede-model tools express intent as a cede-list
+         * and the host stores the complement via corun_cede_to_keep() — see
+         * CORUN_F_CEDE_MODEL. Legacy tools write keep bits directly. */
+        uint32_t keep_mask;
+        /* LED ownership; 0 = follow keep_mask (the common "own both" case) UNLESS
+         * CORUN_F_LED_DISTINCT is set, in which case this mask is authoritative
+         * even when 0. Lets a tool paint a surface while ceding its presses (e.g.
+         * dAVEBOx draws the track-button clip indicator but cedes the press). */
+        uint32_t led_keep_mask;
     } corun;
     volatile uint8_t shadow_display_owner; /* display_owner_t: who currently owns the OLED. Independent of shadow_display_mode (which only says "shadow session active"). */
     /* 1=also strip Move's cable-0 sysex (RGB pad/clip/grid LEDs) during FULL
@@ -189,45 +198,79 @@ typedef struct shadow_control_t {
  * co-run UI (Schwung's chain editor, or Move firmware). One canonical
  * event->group map (corun_group_for_event) is shared by every routing site so
  * the let-through and suppress-from-tool decisions can never drift apart. */
+/* Single discrete buttons each get their own bit; continuous/multi-key surfaces
+ * (pads, steps, knobs, touch, the track-button row, jog) are one group each
+ * (per-key co-run ownership isn't meaningful). Bit 15 is reserved for the legacy
+ * CORUN_KEEP_BACK flag; new button groups skip it and stay <= 25 so the JS-side
+ * signed `| 0` coercion never sees a negative mask. */
 #define CORUN_GRP_OLED          (1u << 0)
 #define CORUN_GRP_PADS          (1u << 1)
 #define CORUN_GRP_STEPS         (1u << 2)
-#define CORUN_GRP_TRANSPORT     (1u << 3)
+/* Bit 3 retired: TRANSPORT is now the composite of the real transport buttons
+ * (defined below). The old single-bit value is reserved/unused — it was never
+ * returned by corun_group_for_event, so nothing routed on it. */
 #define CORUN_GRP_JOG           (1u << 4)  /* jog turn (CC 14) + jog click (CC 3) */
 #define CORUN_GRP_TRACK_BUTTONS (1u << 5)  /* CC 40-43 */
 #define CORUN_GRP_KNOBS         (1u << 6)  /* CC 71-78 */
 #define CORUN_GRP_MASTER        (1u << 7)  /* CC 79 */
 #define CORUN_GRP_SHIFT         (1u << 8)  /* CC 49 */
 #define CORUN_GRP_BACK          (1u << 9)  /* CC 51 */
-#define CORUN_GRP_MENU          (1u << 10) /* CC 50 — framework exit gesture */
+#define CORUN_GRP_MENU          (1u << 10) /* CC 50 */
 #define CORUN_GRP_TOUCH         (1u << 11) /* capacitive-touch notes 0-9 */
-#define CORUN_GRP_MUTE          (1u << 12) /* CC 88 — the Mute button */
+#define CORUN_GRP_MUTE          (1u << 12) /* CC 88 */
+/* Discrete transport + edit + nav buttons — each independently keep/cede-able. */
+#define CORUN_GRP_PLAY          (1u << 13) /* CC 85 */
+#define CORUN_GRP_REC           (1u << 14) /* CC 86 */
+#define CORUN_GRP_SAMPLE        (1u << 16) /* CC 118 (Record/Sample) */
+#define CORUN_GRP_LOOP          (1u << 17) /* CC 58 */
+#define CORUN_GRP_COPY          (1u << 18) /* CC 60 */
+#define CORUN_GRP_DELETE        (1u << 19) /* CC 119 */
+#define CORUN_GRP_UNDO          (1u << 20) /* CC 56 */
+#define CORUN_GRP_CAPTURE       (1u << 21) /* CC 52 */
+#define CORUN_GRP_NAV_UP        (1u << 22) /* CC 55 */
+#define CORUN_GRP_NAV_DOWN      (1u << 23) /* CC 54 */
+#define CORUN_GRP_NAV_LEFT      (1u << 24) /* CC 62 */
+#define CORUN_GRP_NAV_RIGHT     (1u << 25) /* CC 63 */
 
-/* Default keep-set: the canonical sequencer-style co-run split — tool keeps
- * pads, step buttons, transport, Menu, and Mute; cedes the nav surface + screen
- * to the peer. Used whenever corun_keep_mask == 0. Mute is kept by default so
- * tools that don't set an explicit keep_mask behave exactly as before this group
- * existed (Mute stayed with the tool); a tool that wants Move/Schwung to own Mute
- * during co-run omits CORUN_GRP_MUTE from its explicit keep_mask. */
+/* Convenience composites — keep/cede a cluster in one bit-op (optional). */
+#define CORUN_GRP_TRANSPORT (CORUN_GRP_PLAY | CORUN_GRP_REC | CORUN_GRP_SAMPLE | CORUN_GRP_LOOP)
+#define CORUN_GRP_NAV       (CORUN_GRP_NAV_UP | CORUN_GRP_NAV_DOWN | CORUN_GRP_NAV_LEFT | CORUN_GRP_NAV_RIGHT)
+#define CORUN_GRP_EDIT      (CORUN_GRP_COPY | CORUN_GRP_DELETE | CORUN_GRP_UNDO | CORUN_GRP_CAPTURE)
+
+/* The buttons that were UNCLASSIFIED before the cede model. A legacy keep-list
+ * tool (CORUN_F_CEDE_MODEL clear) never named these, so they stay with the tool
+ * regardless of its keep_mask — the byte-for-byte legacy carve-out. */
+#define CORUN_GRP_EXTENDED_ALL (CORUN_GRP_TRANSPORT | CORUN_GRP_EDIT | CORUN_GRP_NAV)
+
+/* Every routable group bit — the universe over which a cede-mask is complemented
+ * into an internal keep-mask (corun_cede_to_keep). Excludes bit 3 (retired) and
+ * bit 15 (the CORUN_KEEP_BACK legacy flag). */
+#define CORUN_GRP_ALL (CORUN_GRP_OLED | CORUN_GRP_PADS | CORUN_GRP_STEPS | CORUN_GRP_JOG \
+    | CORUN_GRP_TRACK_BUTTONS | CORUN_GRP_KNOBS | CORUN_GRP_MASTER | CORUN_GRP_SHIFT \
+    | CORUN_GRP_BACK | CORUN_GRP_MENU | CORUN_GRP_TOUCH | CORUN_GRP_MUTE | CORUN_GRP_EXTENDED_ALL)
+
+/* corun.flags bits. */
+#define CORUN_F_CEDE_MODEL  (1u << 0) /* keep_mask is a complemented cede-mask; extended buttons participate */
+#define CORUN_F_OWN_BACK    (1u << 1) /* tool handles Back itself (no framework auto-exit); cede model */
+#define CORUN_F_LED_DISTINCT (1u << 2) /* led_keep_mask is authoritative even when 0 (don't follow keep_mask) */
+
+/* Legacy default keep-set: the canonical sequencer-style co-run split — tool
+ * keeps pads, step buttons, transport, Menu, and Mute; cedes the nav surface +
+ * screen. Used whenever a LEGACY tool leaves keep_mask == 0. */
 #define CORUN_KEEP_DEFAULT (CORUN_GRP_PADS | CORUN_GRP_STEPS | CORUN_GRP_TRANSPORT | CORUN_GRP_MENU | CORUN_GRP_MUTE)
 
-/* Opt-out flag for tools that prefer their own exit gesture. When this bit is
- * set in keep_mask, the framework does NOT auto-exit on Back press — Back
- * routes per normal keep_mask rules (cedes to peer for sub-view nav unless
- * the tool also keeps CORUN_GRP_BACK). Default (bit unset) reserves Back as
- * the framework exit gesture regardless of keep_mask. Lives in the high half
- * of keep_mask; doesn't collide with any CORUN_GRP_* bit. */
+/* Legacy opt-out flag (bit 15, lives in a legacy tool's keep_mask): when set the
+ * framework does NOT auto-exit on Back — Back routes per the keep_mask. Cede-model
+ * tools use CORUN_F_OWN_BACK instead. Kept for byte-identical legacy behavior. */
 #define CORUN_KEEP_BACK (1u << 15)
 
 /* Map a raw cable-0 MIDI event to its control-surface group, or 0 if it isn't a
- * routable surface control (those always stay with the tool). type is the
- * status nibble (0xB0 CC, 0x90/0x80 note); d1 the data byte. Steps (notes
- * 16-31) are now a first-class surface (CORUN_GRP_STEPS): backward-safe for the
- * default split and any STEPS-keeping tool, but an explicit keep_mask that
- * OMITS STEPS now cedes step input + LEDs (previously steps were unclassified,
- * always kept). Transport stays unclassified (always kept) — they have no settled
- * CC map and no co-run consumer cedes them. */
-static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
+ * routable surface control (sensor CCs like the mic/speaker plug-detect 114/115
+ * — those can't be ceded and always stay with the tool). type is the status
+ * nibble (0xB0 CC, 0x90/0x80 note); d1 the data byte. Every routable input is
+ * now classified; whether an extended button actually participates in keep/cede
+ * depends on the model (legacy carve-out, see corun_event_owner). */
+static inline uint32_t corun_group_for_event(uint8_t type, uint8_t d1) {
     if (type == 0xB0) {
         switch (d1) {
             case 3:  case 14: return CORUN_GRP_JOG;
@@ -236,7 +279,19 @@ static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
             case 50: return CORUN_GRP_MENU;
             case 51: return CORUN_GRP_BACK;
             case 79: return CORUN_GRP_MASTER;
-            case 88: return CORUN_GRP_MUTE;  /* Mute button */
+            case 88: return CORUN_GRP_MUTE;
+            case 85: return CORUN_GRP_PLAY;
+            case 86: return CORUN_GRP_REC;
+            case 118: return CORUN_GRP_SAMPLE;
+            case 58: return CORUN_GRP_LOOP;
+            case 60: return CORUN_GRP_COPY;
+            case 119: return CORUN_GRP_DELETE;
+            case 56: return CORUN_GRP_UNDO;
+            case 52: return CORUN_GRP_CAPTURE;
+            case 55: return CORUN_GRP_NAV_UP;
+            case 54: return CORUN_GRP_NAV_DOWN;
+            case 62: return CORUN_GRP_NAV_LEFT;
+            case 63: return CORUN_GRP_NAV_RIGHT;
             default: if (d1 >= 71 && d1 <= 78) return CORUN_GRP_KNOBS;
                      return 0;
         }
@@ -249,19 +304,32 @@ static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
     return 0;
 }
 
-/* Effective keep-mask: callers that set only the target gate leave keep_mask 0,
- * which means "use the default split". */
-static inline uint16_t corun_keep_mask_eff(uint16_t keep_mask) {
-    return keep_mask ? keep_mask : CORUN_KEEP_DEFAULT;
+/* Translate a module's cede-list into the internal keep-mask: it keeps the whole
+ * routable surface except what it cedes. Used by the host's cede-model API. */
+static inline uint32_t corun_cede_to_keep(uint32_t cede_mask) {
+    return (~cede_mask) & CORUN_GRP_ALL;
+}
+
+/* Effective input keep-mask. Cede-model tools store a complete complemented mask
+ * (keep_mask==0 legitimately means "keep nothing / cede everything"), so it is
+ * returned verbatim. Legacy tools leave keep_mask==0 to mean "default split". */
+static inline uint32_t corun_keep_mask_eff(const volatile shadow_control_t *ctrl) {
+    if (!ctrl) return CORUN_KEEP_DEFAULT;
+    if (ctrl->corun.flags & CORUN_F_CEDE_MODEL) return ctrl->corun.keep_mask;
+    return ctrl->corun.keep_mask ? ctrl->corun.keep_mask : CORUN_KEEP_DEFAULT;
 }
 
 /* Effective LED keep-mask: which groups the tool owns for LED stripping. A tool
- * that wants to paint a surface but cede its input sets led_keep_mask
- * separately; when unset (0) LED ownership follows the input keep_mask, so the
- * common case (own both) needs no extra call. */
-static inline uint16_t corun_led_keep_mask_eff(const volatile shadow_control_t *ctrl) {
-    uint16_t led = ctrl ? ctrl->corun.led_keep_mask : 0;
-    return led ? led : corun_keep_mask_eff(ctrl ? ctrl->corun.keep_mask : 0);
+ * that paints a surface but cedes its input sets led_keep_mask separately. When
+ * unset (0) and not flagged distinct, LED ownership follows the input mask, so
+ * the common case (own both) needs no extra call. CORUN_F_LED_DISTINCT makes the
+ * led mask authoritative even at 0 (needed by cede-model tools, where 0 is a
+ * meaningful "cede all LEDs" value rather than the follow sentinel). */
+static inline uint32_t corun_led_keep_mask_eff(const volatile shadow_control_t *ctrl) {
+    if (!ctrl) return CORUN_KEEP_DEFAULT;
+    uint32_t led = ctrl->corun.led_keep_mask;
+    if ((ctrl->corun.flags & CORUN_F_LED_DISTINCT) || led) return led;
+    return corun_keep_mask_eff(ctrl);
 }
 
 /* Co-run target. Stored in shadow_control->corun.target as int8_t. */
@@ -298,7 +366,7 @@ static inline corun_target_t corun_target(const volatile shadow_control_t *ctrl)
 static inline int corun_id(const volatile shadow_control_t *ctrl) {
     return ctrl ? (int)(int8_t)ctrl->corun.id : -1;
 }
-static inline uint16_t corun_keep_mask(const volatile shadow_control_t *ctrl) {
+static inline uint32_t corun_keep_mask(const volatile shadow_control_t *ctrl) {
     return ctrl ? ctrl->corun.keep_mask : 0;
 }
 
@@ -308,19 +376,25 @@ static inline uint16_t corun_keep_mask(const volatile shadow_control_t *ctrl) {
  * mirror checks anywhere else can drift. */
 static inline corun_owner_t corun_event_owner(const volatile shadow_control_t *ctrl, uint8_t type, uint8_t d1) {
     if (!corun_active(ctrl)) return CORUN_OWNER_TOOL;
-    uint16_t grp = corun_group_for_event(type, d1);
-    /* Back: framework-reserved as the exit gesture by default — the shim's
-     * own handler ends the session on press, neither side sees the event.
-     * Tools that prefer their own exit gesture set CORUN_KEEP_BACK in
-     * keep_mask; Back then routes per normal keep_mask rules (cedes to peer
-     * for sub-view nav unless CORUN_GRP_BACK is also kept), and the framework
-     * stays out of its way. (Menu remains tool-owned by default via
-     * keep_mask.) */
-    if (grp == CORUN_GRP_BACK && !(ctrl->corun.keep_mask & CORUN_KEEP_BACK)) {
+    uint32_t grp = corun_group_for_event(type, d1);
+    int cede_model = (ctrl->corun.flags & CORUN_F_CEDE_MODEL) != 0;
+    /* Back: framework-reserved as the exit gesture by default — the shim's own
+     * handler ends the session on press, neither side sees the event. A tool that
+     * prefers its own exit gesture signals it (cede model: CORUN_F_OWN_BACK;
+     * legacy: CORUN_KEEP_BACK in keep_mask); Back then routes per the normal
+     * keep/cede rule below (to the peer for sub-view nav unless the tool also
+     * keeps CORUN_GRP_BACK). (Menu remains tool-owned by default.) */
+    int own_back = cede_model ? (ctrl->corun.flags & CORUN_F_OWN_BACK)
+                              : (ctrl->corun.keep_mask & CORUN_KEEP_BACK);
+    if (grp == CORUN_GRP_BACK && !own_back) {
         return CORUN_OWNER_NONE;
     }
-    if (!grp) return CORUN_OWNER_TOOL; /* unclassified events always stay with tool */
-    uint16_t keep = corun_keep_mask_eff(ctrl->corun.keep_mask);
+    if (!grp) return CORUN_OWNER_TOOL; /* unclassified (sensor) events stay with tool */
+    /* Legacy carve-out: a pre-cede tool never named the extended buttons, so they
+     * stay with it regardless of its keep_mask — byte-identical to pre-cede
+     * behavior. Cede-model tools govern the full surface uniformly (no carve-out). */
+    if (!cede_model && (grp & CORUN_GRP_EXTENDED_ALL)) return CORUN_OWNER_TOOL;
+    uint32_t keep = corun_keep_mask_eff(ctrl);
     return (keep & grp) ? CORUN_OWNER_TOOL : CORUN_OWNER_PEER;
 }
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -201,11 +201,15 @@ typedef struct shadow_control_t {
 #define CORUN_GRP_BACK          (1u << 9)  /* CC 51 */
 #define CORUN_GRP_MENU          (1u << 10) /* CC 50 — framework exit gesture */
 #define CORUN_GRP_TOUCH         (1u << 11) /* capacitive-touch notes 0-9 */
+#define CORUN_GRP_MUTE          (1u << 12) /* CC 88 — the Mute button */
 
 /* Default keep-set: the canonical sequencer-style co-run split — tool keeps
- * pads, step buttons, transport, and Menu; cedes the nav surface + screen
- * to the peer. Used whenever corun_keep_mask == 0. */
-#define CORUN_KEEP_DEFAULT (CORUN_GRP_PADS | CORUN_GRP_STEPS | CORUN_GRP_TRANSPORT | CORUN_GRP_MENU)
+ * pads, step buttons, transport, Menu, and Mute; cedes the nav surface + screen
+ * to the peer. Used whenever corun_keep_mask == 0. Mute is kept by default so
+ * tools that don't set an explicit keep_mask behave exactly as before this group
+ * existed (Mute stayed with the tool); a tool that wants Move/Schwung to own Mute
+ * during co-run omits CORUN_GRP_MUTE from its explicit keep_mask. */
+#define CORUN_KEEP_DEFAULT (CORUN_GRP_PADS | CORUN_GRP_STEPS | CORUN_GRP_TRANSPORT | CORUN_GRP_MENU | CORUN_GRP_MUTE)
 
 /* Opt-out flag for tools that prefer their own exit gesture. When this bit is
  * set in keep_mask, the framework does NOT auto-exit on Back press — Back
@@ -232,6 +236,7 @@ static inline uint16_t corun_group_for_event(uint8_t type, uint8_t d1) {
             case 50: return CORUN_GRP_MENU;
             case 51: return CORUN_GRP_BACK;
             case 79: return CORUN_GRP_MASTER;
+            case 88: return CORUN_GRP_MUTE;  /* Mute button */
             default: if (d1 >= 71 && d1 <= 78) return CORUN_GRP_KNOBS;
                      return 0;
         }

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -385,13 +385,13 @@ void shadow_clear_move_leds_if_overtake(void) {
         /* LED ownership uses led_keep_mask (falls back to keep_mask): a tool can
          * own a surface's LEDs while still ceding its input — input routing in
          * corun_event_owner still uses keep_mask. */
-        uint16_t keep = corun_led_keep_mask_eff(ctrl);
+        uint32_t keep = corun_led_keep_mask_eff(ctrl);
         for (int i = 0; i < HW_MIDI_OUT_SIZE; i += 4) {
             uint8_t cable = (midi_out[i] >> 4) & 0x0F;
             if (cable != 0) continue;
             uint8_t type = midi_out[i+1] & 0xF0;
             uint8_t d1 = midi_out[i+2];
-            uint16_t grp = corun_group_for_event(type, d1);
+            uint32_t grp = corun_group_for_event(type, d1);
             if (grp && (keep & grp)) {
                 midi_out[i] = 0; midi_out[i+1] = 0; midi_out[i+2] = 0; midi_out[i+3] = 0;
             }
@@ -411,7 +411,7 @@ void shadow_clear_move_leds_if_overtake(void) {
             if (((midi_out[i] >> 4) & 0x0F) != 0) continue;    /* cable 0 */
             if (midi_out[i+1] != 0x3B) continue;               /* RGB LED command marker */
             uint8_t idx = midi_out[i+3];
-            uint16_t grp = corun_group_for_event(0xB0, idx);   /* idx as a CC (buttons/knobs) */
+            uint32_t grp = corun_group_for_event(0xB0, idx);   /* idx as a CC (buttons/knobs) */
             if (!grp) grp = corun_group_for_event(0x90, idx);  /* idx as a note (pads/steps) */
             if (!(grp && (keep & grp))) continue;
             int start = i - 8;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2913,6 +2913,7 @@ static void init_shadow_shm(void)
         shadow_control->overtake_suppress_sysex = 0;
         shadow_control->corun.target = CORUN_TARGET_NONE;  /* co-run inactive at boot */
         shadow_control->corun.id = -1;
+        shadow_control->corun.flags = 0;      /* 0 = legacy keep-list model */
         shadow_control->corun.keep_mask = 0;  /* 0 = default split when a target is set without a manifest */
         shadow_control->corun.led_keep_mask = 0; /* 0 = LED ownership follows keep_mask */
         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI; /* splash boots into shadow UI */
@@ -5683,7 +5684,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         int16_t corun_knob_delta[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
         int corun_knob_coalesce =
             (corun_target(shadow_control) == CORUN_TARGET_MOVE_NATIVE) &&
-            !(corun_keep_mask_eff(shadow_control->corun.keep_mask) & CORUN_GRP_KNOBS);
+            !(corun_keep_mask_eff(shadow_control) & CORUN_GRP_KNOBS);
 
         /* Filter MIDI_IN: zero out jog/back/knobs */
         for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
@@ -6835,6 +6836,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     if (owner == CORUN_OWNER_NONE && type == 0xB0 && d1 == CC_BACK && d2 > 0) {
                         shadow_control->corun.target = CORUN_TARGET_NONE;
                         shadow_control->corun.id = -1;
+                        shadow_control->corun.flags = 0;
                         shadow_control->corun.keep_mask = 0;
                         shadow_control->corun.led_keep_mask = 0;
                         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -241,11 +241,13 @@ static JSValue js_shadow_corun_begin(JSContext *ctx, JSValueConst this_val, int 
     if (argc >= 3 && JS_ToInt32(ctx, &keep, argv[2])) return JS_UNDEFINED;
     if (keep < 0 || keep > 0xFFFF) return JS_UNDEFINED;
     /* Reset LED-keep to "follow keep_mask"; a tool opts into the lights/input
-     * split by calling shadow_corun_set_led_keep_mask() after begin. */
+     * split by calling shadow_corun_set_led_keep_mask() after begin. flags=0 =
+     * legacy keep-list model (this is the legacy entry point). */
+    shadow_control->corun.flags = 0;
     shadow_control->corun.led_keep_mask = 0;
     if (target == CORUN_TARGET_CHAIN_EDIT) {
         if (id < 0 || id >= SHADOW_UI_SLOTS) return JS_UNDEFINED;
-        shadow_control->corun.keep_mask = (uint16_t)keep;
+        shadow_control->corun.keep_mask = (uint32_t)keep;
         shadow_control->corun.id = (int8_t)id;
         shadow_control->ui_slot = (uint8_t)id;
         shadow_control->corun.target = CORUN_TARGET_CHAIN_EDIT;
@@ -253,7 +255,7 @@ static JSValue js_shadow_corun_begin(JSContext *ctx, JSValueConst this_val, int 
         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
     } else if (target == CORUN_TARGET_MOVE_NATIVE) {
         if (id < 0 || id > 7) return JS_UNDEFINED;
-        shadow_control->corun.keep_mask = (uint16_t)keep;
+        shadow_control->corun.keep_mask = (uint32_t)keep;
         shadow_control->corun.id = (int8_t)id;
         shadow_control->corun.target = CORUN_TARGET_MOVE_NATIVE;
         /* move_native cedes the OLED to Move firmware. shadow_display_mode
@@ -274,6 +276,7 @@ static JSValue js_shadow_corun_end(JSContext *ctx, JSValueConst this_val, int ar
     if (!shadow_control) return JS_UNDEFINED;
     shadow_control->corun.target = CORUN_TARGET_NONE;
     shadow_control->corun.id = -1;
+    shadow_control->corun.flags = 0;
     shadow_control->corun.keep_mask = 0;
     shadow_control->corun.led_keep_mask = 0;
     /* Returning to the tool's shadow session — shadow_ui resumes rendering. */
@@ -292,7 +295,7 @@ static JSValue js_shadow_corun_set_led_keep_mask(JSContext *ctx, JSValueConst th
     int32_t mask = 0;
     JS_ToInt32(ctx, &mask, argv[0]);
     if (mask < 0 || mask > 0xFFFF) return JS_UNDEFINED;
-    shadow_control->corun.led_keep_mask = (uint16_t)mask;
+    shadow_control->corun.led_keep_mask = (uint32_t)mask;
     return JS_UNDEFINED;
 }
 
@@ -321,7 +324,75 @@ static JSValue js_shadow_corun_overlay(JSContext *ctx, JSValueConst this_val, in
     return JS_UNDEFINED;
 }
 
-/* shadow_corun_state() -> { target, id, keep_mask } | null
+/* shadow_corun_begin_cede(target, id, cede_mask, flags) -> void
+ * Cede-model entry point: the tool KEEPS the whole control surface and cedes only
+ * the CORUN_GRP_* groups in cede_mask to the peer (keep-by-default). Optional
+ * flags may set CORUN_F_OWN_BACK (tool handles Back itself instead of the
+ * framework exit gesture). Mirrors shadow_corun_begin's target/id validation and
+ * atomicity (mask + flags before target). Stored internally as the keep-mask
+ * complement so every routing site keeps one representation. */
+static JSValue js_shadow_corun_begin_cede(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 2) return JS_UNDEFINED;
+    int target = -1, id = -1, cede = 0, flags = 0;
+    if (JS_ToInt32(ctx, &target, argv[0])) return JS_UNDEFINED;
+    if (JS_ToInt32(ctx, &id, argv[1])) return JS_UNDEFINED;
+    if (argc >= 3 && JS_ToInt32(ctx, &cede, argv[2])) return JS_UNDEFINED;
+    if (argc >= 4 && JS_ToInt32(ctx, &flags, argv[3])) return JS_UNDEFINED;
+    if (cede < 0 || cede > 0x7FFFFFFF) return JS_UNDEFINED;
+    uint8_t f = (uint8_t)(CORUN_F_CEDE_MODEL | ((uint32_t)flags & CORUN_F_OWN_BACK));
+    /* LED follows input unless the tool later calls set_led_cede_mask. */
+    shadow_control->corun.led_keep_mask = 0;
+    if (target == CORUN_TARGET_CHAIN_EDIT) {
+        if (id < 0 || id >= SHADOW_UI_SLOTS) return JS_UNDEFINED;
+        shadow_control->corun.flags = f;
+        shadow_control->corun.keep_mask = corun_cede_to_keep((uint32_t)cede);
+        shadow_control->corun.id = (int8_t)id;
+        shadow_control->ui_slot = (uint8_t)id;
+        shadow_control->corun.target = CORUN_TARGET_CHAIN_EDIT;
+        shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
+    } else if (target == CORUN_TARGET_MOVE_NATIVE) {
+        if (id < 0 || id > 7) return JS_UNDEFINED;
+        shadow_control->corun.flags = f;
+        shadow_control->corun.keep_mask = corun_cede_to_keep((uint32_t)cede);
+        shadow_control->corun.id = (int8_t)id;
+        shadow_control->corun.target = CORUN_TARGET_MOVE_NATIVE;
+        shadow_control->shadow_display_owner = DISPLAY_OWNER_MOVE_FIRMWARE;
+    } else {
+        return JS_UNDEFINED;
+    }
+    return JS_UNDEFINED;
+}
+
+/* shadow_corun_set_cede_mask(cede_mask) -> void
+ * Update the cede-list mid-session (e.g. opening an overlay). Ensures cede model. */
+static JSValue js_shadow_corun_set_cede_mask(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 1) return JS_UNDEFINED;
+    int32_t cede = 0;
+    JS_ToInt32(ctx, &cede, argv[0]);
+    if (cede < 0 || cede > 0x7FFFFFFF) return JS_UNDEFINED;
+    shadow_control->corun.flags |= CORUN_F_CEDE_MODEL;
+    shadow_control->corun.keep_mask = corun_cede_to_keep((uint32_t)cede);
+    return JS_UNDEFINED;
+}
+
+/* shadow_corun_set_led_cede_mask(led_cede_mask) -> void
+ * Cede-model LED split: cede these groups' LEDs to the peer, paint the rest. Sets
+ * CORUN_F_LED_DISTINCT so led_keep_mask is authoritative even at 0 (= cede no
+ * LEDs), rather than the legacy "0 follows input" sentinel. */
+static JSValue js_shadow_corun_set_led_cede_mask(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 1) return JS_UNDEFINED;
+    int32_t cede = 0;
+    JS_ToInt32(ctx, &cede, argv[0]);
+    if (cede < 0 || cede > 0x7FFFFFFF) return JS_UNDEFINED;
+    shadow_control->corun.flags |= CORUN_F_LED_DISTINCT;
+    shadow_control->corun.led_keep_mask = corun_cede_to_keep((uint32_t)cede);
+    return JS_UNDEFINED;
+}
+
+/* shadow_corun_state() -> { target, id, keep_mask, flags } | null
  * Returns null when no co-run is active, else the current state. Tools poll
  * this each frame to detect framework-driven exit (Back press) and to
  * reconcile their own mirror. */
@@ -332,6 +403,7 @@ static JSValue js_shadow_corun_state(JSContext *ctx, JSValueConst this_val, int 
     JS_SetPropertyStr(ctx, obj, "target", JS_NewInt32(ctx, (int)corun_target(shadow_control)));
     JS_SetPropertyStr(ctx, obj, "id", JS_NewInt32(ctx, corun_id(shadow_control)));
     JS_SetPropertyStr(ctx, obj, "keep_mask", JS_NewInt32(ctx, (int)corun_keep_mask(shadow_control)));
+    JS_SetPropertyStr(ctx, obj, "flags", JS_NewInt32(ctx, (int)shadow_control->corun.flags));
     return obj;
 }
 
@@ -2209,6 +2281,10 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_led_keep_mask", JS_NewCFunction(ctx, js_shadow_corun_set_led_keep_mask, "shadow_corun_set_led_keep_mask", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_state", JS_NewCFunction(ctx, js_shadow_corun_state, "shadow_corun_state", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_overlay", JS_NewCFunction(ctx, js_shadow_corun_overlay, "shadow_corun_overlay", 2));
+    /* Cede-default model API (keep-by-default; tool lists only what it cedes). */
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_begin_cede", JS_NewCFunction(ctx, js_shadow_corun_begin_cede, "shadow_corun_begin_cede", 4));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_cede_mask", JS_NewCFunction(ctx, js_shadow_corun_set_cede_mask, "shadow_corun_set_cede_mask", 1));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_led_cede_mask", JS_NewCFunction(ctx, js_shadow_corun_set_led_cede_mask, "shadow_corun_set_led_cede_mask", 1));
     /* Co-run target enum (matches corun_target_t in shadow_constants.h). */
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_NONE",        JS_NewInt32(ctx, CORUN_TARGET_NONE));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_CHAIN_EDIT",  JS_NewInt32(ctx, CORUN_TARGET_CHAIN_EDIT));
@@ -2226,8 +2302,25 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_BACK",          JS_NewInt32(ctx, CORUN_GRP_BACK));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_MENU",          JS_NewInt32(ctx, CORUN_GRP_MENU));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_TOUCH",         JS_NewInt32(ctx, CORUN_GRP_TOUCH));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_MUTE",          JS_NewInt32(ctx, CORUN_GRP_MUTE));
+    /* Extended buttons — now first-class, published so modules stop hand-copying. */
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_PLAY",          JS_NewInt32(ctx, CORUN_GRP_PLAY));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_REC",           JS_NewInt32(ctx, CORUN_GRP_REC));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_SAMPLE",        JS_NewInt32(ctx, CORUN_GRP_SAMPLE));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_LOOP",          JS_NewInt32(ctx, CORUN_GRP_LOOP));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_COPY",          JS_NewInt32(ctx, CORUN_GRP_COPY));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_DELETE",        JS_NewInt32(ctx, CORUN_GRP_DELETE));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_UNDO",          JS_NewInt32(ctx, CORUN_GRP_UNDO));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_CAPTURE",       JS_NewInt32(ctx, CORUN_GRP_CAPTURE));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_NAV_UP",        JS_NewInt32(ctx, CORUN_GRP_NAV_UP));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_NAV_DOWN",      JS_NewInt32(ctx, CORUN_GRP_NAV_DOWN));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_NAV_LEFT",      JS_NewInt32(ctx, CORUN_GRP_NAV_LEFT));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_NAV_RIGHT",     JS_NewInt32(ctx, CORUN_GRP_NAV_RIGHT));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_NAV",           JS_NewInt32(ctx, CORUN_GRP_NAV));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_GRP_EDIT",          JS_NewInt32(ctx, CORUN_GRP_EDIT));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_KEEP_DEFAULT",      JS_NewInt32(ctx, CORUN_KEEP_DEFAULT));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_KEEP_BACK",         JS_NewInt32(ctx, CORUN_KEEP_BACK));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_F_OWN_BACK",        JS_NewInt32(ctx, CORUN_F_OWN_BACK));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_open_tool_cmd",
         JS_NewCFunction(ctx, js_shadow_get_open_tool_cmd, "shadow_get_open_tool_cmd", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_selected_slot", JS_NewCFunction(ctx, js_shadow_get_selected_slot, "shadow_get_selected_slot", 0));

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -239,7 +239,7 @@ static JSValue js_shadow_corun_begin(JSContext *ctx, JSValueConst this_val, int 
     if (JS_ToInt32(ctx, &target, argv[0])) return JS_UNDEFINED;
     if (JS_ToInt32(ctx, &id, argv[1])) return JS_UNDEFINED;
     if (argc >= 3 && JS_ToInt32(ctx, &keep, argv[2])) return JS_UNDEFINED;
-    if (keep < 0 || keep > 0xFFFF) return JS_UNDEFINED;
+    if (keep < 0 || keep > 0x7FFFFFFF) return JS_UNDEFINED;
     /* Reset LED-keep to "follow keep_mask"; a tool opts into the lights/input
      * split by calling shadow_corun_set_led_keep_mask() after begin. flags=0 =
      * legacy keep-list model (this is the legacy entry point). */
@@ -294,7 +294,7 @@ static JSValue js_shadow_corun_set_led_keep_mask(JSContext *ctx, JSValueConst th
     if (!shadow_control || argc < 1) return JS_UNDEFINED;
     int32_t mask = 0;
     JS_ToInt32(ctx, &mask, argv[0]);
-    if (mask < 0 || mask > 0xFFFF) return JS_UNDEFINED;
+    if (mask < 0 || mask > 0x7FFFFFFF) return JS_UNDEFINED;
     shadow_control->corun.led_keep_mask = (uint32_t)mask;
     return JS_UNDEFINED;
 }
@@ -311,8 +311,8 @@ static JSValue js_shadow_corun_overlay(JSContext *ctx, JSValueConst this_val, in
     int active = 0, keep = 0;
     if (JS_ToInt32(ctx, &active, argv[0])) return JS_UNDEFINED;
     if (JS_ToInt32(ctx, &keep, argv[1])) return JS_UNDEFINED;
-    if (keep < 0 || keep > 0xFFFF) return JS_UNDEFINED;
-    shadow_control->corun.keep_mask = (uint16_t)keep;
+    if (keep < 0 || keep > 0x7FFFFFFF) return JS_UNDEFINED;
+    shadow_control->corun.keep_mask = (uint32_t)keep;
     if (active) {
         shadow_control->shadow_display_owner = DISPLAY_OWNER_SCHWUNG_UI;
     } else {

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -407,6 +407,23 @@ static JSValue js_shadow_corun_state(JSContext *ctx, JSValueConst this_val, int 
     return obj;
 }
 
+/* shadow_corun_event_owner(status, d1) -> CORUN_OWNER_*
+ * Single source of truth for "who owns this control-surface event right now",
+ * exposed for JS dispatch decisions (e.g. a canvas overlay deciding whether to
+ * consume an event or let it fall through to the tool). Wraps the C
+ * corun_event_owner so the keep/cede spec, legacy carve-out, and Back handling
+ * never drift between C and JS. `status` is the MIDI status byte (the low nibble
+ * is ignored — only the type matters). Returns CORUN_OWNER_TOOL when no co-run. */
+static JSValue js_shadow_corun_event_owner(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 2) return JS_NewInt32(ctx, CORUN_OWNER_TOOL);
+    int status = 0, d1 = 0;
+    if (JS_ToInt32(ctx, &status, argv[0])) return JS_NewInt32(ctx, CORUN_OWNER_TOOL);
+    if (JS_ToInt32(ctx, &d1, argv[1])) return JS_NewInt32(ctx, CORUN_OWNER_TOOL);
+    corun_owner_t owner = corun_event_owner(shadow_control, (uint8_t)(status & 0xF0), (uint8_t)d1);
+    return JS_NewInt32(ctx, (int)owner);
+}
+
 /* shadow_get_selected_slot() -> int
  * Returns the track-selected slot (0-3) for playback/knobs.
  */
@@ -2285,6 +2302,12 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_begin_cede", JS_NewCFunction(ctx, js_shadow_corun_begin_cede, "shadow_corun_begin_cede", 4));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_cede_mask", JS_NewCFunction(ctx, js_shadow_corun_set_cede_mask, "shadow_corun_set_cede_mask", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_set_led_cede_mask", JS_NewCFunction(ctx, js_shadow_corun_set_led_cede_mask, "shadow_corun_set_led_cede_mask", 1));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_corun_event_owner", JS_NewCFunction(ctx, js_shadow_corun_event_owner, "shadow_corun_event_owner", 2));
+    /* Owner enum (matches corun_owner_t) — for JS dispatch decisions. */
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_OWNER_TOOL", JS_NewInt32(ctx, CORUN_OWNER_TOOL));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_OWNER_PEER", JS_NewInt32(ctx, CORUN_OWNER_PEER));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_OWNER_BOTH", JS_NewInt32(ctx, CORUN_OWNER_BOTH));
+    JS_SetPropertyStr(ctx, global_obj, "CORUN_OWNER_NONE", JS_NewInt32(ctx, CORUN_OWNER_NONE));
     /* Co-run target enum (matches corun_target_t in shadow_constants.h). */
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_NONE",        JS_NewInt32(ctx, CORUN_TARGET_NONE));
     JS_SetPropertyStr(ctx, global_obj, "CORUN_TARGET_CHAIN_EDIT",  JS_NewInt32(ctx, CORUN_TARGET_CHAIN_EDIT));

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14395,7 +14395,15 @@ globalThis.tick = function() {
     }
 
     if (view === VIEWS.CANVAS || (coRunUiActive() && coRunView === VIEWS.CANVAS)) {
-        tickCanvasPreview();
+        /* In co-run the outer view is OVERTAKE_MODULE, so call through
+         * runCoRunChainEdit (sets view=coRunView) — otherwise tickCanvasPreview's
+         * own `view !== VIEWS.CANVAS` guard early-returns and the module's tick
+         * hook (animation/state polling) never fires. Mirrors the draw path. */
+        if (coRunUiActive()) {
+            runCoRunChainEdit(tickCanvasPreview);
+        } else {
+            tickCanvasPreview();
+        }
         canvasTickCounter = (canvasTickCounter || 0) + 1;
         if (canvasTickCounter % 3 === 0) needsRedraw = true;
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -9795,7 +9795,10 @@ function invokeCanvasOverlayHook(hookName, payload) {
 }
 
 function dispatchCanvasMidi(data, source) {
-    if (view !== VIEWS.CANVAS) return false;
+    /* Also fire when the canvas is the active co-run overlay (outer view is
+     * OVERTAKE_MODULE then). Runs before the co-run input block, so jog-turn /
+     * encoders / knob-touch reach the canvas onMidi instead of the tool. */
+    if (view !== VIEWS.CANVAS && !(coRunUiActive() && coRunView === VIEWS.CANVAS)) return false;
     const midi = Array.isArray(data) ? data.slice() : Array.from(data || []);
     if (!midi || midi.length === 0) return true;
 
@@ -14839,15 +14842,22 @@ globalThis.onMidiMessageInternal = function(data) {
         }
     }
 
-    if (view === VIEWS.CANVAS && (status & 0xF0) === 0xB0) {
+    /* In co-run the outer view is OVERTAKE_MODULE; the canvas is the active
+     * co-run overlay when coRunView === CANVAS. Steal jog-click/Back to close it
+     * (wrapped so coRunView returns to the hierarchy editor), mirroring the
+     * non-co-run steal below. */
+    var canvasInCorun = coRunUiActive() && coRunView === VIEWS.CANVAS;
+    if ((view === VIEWS.CANVAS || canvasInCorun) && (status & 0xF0) === 0xB0) {
         if (d1 === MoveMainButton && d2 > 0) {
-            closeCanvasPreview(false);
+            if (canvasInCorun) runCoRunChainEdit(function() { closeCanvasPreview(false); });
+            else closeCanvasPreview(false);
             announce("Hierarchy Editor");
             needsRedraw = true;
             return;
         }
         if (d1 === MoveBack && d2 > 0) {
-            closeCanvasPreview(true);
+            if (canvasInCorun) runCoRunChainEdit(function() { closeCanvasPreview(true); });
+            else closeCanvasPreview(true);
             announce("Hierarchy Editor");
             needsRedraw = true;
             return;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -13726,6 +13726,7 @@ function dispatchCoRunDraw() {
             drawComponentEdit();
             break;
         case VIEWS.HIERARCHY_EDITOR:     drawHierarchyEditor(); break;
+        case VIEWS.CANVAS:               drawCanvasPreview(); break;
         case VIEWS.KNOB_EDITOR:          drawKnobEditor(); break;
         case VIEWS.KNOB_PARAM_PICKER:    drawKnobParamPicker(); break;
         case VIEWS.DYNAMIC_PARAM_PICKER: drawDynamicParamPicker(); break;
@@ -14377,7 +14378,7 @@ globalThis.tick = function() {
         processPendingHierKnob();
     }
 
-    if (view === VIEWS.CANVAS) {
+    if (view === VIEWS.CANVAS || (coRunUiActive() && coRunView === VIEWS.CANVAS)) {
         tickCanvasPreview();
         canvasTickCounter = (canvasTickCounter || 0) + 1;
         if (canvasTickCounter % 3 === 0) needsRedraw = true;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -9798,9 +9798,22 @@ function dispatchCanvasMidi(data, source) {
     /* Also fire when the canvas is the active co-run overlay (outer view is
      * OVERTAKE_MODULE then). Runs before the co-run input block, so jog-turn /
      * encoders / knob-touch reach the canvas onMidi instead of the tool. */
-    if (view !== VIEWS.CANVAS && !(coRunUiActive() && coRunView === VIEWS.CANVAS)) return false;
+    const canvasCorun = coRunUiActive() && coRunView === VIEWS.CANVAS;
+    if (view !== VIEWS.CANVAS && !canvasCorun) return false;
     const midi = Array.isArray(data) ? data.slice() : Array.from(data || []);
     if (!midi || midi.length === 0) return true;
+
+    /* In co-run the canvas is an overlay over a STILL-RUNNING tool. Consume only
+     * the events the module's co-run spec routes to the peer (this shadow_ui
+     * side); tool-kept and unclassified events must fall through so the buttons
+     * available before the canvas opened (pads / steps / transport / ...) keep
+     * working. Single source of truth = the host's corun_event_owner, so the
+     * keep/cede spec and the legacy carve-out are honored without duplicating
+     * the logic here. (Jog-click / Back are the close gesture, stolen before
+     * this. A full-screen canvas — not co-run — still owns the whole surface.) */
+    if (canvasCorun && typeof shadow_corun_event_owner === "function") {
+        if (shadow_corun_event_owner(midi[0] | 0, midi[1] | 0) !== CORUN_OWNER_PEER) return false;
+    }
 
     invokeCanvasOverlayHook("onMidi", { source, data: midi });
     return true;

--- a/tests/host/test_corun_cede_default.c
+++ b/tests/host/test_corun_cede_default.c
@@ -1,0 +1,138 @@
+/* Unit test for the co-run ownership contract (corun_event_owner) — both the
+ * new cede-default model and the frozen legacy keep-list model.
+ *
+ * The cede model is what modules see going forward: a tool KEEPS the whole
+ * control surface and lists only what it CEDES to the peer; every routable input
+ * is a first-class group. The legacy model is the pre-cede keep-list contract,
+ * preserved byte-identically so no existing module's behavior changes.
+ *
+ * Build/run: bash tests/host/test_corun_cede_default.sh
+ */
+#include <stdio.h>
+#include <string.h>
+#include "shadow_constants.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } } while (0)
+
+#define CC   0xB0
+#define NOTE 0x90
+
+/* Legacy keep-list module: flags=0, raw keep_mask. */
+static shadow_control_t mk_legacy(uint32_t keep_mask) {
+    shadow_control_t c;
+    memset(&c, 0, sizeof c);
+    c.corun.target = CORUN_TARGET_MOVE_NATIVE;
+    c.corun.id = 0;
+    c.corun.flags = 0;
+    c.corun.keep_mask = keep_mask;
+    return c;
+}
+
+/* New cede-model module: flags=CEDE_MODEL, keep stored as the complement of the
+ * cede set (exactly what the host API does at the JS boundary). */
+static shadow_control_t mk_cede(uint32_t cede_mask, uint8_t extra_flags) {
+    shadow_control_t c;
+    memset(&c, 0, sizeof c);
+    c.corun.target = CORUN_TARGET_MOVE_NATIVE;
+    c.corun.id = 0;
+    c.corun.flags = (uint8_t)(CORUN_F_CEDE_MODEL | extra_flags);
+    c.corun.keep_mask = corun_cede_to_keep(cede_mask);
+    return c;
+}
+
+#define OWN(c, type, d1) corun_event_owner(&(c), (type), (d1))
+
+int main(void) {
+    /* ---- 1. Full classifier: every routable input maps to a group ---- */
+    CHECK(corun_group_for_event(CC, 3)   == CORUN_GRP_JOG,           "jog click -> JOG");
+    CHECK(corun_group_for_event(CC, 14)  == CORUN_GRP_JOG,           "jog turn -> JOG");
+    CHECK(corun_group_for_event(CC, 40)  == CORUN_GRP_TRACK_BUTTONS, "row -> TRACK_BUTTONS");
+    CHECK(corun_group_for_event(CC, 49)  == CORUN_GRP_SHIFT,         "49 -> SHIFT");
+    CHECK(corun_group_for_event(CC, 50)  == CORUN_GRP_MENU,          "50 -> MENU");
+    CHECK(corun_group_for_event(CC, 51)  == CORUN_GRP_BACK,          "51 -> BACK");
+    CHECK(corun_group_for_event(CC, 52)  == CORUN_GRP_CAPTURE,       "52 -> CAPTURE");
+    CHECK(corun_group_for_event(CC, 54)  == CORUN_GRP_NAV_DOWN,      "54 -> NAV_DOWN");
+    CHECK(corun_group_for_event(CC, 55)  == CORUN_GRP_NAV_UP,        "55 -> NAV_UP");
+    CHECK(corun_group_for_event(CC, 56)  == CORUN_GRP_UNDO,          "56 -> UNDO");
+    CHECK(corun_group_for_event(CC, 58)  == CORUN_GRP_LOOP,          "58 -> LOOP");
+    CHECK(corun_group_for_event(CC, 60)  == CORUN_GRP_COPY,          "60 -> COPY");
+    CHECK(corun_group_for_event(CC, 62)  == CORUN_GRP_NAV_LEFT,      "62 -> NAV_LEFT");
+    CHECK(corun_group_for_event(CC, 63)  == CORUN_GRP_NAV_RIGHT,     "63 -> NAV_RIGHT");
+    CHECK(corun_group_for_event(CC, 71)  == CORUN_GRP_KNOBS,         "71 -> KNOBS");
+    CHECK(corun_group_for_event(CC, 78)  == CORUN_GRP_KNOBS,         "78 -> KNOBS");
+    CHECK(corun_group_for_event(CC, 79)  == CORUN_GRP_MASTER,        "79 -> MASTER");
+    CHECK(corun_group_for_event(CC, 85)  == CORUN_GRP_PLAY,          "85 -> PLAY");
+    CHECK(corun_group_for_event(CC, 86)  == CORUN_GRP_REC,           "86 -> REC");
+    CHECK(corun_group_for_event(CC, 88)  == CORUN_GRP_MUTE,          "88 -> MUTE");
+    CHECK(corun_group_for_event(CC, 118) == CORUN_GRP_SAMPLE,        "118 -> SAMPLE");
+    CHECK(corun_group_for_event(CC, 119) == CORUN_GRP_DELETE,        "119 -> DELETE");
+    CHECK(corun_group_for_event(NOTE, 0) == CORUN_GRP_TOUCH,         "note0 -> TOUCH (knob)");
+    CHECK(corun_group_for_event(NOTE, 9) == CORUN_GRP_TOUCH,         "note9 -> TOUCH (main)");
+    CHECK(corun_group_for_event(NOTE, 16)== CORUN_GRP_STEPS,         "note16 -> STEPS");
+    CHECK(corun_group_for_event(NOTE, 68)== CORUN_GRP_PADS,          "note68 -> PADS");
+    /* Sensors stay unclassified (not routable) */
+    CHECK(corun_group_for_event(CC, 114) == 0,                       "114 plug-detect unclassified");
+    CHECK(corun_group_for_event(CC, 115) == 0,                       "115 plug-detect unclassified");
+
+    /* ---- 2. Inactive co-run: everything is the tool's ---- */
+    { shadow_control_t c = mk_legacy(0); c.corun.target = CORUN_TARGET_NONE;
+      CHECK(OWN(c, CC, 14) == CORUN_OWNER_TOOL, "inactive -> TOOL"); }
+
+    /* ---- 3. Legacy model (frozen behavior) ---- */
+    /* 3a. keep_mask==0 => default split: keeps pads/steps/transport/menu/mute, cedes jog/knobs */
+    { shadow_control_t c = mk_legacy(0);
+      CHECK(OWN(c, NOTE, 68) == CORUN_OWNER_TOOL, "legacy default: PADS tool");
+      CHECK(OWN(c, CC, 50)   == CORUN_OWNER_TOOL, "legacy default: MENU tool");
+      CHECK(OWN(c, CC, 88)   == CORUN_OWNER_TOOL, "legacy default: MUTE tool");
+      CHECK(OWN(c, CC, 14)   == CORUN_OWNER_PEER, "legacy default: JOG peer");
+      CHECK(OWN(c, CC, 71)   == CORUN_OWNER_PEER, "legacy default: KNOBS peer"); }
+    /* 3b. legacy explicit keep cedes the unlisted */
+    { shadow_control_t c = mk_legacy(CORUN_GRP_PADS | CORUN_GRP_STEPS);
+      CHECK(OWN(c, NOTE, 68) == CORUN_OWNER_TOOL, "legacy keep PADS: tool");
+      CHECK(OWN(c, CC, 50)   == CORUN_OWNER_PEER, "legacy keep PADS: MENU ceded"); }
+    /* 3c. CRITICAL legacy carve-out: newly-classified buttons stay with a legacy tool */
+    { shadow_control_t c = mk_legacy(CORUN_GRP_PADS);
+      CHECK(OWN(c, CC, 85)  == CORUN_OWNER_TOOL, "legacy: PLAY stays tool (carve-out)");
+      CHECK(OWN(c, CC, 60)  == CORUN_OWNER_TOOL, "legacy: COPY stays tool (carve-out)");
+      CHECK(OWN(c, CC, 55)  == CORUN_OWNER_TOOL, "legacy: NAV stays tool (carve-out)"); }
+    /* 3d. Back: framework exit unless legacy KEEP_BACK set */
+    { shadow_control_t c = mk_legacy(0);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_NONE, "legacy: Back -> framework (NONE)"); }
+    { shadow_control_t c = mk_legacy(CORUN_KEEP_BACK);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_PEER, "legacy KEEP_BACK + BACK not kept -> peer"); }
+    { shadow_control_t c = mk_legacy(CORUN_KEEP_BACK | CORUN_GRP_BACK);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_TOOL, "legacy KEEP_BACK + BACK kept -> tool"); }
+
+    /* ---- 4. Cede model (the new contract) ---- */
+    /* 4a. cede jog+knobs: those go to peer, everything else (incl. new buttons) kept */
+    { shadow_control_t c = mk_cede(CORUN_GRP_JOG | CORUN_GRP_KNOBS, 0);
+      CHECK(OWN(c, CC, 14)  == CORUN_OWNER_PEER, "cede {JOG,KNOBS}: JOG peer");
+      CHECK(OWN(c, CC, 71)  == CORUN_OWNER_PEER, "cede {JOG,KNOBS}: KNOBS peer");
+      CHECK(OWN(c, NOTE,68) == CORUN_OWNER_TOOL, "cede {JOG,KNOBS}: PADS kept");
+      CHECK(OWN(c, CC, 50)  == CORUN_OWNER_TOOL, "cede {JOG,KNOBS}: MENU kept");
+      CHECK(OWN(c, CC, 85)  == CORUN_OWNER_TOOL, "cede {JOG,KNOBS}: PLAY kept by default");
+      CHECK(OWN(c, CC, 60)  == CORUN_OWNER_TOOL, "cede {JOG,KNOBS}: COPY kept by default");
+      CHECK(OWN(c, CC, 88)  == CORUN_OWNER_TOOL, "cede {JOG,KNOBS}: MUTE kept"); }
+    /* 4b. per-button independence: cede COPY only, DELETE/UNDO/nav unaffected */
+    { shadow_control_t c = mk_cede(CORUN_GRP_COPY, 0);
+      CHECK(OWN(c, CC, 60)  == CORUN_OWNER_PEER, "cede {COPY}: COPY peer");
+      CHECK(OWN(c, CC, 119) == CORUN_OWNER_TOOL, "cede {COPY}: DELETE kept");
+      CHECK(OWN(c, CC, 56)  == CORUN_OWNER_TOOL, "cede {COPY}: UNDO kept");
+      CHECK(OWN(c, CC, 55)  == CORUN_OWNER_TOOL, "cede {COPY}: NAV kept"); }
+    /* 4c. cede nothing => tool owns the whole surface */
+    { shadow_control_t c = mk_cede(0, 0);
+      CHECK(OWN(c, CC, 14)  == CORUN_OWNER_TOOL, "cede {}: JOG kept");
+      CHECK(OWN(c, CC, 71)  == CORUN_OWNER_TOOL, "cede {}: KNOBS kept"); }
+    /* 4d. Back in cede model: framework exit unless OWN_BACK; then governed by cede */
+    { shadow_control_t c = mk_cede(0, 0);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_NONE, "cede: Back -> framework (NONE)"); }
+    { shadow_control_t c = mk_cede(0, CORUN_F_OWN_BACK);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_TOOL, "cede OWN_BACK + not ceded -> tool"); }
+    { shadow_control_t c = mk_cede(CORUN_GRP_BACK, CORUN_F_OWN_BACK);
+      CHECK(OWN(c, CC, 51)  == CORUN_OWNER_PEER, "cede OWN_BACK + ceded BACK -> peer"); }
+
+    if (fails) { fprintf(stderr, "%d check(s) failed\n", fails); return 1; }
+    printf("PASS: corun cede-default contract (%d checks)\n", 0);
+    return 0;
+}

--- a/tests/host/test_corun_cede_default.sh
+++ b/tests/host/test_corun_cede_default.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+bin="build/tests/test_corun_cede_default"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Isrc/host \
+  tests/host/test_corun_cede_default.c \
+  -o "$bin"
+
+"$bin"


### PR DESCRIPTION
Bundles three related co-run / overtake improvements that share the same surfaces (`shadow_constants.h` ownership groups, `shadow_ui.c`/`shadow_ui.js` dispatch), so they're submitted together rather than as conflicting separate PRs.

## 1. Cede-default ownership model (generalizes co-run input ownership)

**Problem.** Today a co-run tool implicitly *owns* every Move control surface it can see (knobs, pads, transport, mute). That makes it awkward for a tool to deliberately hand a surface back to Move firmware — there was no first-class contract for "I want my notes/pads, but Move keeps the rest."

**Change.** Introduces a **cede-default** ownership model: a tool declares the groups it claims, and everything else is ceded to Move by default. The keep-mask machinery (already used for LED ownership in #122) is extended into a single generic `shadow_corun_event_owner` decision used by the shim, LED queue, and the JS bridge. Ships with a header-level contract test (`tests/host/test_corun_cede_default.c`) and `docs/CORUN.md` coverage.

## 2. Expose the full Move control surface as individually-cedeable groups

**Problem.** Co-run ownership could only be split at a coarse granularity — most of Move's panel was lumped together (Transport was a single bit) or simply unclassified, so a tool couldn't hand back, say, *just the Mute button* or *just the nav arrows* while keeping its pads. Concretely, this blocked dAVEBOx from letting Move mute its own instruments and drum pads during co-run (CC 88 was unclassified, so it could never be ceded).

**Change.** Widens the co-run masks to `uint32` and classifies the rest of Move's panel into individual, cedeable groups:
- **Mute** (CC 88)
- **Transport split into individual buttons** — Play / Rec / Sample / Loop (the old single `TRANSPORT` bit is now a composite of these)
- **Edit buttons** — Copy / Delete / Undo / Capture
- **Nav arrows** — Up / Down / Left / Right
- plus composite helpers (`NAV`, `EDIT`, `EXTENDED_ALL`, `ALL`).

Each is kept-by-default (`CORUN_KEEP_DEFAULT`), so existing tools are unchanged; a tool opts to cede any of them by omitting it from its explicit keep-mask, after which the generic `corun_event_owner` predicate routes the press to Move firmware (and suppresses the duplicate to the tool). No per-control routing code — the single predicate handles them all. Mute is the first consumer (dAVEBOx cedes it for Move-native instrument/drum mute) but the same mechanism now covers the whole surface.

## 3. Render + route a module's `type:"canvas"` sub-view in co-run

**Problem.** A module that draws a custom full-screen `type:"canvas"` editor (e.g. the OB-Xd "Bank Editor") went **blank and unresponsive** the moment that module was used inside a co-run/overtake session: the co-run draw and input dispatch paths had no `CANVAS` case, so the canvas was never drawn and jog/encoder/touch never reached it.

**Change.** Three small commits:
- add the canvas sub-view to the co-run draw path (`dispatchCoRunDraw`);
- route jog / encoders / touch to the canvas in co-run, including co-run-aware close/Back handling;
- fix a follow-on where the canvas overlay swallowed the *tool's* input — the overlay must be a consume-only peer, not steal events the tool still needs.

This is a fix on `upstream/main` too (its `dispatchCoRunDraw` likewise has no `CANVAS` case); the canvas commits cherry-pick cleanly and are fix-only with no fork dependencies.

## Relationship to other PRs

- **#122 (co-run/overtake LED ownership, merged):** the cede-default model generalizes the `keep_mask` concept introduced there from LEDs to all input surfaces.
- **#134 / #125 (merged in v0.11.0):** orthogonal co-run shim fixes (knob-CC rate-limit, garbage-MIDI status guard); no overlap with the ownership/render changes here.
- Internal planning/spec docs were intentionally **excluded** from this PR; only the shipping code, the contract test, and `docs/CORUN.md` are included.

Verification: header changes compile and the cede-default contract test passes; `shadow_ui.js` parses clean. All commits were previously device-verified on Move hardware.
