### PR TITLE
fix(remote-ui): correct shadow_param_t Go offsets after trace fields added

### DIFF
--- a/schwung-manager/shmparams.go
+++ b/schwung-manager/shmparams.go
@@ -23,7 +23,7 @@ type ShmParams struct {
 }
 
 // Byte offsets into shadow_param_t.
-// Struct layout (ARM64, packed uint8 fields then naturally aligned uint32):
+// Struct layout (ARM64, packed uint8 fields then naturally aligned uint32/64):
 //
 //	uint8_t  request_type   @ 0
 //	uint8_t  slot           @ 1
@@ -32,8 +32,16 @@ type ShmParams struct {
 //	uint32_t request_id     @ 4
 //	uint32_t response_id    @ 8
 //	int32_t  result_len     @ 12
-//	char     key[64]        @ 16
-//	char     value[65536]   @ 80
+//	uint64_t trace_id       @ 16   (OTLP trace context, Phase 2b)
+//	uint64_t parent_span_id @ 24   (OTLP trace context, Phase 2b)
+//	char     key[64]        @ 32
+//	char     value[65536]   @ 96
+//
+// NOTE: the two uint64 trace fields were added to shadow_param_t by the OTLP
+// trace work (5a5aa645) and pushed key/value down by 16 bytes. This Go mirror
+// must track that or every request's key lands at the wrong offset, the shim
+// reads an empty key, and every GET returns empty (remote UI shows "no module"
+// and default slot params).
 const (
 	paramOffRequestType   = 0
 	paramOffSlot          = 1
@@ -42,8 +50,10 @@ const (
 	paramOffRequestID     = 4
 	paramOffResponseID    = 8
 	paramOffResultLen     = 12
-	paramOffKey           = 16
-	paramOffValue         = 80
+	paramOffTraceID       = 16
+	paramOffParentSpanID  = 24
+	paramOffKey           = 32
+	paramOffValue         = 96
 
 	paramKeyLen   = 64
 	paramValueLen = 65536


### PR DESCRIPTION
## Problem

The remote UI (schwung-manager :7700) shows **every slot as "no module"** with slot params stuck at defaults (e.g. receive channel), even when modules are loaded and rendering normally. The on-device shadow UI is unaffected.

## Root cause

The OTLP trace work (`5a5aa645`, "Phase 2b — cross-process parent/child correlation") inserted two `uint64` fields — `trace_id` and `parent_span_id` — at offset 16 of `shadow_param_t` (`src/host/shadow_constants.h`), shifting `key` 16→32 and `value` 80→96.

`schwung-manager/shmparams.go` mirrors that struct by hardcoded byte offsets and was never updated, so it kept `paramOffKey = 16` / `paramOffValue = 80`. Every manager request's key lands 16 bytes early → the shim reads an empty key → matches no param → returns empty for **every** GET. `shadow_ui.js` uses the C struct directly, so the on-device UI keeps working; only the Go manager's reads break.

It compiles clean because the grown struct still fits `SHADOW_PARAM_BUFFER_SIZE` (65664), so `shadow_param_size_check` never fires.

## Fix

Update the Go offset mirror to `key@32` / `value@96`, add the two trace-field offsets, and document the layout so the mirror stays in sync the next time `shadow_param_t` changes.

## Testing

Built the ARM64 manager, deployed to a Move, clean reboot. Before: all slots empty / default params. After: slots report their real modules and real slot params (e.g. `synth="obxd"`, `receive_channel="5"`). Confirmed against a clean-boot A/B (old binary on a clean reboot = still broken; new binary = correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)