### PR TITLE
catalog: add PushNPull audio FX

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -258,6 +258,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "pushnpull",
+      "name": "PushNPull",
+      "description": "Creative sidechain effects for dummies - a tempo-synced curve shaper that ducks/boosts volume and/or sweeps a multimode filter, locked to the beat",
+      "author": "legsmechanical",
+      "component_type": "audio_fx",
+      "github_repo": "legsmechanical/schwung-pushnpull",
+      "default_branch": "main",
+      "asset_name": "pushnpull-module.tar.gz",
+      "min_host_version": "0.11.0"
+    },
+    {
       "id": "radiogarden",
       "name": "Radio Garden",
       "description": "Browse and stream live radio from 200 cities worldwide via Radio Garden",


### PR DESCRIPTION
Adds **PushNPull** to the module catalog.

PushNPull is a tempo-synced **curve-shaping sidechain effect**: a beat-locked bipolar curve ducks/boosts the output **volume** and/or sweeps a multimode **filter**, locked to MIDI clock — compressor-free pumping with no kick routing. It also doubles as a rhythmic volume/filter LFO (gate, stutter, swell, tremolo, filter-pump). On-device it has a live **Visual Edit** canvas showing the curve with the eight knobs mapped over it.

- Repo: https://github.com/legsmechanical/schwung-pushnpull (public, MIT)
- `component_type: audio_fx`, `api_version: 2`
- `min_host_version: 0.11.0` (the on-device Visual Edit uses the `type:"canvas"` chain-param UI)
- Forked from `schwung-filter`; first tagged release `v0.1.0`.

Catalog entry only — no host code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)