### PR TITLE
perf(shim): drain injected MIDI up to MIDI_IN capacity (31), not 16/frame

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -579,7 +579,13 @@ void shadow_drain_midi_inject(void)
     int hw_offset = 0;
     int injected = 0;
     uint8_t pkt[4];
-    while (injected < 16 && shadow_midi_inject_peek(inject_shm, pkt)) {
+    /* Drain up to the MIDI_IN mailbox capacity (31 slots) per frame, not a
+     * fixed 16. A dense polyphonic burst (e.g. several ROUTE_MOVE tracks
+     * landing a chord on the same step) exceeds 16 simultaneous events; at
+     * the old cap the remainder dribbled out over later frames, smearing the
+     * chord's attack. 31 is the hardware slot count, so this cannot overflow,
+     * and the empty-slot / saw_existing race guard below is unchanged. */
+    while (injected < MIDI_IN_MAX_EVTS && shadow_midi_inject_peek(inject_shm, pkt)) {
         /* Find an empty 8-byte slot (byte 0 == 0 means no cable/CIN, unused) */
         int saw_existing = 0;
         while (hw_offset < MIDI_IN_MAX_BYTES) {


### PR DESCRIPTION
## Problem

A Schwung tool streaming dense polyphony into Move — chords and fast subdivisions across several `ROUTE_MOVE` tracks — has its chord attacks **smeared**: notes that should land together get spread across multiple audio frames, producing an audible strum on what should be one hit.

`shadow_drain_midi_inject` was rate-limited to **16** injected packets per audio frame, but the MIDI_IN hardware mailbox holds **31** events. A burst larger than 16 (e.g. 4 tracks × a ~5-voice chord on a 1/32 step) drained 16 this frame and dribbled the remainder into following frames.

## Change

Raise the per-frame drain cap from a hard-coded 16 to `MIDI_IN_MAX_EVTS` (31 — the mailbox's actual slot count). 31 is the physical buffer size, so it cannot overflow, and the empty-slot / `saw_existing` race guard is untouched. One-line change plus a comment.

## Relationship to other PRs

- **Builds on #128 (MPSC-safe inject ring, merged — in the public release):** the ring is now multi-producer-safe, so draining it harder per frame is sound.
- **Orthogonal to #126 (hold MIDI_IN inject after overtake exit) and #125 (drop garbage MIDI_IN forwards, merged):** those change *when* injects are allowed / filtered; this changes only *how many* are delivered per frame. No overlap.

Tested on hardware with heavy 4-track polyphonic 1/32 stabs: bursts now drain up to 31 in a single frame (previously pinned at 16), with zero dropped notes and the defer guard firing only incidentally on hardware control input.
